### PR TITLE
feat: enable secure pause-and-resume execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "tsup --tsconfig tsconfig.build.json",
     "check": "ultracite check",
     "fix": "ultracite fix",
-    "type-check": "tsc -p tsconfig.build.json --noEmit",
+    "type-check": "tsc -p tsconfig.build.json --noEmit && tsc -p src/tsconfig.json",
     "test": "pnpm test:node",
     "test:watch": "vitest --config vitest.node.config.js",
     "test:node": "vitest --config vitest.node.config.js --run"

--- a/src/continuation-codec.test.ts
+++ b/src/continuation-codec.test.ts
@@ -1,0 +1,288 @@
+import { createHmac } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSignedContinuationCodec,
+  createStoredContinuationCodec,
+} from './continuation-codec.js';
+import type { StoredContinuation } from './continuation-codec.js';
+import type { RunContinuationState } from './types.js';
+
+const state: RunContinuationState = {
+  determinism: {
+    dateNowMs: 1_700_000_000_000,
+    randomSeed: '01'.repeat(16),
+  },
+  ledger: [
+    {
+      bindingName: 'tools.pause',
+      inputJson: '[[]]',
+      interruptionId: 'interrupt-1',
+      payloadJson: '[{"kind":1},"approval"]',
+      status: 'interrupted',
+    },
+  ],
+  logicalRunId: '03'.repeat(16),
+  runtime: 'run-replay-v2',
+  scopeHash: '02'.repeat(32),
+  serde: 'run-js-v1',
+  source: 'return await tools.pause();',
+  version: 2,
+};
+
+const tokenBody = (token: string): string => {
+  const [body] = token.split('.');
+  if (body === undefined) {
+    throw new Error('Expected a signed continuation body.');
+  }
+  return body;
+};
+
+afterEach(() => vi.useRealTimers());
+
+describe('continuation codecs', () => {
+  it('atomically consumes stored continuations', async () => {
+    const values = new Map<string, StoredContinuation>();
+    const codec = createStoredContinuationCodec({
+      storage: {
+        set(key, value) {
+          values.set(key, value);
+        },
+        take(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+      },
+    });
+    const token = await codec.encode(state);
+    await expect(codec.decode(token)).resolves.toEqual(state);
+    await expect(codec.decode(token)).rejects.toMatchObject({
+      code: 'RUN_PROTOCOL_ERROR',
+    });
+  });
+
+  it('allows exactly one of many concurrent stored continuation consumers', async () => {
+    const values = new Map<string, StoredContinuation>();
+    const codec = createStoredContinuationCodec({
+      storage: {
+        set(key, value) {
+          values.set(key, value);
+        },
+        async take(key) {
+          const value = values.get(key);
+          values.delete(key);
+          await Promise.resolve();
+          return value;
+        },
+      },
+    });
+    const token = await codec.encode(state);
+    const results = await Promise.allSettled(
+      Array.from({ length: 32 }, () => codec.decode(token)),
+    );
+    expect(
+      results.filter(result => result.status === 'fulfilled'),
+    ).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(
+      31,
+    );
+  });
+
+  it('enforces stored continuation expiry itself', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const values = new Map<string, StoredContinuation>();
+    const codec = createStoredContinuationCodec({
+      maxAgeMs: 10,
+      storage: {
+        set(key, value) {
+          values.set(key, value);
+        },
+        take(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+      },
+    });
+    const token = await codec.encode(state);
+    vi.setSystemTime(1011);
+    await expect(codec.decode(token)).rejects.toThrow('expired');
+  });
+
+  it('bounds signed tokens before returning or verifying them', () => {
+    const codec = createSignedContinuationCodec({
+      maxTokenBytes: 32,
+      secret: 's'.repeat(32),
+    });
+    expect(() => codec.encode(state)).toThrow('size limit');
+    expect(() => codec.decode('x'.repeat(33))).toThrow('size limit');
+  });
+
+  it('requires strong signing keys and validates key-rotation options', () => {
+    expect(() =>
+      createSignedContinuationCodec({ secret: 'too-short' }),
+    ).toThrow('at least 32 bytes');
+    expect(() =>
+      createSignedContinuationCodec({
+        secret: 's'.repeat(32),
+        verificationSecrets: ['old-short'],
+      }),
+    ).toThrow('at least 32 bytes');
+    expect(() =>
+      createSignedContinuationCodec({
+        clockSkewMs: -1,
+        secret: 's'.repeat(32),
+      }),
+    ).toThrow('non-negative integer');
+  });
+
+  it('supports verification-only previous secrets during key rotation', () => {
+    const oldSecret = 'o'.repeat(32);
+    const newSecret = 'n'.repeat(32);
+    const oldCodec = createSignedContinuationCodec({ secret: oldSecret });
+    const rotatedCodec = createSignedContinuationCodec({
+      secret: newSecret,
+      verificationSecrets: [oldSecret],
+    });
+    const oldToken = oldCodec.encode(state) as string;
+    expect(rotatedCodec.decode(oldToken)).toEqual(state);
+
+    const newToken = rotatedCodec.encode(state) as string;
+    expect(() => oldCodec.decode(newToken)).toThrow('signature');
+  });
+
+  it('expires at the exact boundary and rejects future-issued tokens', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const codec = createSignedContinuationCodec({
+      clockSkewMs: 0,
+      maxAgeMs: 10,
+      secret: 's'.repeat(32),
+    });
+    const token = codec.encode(state) as string;
+    vi.setSystemTime(1010);
+    expect(() => codec.decode(token)).toThrow('expired');
+
+    vi.setSystemTime(2000);
+    const futureToken = codec.encode(state) as string;
+    vi.setSystemTime(1999);
+    expect(() => codec.decode(futureToken)).toThrow('future');
+  });
+
+  it.each([
+    ['format', 'other'],
+    ['version', 2],
+    ['algorithm', 'none'],
+    ['nonce', 'bad'],
+  ])('rejects authenticated envelope confusion in %s', (field, value) => {
+    const secret = 's'.repeat(32);
+    const codec = createSignedContinuationCodec({ secret });
+    const token = codec.encode(state) as string;
+    const body = tokenBody(token);
+    const envelope = JSON.parse(
+      Buffer.from(body, 'base64url').toString(),
+    ) as Record<string, unknown>;
+    envelope[field] = value;
+    const changedBody = Buffer.from(JSON.stringify(envelope)).toString(
+      'base64url',
+    );
+    const signature = createHmac('sha256', secret)
+      .update('run.continuation.v1\0')
+      .update(changedBody)
+      .digest('base64url');
+    expect(() => codec.decode(`${changedBody}.${signature}`)).toThrow(
+      /envelope|canonical|lifetime/i,
+    );
+  });
+
+  it('rejects authenticated unknown envelope fields and non-canonical JSON', () => {
+    const secret = 's'.repeat(32);
+    const codec = createSignedContinuationCodec({ secret });
+    const token = codec.encode(state) as string;
+    const body = tokenBody(token);
+    const envelope = JSON.parse(
+      Buffer.from(body, 'base64url').toString(),
+    ) as Record<string, unknown>;
+    envelope.extra = true;
+    const changedBody = Buffer.from(JSON.stringify(envelope)).toString(
+      'base64url',
+    );
+    const signature = createHmac('sha256', secret)
+      .update('run.continuation.v1\0')
+      .update(changedBody)
+      .digest('base64url');
+    expect(() => codec.decode(`${changedBody}.${signature}`)).toThrow(
+      /envelope|canonical/i,
+    );
+  });
+
+  it('rejects bit changes, truncation, extension, wrong keys, and invalid base64', () => {
+    const codec = createSignedContinuationCodec({ secret: 's'.repeat(32) });
+    const wrong = createSignedContinuationCodec({ secret: 'w'.repeat(32) });
+    const token = codec.encode(state) as string;
+    const mutations = [
+      token.slice(0, -1),
+      `${token}x`,
+      `!${token.slice(1)}`,
+      `${token.split('.')[0]}.=`,
+      `${token.slice(0, 10)}${token[10] === 'A' ? 'B' : 'A'}${token.slice(11)}`,
+    ];
+    for (const mutation of mutations) {
+      expect(() => codec.decode(mutation)).toThrow();
+    }
+    expect(() => wrong.decode(token)).toThrow('signature');
+  });
+
+  it('fails closed for 1,000 deterministic signed-token mutations', () => {
+    const codec = createSignedContinuationCodec({ secret: 's'.repeat(32) });
+    const token = codec.encode(state) as string;
+    let random = 1_831_565_813;
+    const next = (): number => {
+      random = (random * 1_664_525 + 1_013_904_223) % 4_294_967_296;
+      return random;
+    };
+    for (let iteration = 0; iteration < 1000; iteration += 1) {
+      const index = next() % token.length;
+      const replacement = String.fromCodePoint(33 + (next() % 90));
+      const mutation = `${token.slice(0, index)}${replacement}${token.slice(index + 1)}`;
+      if (mutation !== token) {
+        expect(() => codec.decode(mutation)).toThrowError(
+          expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }),
+        );
+      }
+    }
+  });
+
+  it.each([
+    '',
+    'x',
+    'a'.repeat(42),
+    'a'.repeat(44),
+    'a'.repeat(257),
+    'bad!key',
+  ])('rejects malformed stored key %j before storage access', async key => {
+    const take = vi.fn();
+    const codec = createStoredContinuationCodec({
+      storage: { set: () => {}, take },
+    });
+    await expect(codec.decode(key)).rejects.toMatchObject({
+      code: 'RUN_PROTOCOL_ERROR',
+    });
+    expect(take).not.toHaveBeenCalled();
+  });
+
+  it('does not issue a stored key before persistence succeeds', async () => {
+    const codec = createStoredContinuationCodec({
+      storage: {
+        set() {
+          throw new Error('storage unavailable');
+        },
+        take() {
+          throw new Error('not used');
+        },
+      },
+    });
+    await expect(codec.encode(state)).rejects.toThrow('storage unavailable');
+  });
+});

--- a/src/continuation-codec.ts
+++ b/src/continuation-codec.ts
@@ -1,0 +1,335 @@
+import { Buffer } from 'node:buffer';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { RunProtocolError } from './errors.js';
+import type {
+  ContinuationCodec,
+  ContinuationOperationContext,
+  RunContinuationState,
+} from './types.js';
+import { parseJson } from './utils/parse-json.js';
+import { hasExactKeys, isPlainRecord } from './utils/object-validation.js';
+
+const DEFAULT_MAX_AGE_MS = 60 * 60 * 1000;
+const DEFAULT_MAX_TOKEN_BYTES = 32 * 1024 * 1024;
+const DEFAULT_CLOCK_SKEW_MS = 60_000;
+const SIGNATURE_DOMAIN = 'run.continuation.v1\0';
+const ENVELOPE_KEYS = [
+  'algorithm',
+  'expiresAtMs',
+  'format',
+  'issuedAtMs',
+  'nonce',
+  'state',
+  'version',
+] as const;
+
+export interface SignedContinuationCodecOptions {
+  /** Primary HMAC key used for new tokens and verification. */
+  secret: string | Uint8Array;
+  /** Previous HMAC keys accepted only for verification during key rotation. */
+  verificationSecrets?: (string | Uint8Array)[];
+  maxAgeMs?: number;
+  maxTokenBytes?: number;
+  /** Allowed positive clock skew for issued-at validation. @defaultValue `60_000` */
+  clockSkewMs?: number;
+}
+
+export interface ContinuationStorage {
+  set(
+    key: string,
+    value: StoredContinuation,
+    context?: ContinuationOperationContext,
+  ): void | Promise<void>;
+  /** Atomically reads and removes a continuation. */
+  take(
+    key: string,
+    context?: ContinuationOperationContext,
+  ): StoredContinuation | undefined | Promise<StoredContinuation | undefined>;
+}
+
+export interface StoredContinuation {
+  state: RunContinuationState;
+  expiresAtMs: number;
+}
+
+const throwIfOperationAborted = (
+  context: ContinuationOperationContext | undefined,
+): void => {
+  if (context?.abortSignal.aborted) {
+    throw (
+      context.abortSignal.reason ??
+      new DOMException('The continuation operation was aborted.', 'AbortError')
+    );
+  }
+};
+
+const sign = (body: string, secret: Uint8Array): string =>
+  createHmac('sha256', secret)
+    .update(SIGNATURE_DOMAIN)
+    .update(body)
+    .digest('base64url');
+
+const decodeBase64Url = (value: string, label: string): Buffer => {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw new RunProtocolError(`${label} is malformed.`);
+  }
+  const decoded = Buffer.from(value, 'base64url');
+  if (decoded.toString('base64url') !== value) {
+    throw new RunProtocolError(`${label} is malformed.`);
+  }
+  return decoded;
+};
+
+const verifySignature = (
+  body: string,
+  signature: string,
+  secrets: Uint8Array[],
+): boolean => {
+  let received: Buffer;
+  try {
+    received = decodeBase64Url(signature, 'Continuation signature');
+  } catch {
+    return false;
+  }
+  let valid = false;
+  for (const secret of secrets) {
+    const expected = Buffer.from(sign(body, secret), 'base64url');
+    const sameLength = received.byteLength === expected.byteLength;
+    const candidate = sameLength ? received : Buffer.alloc(expected.byteLength);
+    valid = timingSafeEqual(candidate, expected) || valid;
+  }
+  return valid;
+};
+
+const isEnvelope = (
+  value: unknown,
+): value is {
+  format: 'run-continuation';
+  version: 1;
+  algorithm: 'HS256';
+  state: RunContinuationState;
+  issuedAtMs: number;
+  expiresAtMs: number;
+  nonce: string;
+} =>
+  isPlainRecord(value) &&
+  hasExactKeys(value, [...ENVELOPE_KEYS]) &&
+  value.format === 'run-continuation' &&
+  value.version === 1 &&
+  value.algorithm === 'HS256' &&
+  typeof (value as { issuedAtMs?: unknown }).issuedAtMs === 'number' &&
+  Number.isSafeInteger((value as { issuedAtMs: number }).issuedAtMs) &&
+  typeof (value as { expiresAtMs?: unknown }).expiresAtMs === 'number' &&
+  Number.isSafeInteger((value as { expiresAtMs: number }).expiresAtMs) &&
+  (value as { expiresAtMs: number }).expiresAtMs >
+    (value as { issuedAtMs: number }).issuedAtMs &&
+  typeof (value as { nonce?: unknown }).nonce === 'string' &&
+  /^[0-9a-f]{32}$/u.test((value as { nonce: string }).nonce) &&
+  typeof (value as { state?: unknown }).state === 'object' &&
+  (value as { state?: unknown }).state !== null;
+
+const canonicalJson = (
+  value: unknown,
+  seen = new WeakSet<object>(),
+): string => {
+  if (value === null || typeof value !== 'object') {
+    const encoded = JSON.stringify(value);
+    if (
+      encoded === undefined ||
+      typeof value === 'bigint' ||
+      (typeof value === 'number' && !Number.isFinite(value))
+    ) {
+      throw new RunProtocolError('Continuation contains a non-JSON value.');
+    }
+    return encoded;
+  }
+  if (seen.has(value)) {
+    throw new RunProtocolError('Continuation contains a cyclic value.');
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const items: string[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      if (!Object.hasOwn(value, index)) {
+        throw new RunProtocolError('Continuation contains a sparse array.');
+      }
+      items.push(canonicalJson(value[index], seen));
+    }
+    seen.delete(value);
+    return `[${items.join(',')}]`;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new RunProtocolError('Continuation contains a non-plain object.');
+  }
+  const record = value as Record<string, unknown>;
+  const result = `{${Object.keys(record)
+    .toSorted()
+    .map(key => `${JSON.stringify(key)}:${canonicalJson(record[key], seen)}`)
+    .join(',')}}`;
+  seen.delete(value);
+  return result;
+};
+
+const assertTokenLength = (token: string, maxBytes: number): void => {
+  const bytes = Buffer.byteLength(token);
+  if (bytes > maxBytes) {
+    throw new RunProtocolError(
+      `Continuation token exceeds the ${maxBytes} byte size limit.`,
+      { bytes, maxBytes },
+    );
+  }
+};
+
+const assertSecret = (secret: Uint8Array): void => {
+  if (secret.byteLength < 32) {
+    throw new TypeError(
+      'Continuation secret must contain at least 32 bytes of key material.',
+    );
+  }
+};
+
+export const createSignedContinuationCodec = (
+  options: SignedContinuationCodecOptions,
+): ContinuationCodec<string> => {
+  const primarySecret = Buffer.from(options.secret);
+  assertSecret(primarySecret);
+  const verificationSecrets = (options.verificationSecrets ?? []).map(value =>
+    Buffer.from(value),
+  );
+  for (const secret of verificationSecrets) {
+    assertSecret(secret);
+  }
+  const secrets = [primarySecret, ...verificationSecrets];
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0) {
+    throw new TypeError('Continuation maxAgeMs must be a positive integer.');
+  }
+  const maxTokenBytes = options.maxTokenBytes ?? DEFAULT_MAX_TOKEN_BYTES;
+  if (!Number.isSafeInteger(maxTokenBytes) || maxTokenBytes <= 0) {
+    throw new TypeError(
+      'Continuation maxTokenBytes must be a positive integer.',
+    );
+  }
+  const clockSkewMs = options.clockSkewMs ?? DEFAULT_CLOCK_SKEW_MS;
+  if (!Number.isSafeInteger(clockSkewMs) || clockSkewMs < 0) {
+    throw new TypeError(
+      'Continuation clockSkewMs must be a non-negative integer.',
+    );
+  }
+
+  return {
+    decode(token) {
+      if (typeof token !== 'string') {
+        throw new RunProtocolError('Continuation token must be a string.');
+      }
+      assertTokenLength(token, maxTokenBytes);
+      const separator = token.lastIndexOf('.');
+      if (separator <= 0) {
+        throw new RunProtocolError('Continuation token is malformed.');
+      }
+      const body = token.slice(0, separator);
+      const signature = token.slice(separator + 1);
+      const bodyBytes = decodeBase64Url(body, 'Continuation payload');
+      if (!verifySignature(body, signature, secrets)) {
+        throw new RunProtocolError('Continuation signature is invalid.');
+      }
+      let payload: unknown;
+      try {
+        payload = parseJson(bodyBytes.toString('utf8'));
+      } catch {
+        throw new RunProtocolError('Continuation payload is malformed.');
+      }
+      if (!isEnvelope(payload)) {
+        throw new RunProtocolError('Continuation envelope is invalid.');
+      }
+      if (Buffer.from(canonicalJson(payload)).toString('base64url') !== body) {
+        throw new RunProtocolError(
+          'Continuation payload is not canonically encoded.',
+        );
+      }
+      const now = Date.now();
+      if (payload.expiresAtMs <= now) {
+        throw new RunProtocolError('Continuation has expired.');
+      }
+      if (payload.issuedAtMs > now + clockSkewMs) {
+        throw new RunProtocolError('Continuation was issued in the future.');
+      }
+      if (payload.expiresAtMs - payload.issuedAtMs > maxAgeMs) {
+        throw new RunProtocolError('Continuation lifetime is invalid.');
+      }
+      return structuredClone(payload.state);
+    },
+    encode(state) {
+      const issuedAtMs = Date.now();
+      const payload = {
+        algorithm: 'HS256',
+        expiresAtMs: issuedAtMs + maxAgeMs,
+        format: 'run-continuation',
+        issuedAtMs,
+        nonce: randomBytes(16).toString('hex'),
+        state: structuredClone(state),
+        version: 1,
+      };
+      const body = Buffer.from(canonicalJson(payload)).toString('base64url');
+      const signature = sign(body, primarySecret);
+      const token = `${body}.${signature}`;
+      assertTokenLength(token, maxTokenBytes);
+      return token;
+    },
+  };
+};
+
+export const createStoredContinuationCodec = ({
+  storage,
+  maxAgeMs = DEFAULT_MAX_AGE_MS,
+}: {
+  storage: ContinuationStorage;
+  maxAgeMs?: number;
+}): ContinuationCodec<string> => {
+  if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0) {
+    throw new TypeError('Continuation maxAgeMs must be a positive integer.');
+  }
+  return {
+    async decode(key, context) {
+      throwIfOperationAborted(context);
+      if (
+        typeof key !== 'string' ||
+        !/^[A-Za-z0-9_-]{43}$/u.test(key) ||
+        Buffer.from(key, 'base64url').toString('base64url') !== key
+      ) {
+        throw new RunProtocolError('Stored continuation key is invalid.');
+      }
+      const stored = await storage.take(key, context);
+      throwIfOperationAborted(context);
+      if (stored === undefined) {
+        throw new RunProtocolError('Stored continuation was not found.');
+      }
+      if (
+        !isPlainRecord(stored) ||
+        !hasExactKeys(stored, ['expiresAtMs', 'state']) ||
+        !Number.isSafeInteger(stored.expiresAtMs)
+      ) {
+        throw new RunProtocolError('Stored continuation envelope is invalid.');
+      }
+      if (stored.expiresAtMs <= Date.now()) {
+        throw new RunProtocolError('Stored continuation has expired.');
+      }
+      return structuredClone(stored.state);
+    },
+    async encode(state, context) {
+      const key = randomBytes(32).toString('base64url');
+      throwIfOperationAborted(context);
+      await storage.set(
+        key,
+        {
+          expiresAtMs: Date.now() + maxAgeMs,
+          state: structuredClone(state),
+        },
+        context,
+      );
+      throwIfOperationAborted(context);
+      return key;
+    },
+  };
+};

--- a/src/continuation-validation-hardening.test.ts
+++ b/src/continuation-validation-hardening.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { assertContinuationState } from './continuation-validation.js';
+import type { RunContinuationState } from './types.js';
+import { normalizeOptions } from './utils/options.js';
+
+const source = `
+  await tools.first({ value: 1 });
+  try { await tools.second({ value: 2 }); } catch {}
+  return await tools.pause({ value: 3 });
+`;
+const scopeHash = '02'.repeat(32);
+
+const requireEntry = <T>(values: T[], index: number): T => {
+  const value = values[index];
+  if (value === undefined) {
+    throw new Error(`Missing test ledger entry at index ${index}.`);
+  }
+  return value;
+};
+
+const validState = (): RunContinuationState => ({
+  determinism: {
+    dateNowMs: 1_700_000_000_000,
+    randomSeed: '01'.repeat(16),
+  },
+  ledger: [
+    {
+      bindingName: 'tools.first',
+      dateNowMs: 1_700_000_000_001,
+      inputJson: '[[1],{"value":2},1]',
+      settledOrder: 1,
+      status: 'fulfilled',
+      valueJson: '[true]',
+    },
+    {
+      bindingName: 'tools.second',
+      dateNowMs: 1_700_000_000_002,
+      error: { message: 'expected', name: 'Error' },
+      inputJson: '[[1],{"value":2},2]',
+      settledOrder: 2,
+      status: 'rejected',
+    },
+    {
+      bindingName: 'tools.pause',
+      inputJson: '[[1],{"value":2},3]',
+      interruptionId: 'interrupt-3',
+      payloadJson: '[{"kind":1},"pause"]',
+      status: 'interrupted',
+    },
+  ],
+  logicalRunId: '03'.repeat(16),
+  runtime: 'run-replay-v2',
+  scopeHash,
+  serde: 'run-js-v1',
+  source,
+  version: 2,
+});
+
+const expectInvalid = (value: unknown): void => {
+  expect(() =>
+    assertContinuationState(value, source, scopeHash, normalizeOptions()),
+  ).toThrowError(expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }));
+};
+
+describe('continuation state validation hardening', () => {
+  it('accepts only the exact versioned state shape', () => {
+    expect(() =>
+      assertContinuationState(
+        validState(),
+        source,
+        scopeHash,
+        normalizeOptions(),
+      ),
+    ).not.toThrow();
+    for (const mutation of [
+      (state: Record<string, unknown>) => {
+        state.extra = true;
+      },
+      (state: Record<string, unknown>) => {
+        (state.determinism as Record<string, unknown>).extra = true;
+      },
+      (state: Record<string, unknown>) => {
+        ((state.ledger as unknown[])[0] as Record<string, unknown>).extra =
+          true;
+      },
+    ]) {
+      const state = validState() as unknown as Record<string, unknown>;
+      mutation(state);
+      expectInvalid(state);
+    }
+  });
+
+  it('rejects sparse arrays, cycles, accessors, and non-plain objects', () => {
+    const sparse = validState();
+    sparse.ledger = [];
+    sparse.ledger.length = 3;
+    sparse.ledger[0] = requireEntry(validState().ledger, 0);
+    sparse.ledger[2] = requireEntry(validState().ledger, 2);
+    expectInvalid(sparse);
+
+    const cycle = validState() as RunContinuationState & { cycle?: unknown };
+    cycle.cycle = cycle;
+    expectInvalid(cycle);
+
+    const accessor = validState();
+    Object.defineProperty(accessor.determinism, 'randomSeed', {
+      get() {
+        throw new Error('accessor failure');
+      },
+    });
+    expectInvalid(accessor);
+
+    expectInvalid({ ...validState(), determinism: new Date() });
+  });
+
+  it('fails closed for 10,000 structure-aware state mutations', () => {
+    let random = 2_738_958_700;
+    const next = (): number => {
+      random = (random * 1_664_525 + 1_013_904_223) % 4_294_967_296;
+      return random;
+    };
+    const generatedJson = (depth: number): unknown => {
+      if (depth > 2) {
+        return next() % 2 === 0 ? next() : `v-${next()}`;
+      }
+      return next() % 2 === 0
+        ? Array.from({ length: next() % 4 }, () => generatedJson(depth + 1))
+        : { value: generatedJson(depth + 1) };
+    };
+
+    for (let iteration = 0; iteration < 10_000; iteration += 1) {
+      const state = validState() as unknown as Record<string, unknown>;
+      const ledger = state.ledger as Record<string, unknown>[];
+      switch (next() % 12) {
+        case 0: {
+          state.version = next();
+          break;
+        }
+        case 1: {
+          state.runtime = `runtime-${next()}`;
+          break;
+        }
+        case 2: {
+          state.source = `${source}\n${next()}`;
+          break;
+        }
+        case 3: {
+          (state.determinism as Record<string, unknown>).randomSeed =
+            `${next()}`;
+          break;
+        }
+        case 4: {
+          (state.determinism as Record<string, unknown>).dateNowMs = -1;
+          break;
+        }
+        case 5: {
+          requireEntry(ledger, next() % ledger.length).bindingName =
+            'constructor';
+          break;
+        }
+        case 6: {
+          requireEntry(ledger, next() % ledger.length).inputJson = '{';
+          break;
+        }
+        case 7: {
+          requireEntry(ledger, 0).settledOrder = 2;
+          break;
+        }
+        case 8: {
+          requireEntry(ledger, 1).error = {
+            extra: true,
+            message: 'x',
+            name: 'Error',
+          };
+          break;
+        }
+        case 9: {
+          requireEntry(ledger, 2).interruptionId = `interrupt-${next()}`;
+          break;
+        }
+        case 10: {
+          requireEntry(ledger, 2).payloadJson = '{';
+          break;
+        }
+        default: {
+          requireEntry(ledger, next() % ledger.length).extra = generatedJson(0);
+        }
+      }
+      expectInvalid(state);
+    }
+  });
+
+  it('enforces exact aggregate state bytes rather than an entry estimate', () => {
+    const state = validState();
+    const exactBytes = Buffer.byteLength(JSON.stringify(state));
+    expect(() =>
+      assertContinuationState(state, source, scopeHash, {
+        ...normalizeOptions(),
+        maxContinuationBytes: exactBytes,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertContinuationState(state, source, scopeHash, {
+        ...normalizeOptions(),
+        maxContinuationBytes: exactBytes - 1,
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }));
+  });
+});

--- a/src/continuation-validation.ts
+++ b/src/continuation-validation.ts
@@ -1,0 +1,402 @@
+import { Buffer } from 'node:buffer';
+import { RunProtocolError } from './errors.js';
+import type {
+  NormalizedRunOptions,
+  RunContinuationState,
+  RunLedgerEntry,
+  SerializableError,
+} from './types.js';
+import { parseJson } from './utils/parse-json.js';
+import { hasExactKeys } from './utils/object-validation.js';
+import { parseJsonPayload } from './utils/serialization.js';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isSerializableError = (value: unknown): value is SerializableError =>
+  isRecord(value) &&
+  Object.keys(value).every(key =>
+    ['code', 'details', 'message', 'name', 'stack'].includes(key),
+  ) &&
+  typeof value.name === 'string' &&
+  typeof value.message === 'string' &&
+  (value.stack === undefined || typeof value.stack === 'string') &&
+  (value.code === undefined || typeof value.code === 'string');
+
+const assertJsonValue = (
+  value: unknown,
+  seen = new WeakSet<object>(),
+): void => {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    return;
+  }
+  if (typeof value !== 'object') {
+    throw new RunProtocolError('Continuation contains a non-JSON value.');
+  }
+  if (seen.has(value)) {
+    throw new RunProtocolError('Continuation contains a cyclic value.');
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertJsonValue(item, seen);
+    }
+  } else {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new RunProtocolError('Continuation contains a non-plain object.');
+    }
+    for (const item of Object.values(value)) {
+      assertJsonValue(item, seen);
+    }
+  }
+  seen.delete(value);
+};
+
+const assertSerializedPayload = (
+  value: string,
+  maxBytes: number,
+  index: number,
+): void => {
+  const bytes = Buffer.byteLength(value);
+  if (bytes > maxBytes) {
+    throw new RunProtocolError('Continuation ledger payload is too large.', {
+      bytes,
+      index,
+      maxBytes,
+    });
+  }
+  try {
+    parseJson(value);
+    parseJsonPayload(value, 'Continuation ledger payload');
+  } catch {
+    throw new RunProtocolError(
+      'Continuation ledger payload is invalid run-js-v1 data.',
+      { index },
+    );
+  }
+};
+
+type FulfilledLedgerEntry = Extract<RunLedgerEntry, { status: 'fulfilled' }>;
+type RejectedLedgerEntry = Extract<RunLedgerEntry, { status: 'rejected' }>;
+type InterruptedLedgerEntry = Extract<
+  RunLedgerEntry,
+  { status: 'interrupted' }
+>;
+
+type AssertFulfilledEntry = (
+  value: Record<string, unknown>,
+  index: number,
+  options: NormalizedRunOptions,
+) => asserts value is FulfilledLedgerEntry;
+
+const assertFulfilledEntry: AssertFulfilledEntry = (value, index, options) => {
+  if (
+    !hasExactKeys(value, [
+      'bindingName',
+      'dateNowMs',
+      'inputJson',
+      'settledOrder',
+      'status',
+      'valueJson',
+    ]) ||
+    typeof value.settledOrder !== 'number' ||
+    !Number.isSafeInteger(value.settledOrder) ||
+    value.settledOrder <= 0 ||
+    !Number.isSafeInteger(value.dateNowMs) ||
+    (value.dateNowMs as number) < 0 ||
+    typeof value.valueJson !== 'string'
+  ) {
+    throw new RunProtocolError('Fulfilled continuation entry is malformed.', {
+      index,
+    });
+  }
+  assertSerializedPayload(
+    value.valueJson,
+    options.maxBindingOutputBytes,
+    index,
+  );
+};
+
+type AssertRejectedEntry = (
+  value: Record<string, unknown>,
+  index: number,
+  options: NormalizedRunOptions,
+) => asserts value is RejectedLedgerEntry;
+
+const assertRejectedEntry: AssertRejectedEntry = (value, index, options) => {
+  if (
+    !hasExactKeys(value, [
+      'bindingName',
+      'dateNowMs',
+      'error',
+      'inputJson',
+      'settledOrder',
+      'status',
+    ]) ||
+    typeof value.settledOrder !== 'number' ||
+    !Number.isSafeInteger(value.settledOrder) ||
+    value.settledOrder <= 0 ||
+    !Number.isSafeInteger(value.dateNowMs) ||
+    (value.dateNowMs as number) < 0 ||
+    !isSerializableError(value.error)
+  ) {
+    throw new RunProtocolError('Rejected continuation entry is malformed.', {
+      index,
+    });
+  }
+  assertJsonValue(value.error);
+  const errorBytes = Buffer.byteLength(JSON.stringify(value.error));
+  if (errorBytes > options.maxBindingOutputBytes) {
+    throw new RunProtocolError('Continuation error payload is too large.', {
+      bytes: errorBytes,
+      index,
+      maxBytes: options.maxBindingOutputBytes,
+    });
+  }
+};
+
+type AssertInterruptedEntry = (
+  value: Record<string, unknown>,
+  index: number,
+  options: NormalizedRunOptions,
+) => asserts value is InterruptedLedgerEntry;
+
+const assertInterruptedEntry: AssertInterruptedEntry = (
+  value,
+  index,
+  options,
+) => {
+  if (
+    !hasExactKeys(value, [
+      'bindingName',
+      'inputJson',
+      'interruptionId',
+      'payloadJson',
+      'status',
+    ]) ||
+    value.interruptionId !== `interrupt-${index + 1}` ||
+    typeof value.payloadJson !== 'string'
+  ) {
+    throw new RunProtocolError('Interrupted continuation entry is malformed.', {
+      index,
+    });
+  }
+  assertSerializedPayload(
+    value.payloadJson,
+    options.maxBindingOutputBytes,
+    index,
+  );
+};
+
+type AssertLedgerEntry = (
+  value: unknown,
+  index: number,
+  options: NormalizedRunOptions,
+) => asserts value is RunLedgerEntry;
+
+const assertLedgerEntry: AssertLedgerEntry = (value, index, options) => {
+  if (
+    !isRecord(value) ||
+    typeof value.bindingName !== 'string' ||
+    !/^[A-Za-z_$][\w$]*\.[^.]+$/u.test(value.bindingName) ||
+    Buffer.byteLength(value.bindingName) > 1024 ||
+    typeof value.inputJson !== 'string' ||
+    !['fulfilled', 'rejected', 'interrupted'].includes(String(value.status))
+  ) {
+    throw new RunProtocolError('Continuation ledger entry is malformed.', {
+      index,
+    });
+  }
+  assertSerializedPayload(value.inputJson, options.maxBindingInputBytes, index);
+  if (
+    !Array.isArray(
+      parseJsonPayload(value.inputJson, 'Continuation ledger arguments'),
+    )
+  ) {
+    throw new RunProtocolError(
+      'Continuation ledger arguments must be encoded as an array.',
+      { index },
+    );
+  }
+  if (value.status === 'fulfilled') {
+    assertFulfilledEntry(value, index, options);
+    return;
+  }
+  if (value.status === 'rejected') {
+    assertRejectedEntry(value, index, options);
+    return;
+  }
+  assertInterruptedEntry(value, index, options);
+};
+
+const isMatchingContinuationState = (
+  value: unknown,
+  source: string,
+  scopeHash: string,
+): value is RunContinuationState =>
+  isRecord(value) &&
+  hasExactKeys(value, [
+    'determinism',
+    'ledger',
+    'logicalRunId',
+    'runtime',
+    'serde',
+    'scopeHash',
+    'source',
+    'version',
+  ]) &&
+  value.version === 2 &&
+  value.runtime === 'run-replay-v2' &&
+  value.serde === 'run-js-v1' &&
+  value.source === source &&
+  typeof value.logicalRunId === 'string' &&
+  /^[0-9a-f]{32}$/u.test(value.logicalRunId) &&
+  typeof value.scopeHash === 'string' &&
+  /^[0-9a-f]{64}$/u.test(value.scopeHash) &&
+  value.scopeHash === scopeHash;
+
+const hasValidDeterminism = (value: unknown): boolean =>
+  isRecord(value) &&
+  hasExactKeys(value, ['dateNowMs', 'randomSeed']) &&
+  Number.isSafeInteger(value.dateNowMs) &&
+  (value.dateNowMs as number) >= 0 &&
+  typeof value.randomSeed === 'string' &&
+  /^[0-9a-f]{32}$/iu.test(value.randomSeed);
+
+const addSettledOrder = (orders: Set<number>, order: number): void => {
+  if (orders.has(order)) {
+    throw new RunProtocolError('Continuation settled order is duplicated.');
+  }
+  orders.add(order);
+};
+
+const validateLedger = (
+  value: RunContinuationState,
+  options: NormalizedRunOptions,
+): void => {
+  if (
+    !Array.isArray(value.ledger) ||
+    value.ledger.length === 0 ||
+    value.ledger.length > options.maxBridgeRequests
+  ) {
+    throw new RunProtocolError('Continuation ledger length is invalid.');
+  }
+
+  let totalBytes = Buffer.byteLength(value.source) + 128;
+  const interruptionIds = new Set<string>();
+  const settledOrders = new Set<number>();
+  for (const [index, entry] of value.ledger.entries()) {
+    assertLedgerEntry(entry, index, options);
+    totalBytes += Buffer.byteLength(entry.bindingName);
+    totalBytes += Buffer.byteLength(entry.inputJson);
+    if (entry.status === 'fulfilled') {
+      addSettledOrder(settledOrders, entry.settledOrder);
+      totalBytes += Buffer.byteLength(entry.valueJson);
+    } else if (entry.status === 'rejected') {
+      addSettledOrder(settledOrders, entry.settledOrder);
+      totalBytes += Buffer.byteLength(JSON.stringify(entry.error));
+    } else {
+      if (interruptionIds.has(entry.interruptionId)) {
+        throw new RunProtocolError(
+          'Continuation ledger contains a duplicate interruption id.',
+        );
+      }
+      interruptionIds.add(entry.interruptionId);
+      totalBytes += Buffer.byteLength(entry.interruptionId);
+      totalBytes += Buffer.byteLength(entry.payloadJson);
+    }
+    if (totalBytes > options.maxContinuationBytes) {
+      throw new RunProtocolError(
+        `Continuation state exceeds the ${options.maxContinuationBytes} byte size limit.`,
+        { bytes: totalBytes, maxBytes: options.maxContinuationBytes },
+      );
+    }
+  }
+  const exactBytes = Buffer.byteLength(JSON.stringify(value));
+  if (exactBytes > options.maxContinuationBytes) {
+    throw new RunProtocolError(
+      `Continuation state exceeds the ${options.maxContinuationBytes} byte size limit.`,
+      { bytes: exactBytes, maxBytes: options.maxContinuationBytes },
+    );
+  }
+  for (let order = 1; order <= settledOrders.size; order += 1) {
+    if (!settledOrders.has(order)) {
+      throw new RunProtocolError(
+        'Continuation settled order is not unique and contiguous.',
+      );
+    }
+  }
+};
+
+type ValidateContinuationState = (
+  value: unknown,
+  source: string,
+  scopeHash: string,
+  options: NormalizedRunOptions,
+) => asserts value is RunContinuationState;
+
+const validateContinuationState: ValidateContinuationState = (
+  value,
+  source,
+  scopeHash,
+  options,
+) => {
+  if (!isMatchingContinuationState(value, source, scopeHash)) {
+    throw new RunProtocolError(
+      'Continuation does not match the supplied source, scope, or runtime version.',
+    );
+  }
+  if (!hasValidDeterminism(value.determinism)) {
+    throw new RunProtocolError('Continuation determinism state is invalid.');
+  }
+  validateLedger(value, options);
+};
+
+export const assertContinuationTokenSize = (
+  token: unknown,
+  maxBytes: number,
+): void => {
+  let bytes: number | undefined;
+  if (typeof token === 'string') {
+    bytes = Buffer.byteLength(token);
+  } else if (token instanceof Uint8Array) {
+    bytes = token.byteLength;
+  }
+  if (bytes !== undefined && bytes > maxBytes) {
+    throw new RunProtocolError(
+      `Continuation token exceeds the ${maxBytes} byte size limit.`,
+      { bytes, maxBytes },
+    );
+  }
+};
+
+type AssertContinuationState = (
+  value: unknown,
+  source: string,
+  scopeHash: string,
+  options: NormalizedRunOptions,
+) => asserts value is RunContinuationState;
+
+export const assertContinuationState: AssertContinuationState = (
+  value,
+  source,
+  scopeHash,
+  options,
+) => {
+  try {
+    validateContinuationState(value, source, scopeHash, options);
+  } catch (error) {
+    if (error instanceof RunProtocolError) {
+      throw error;
+    }
+    throw new RunProtocolError('Continuation state is invalid.', {
+      cause: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "..",
+    "types": ["node"]
+  },
+  "include": ["**/*.test.ts"],
+  "exclude": ["../dist", "../node_modules"]
+}


### PR DESCRIPTION
this enables secure pause-and-resume execution.

typical flow:
- Sandboxed code calls a binding requiring approval/authentication.
- The run pauses and creates continuation state containing:
  - Source code
  - Completed binding results
  - Pending interruption
  - Deterministic time/random state
  - Run and scope identifiers

- The codec converts that state into an opaque token.
- Later, the caller supplies the token and a resolution.
- Execution replays without repeating completed bindings.
- Two codec options were added:
  - Signed codec: embeds state in an HMAC-protected token. It detects tampering, expiration, wrong keys, and key rotation.
  - Stored codec: stores state externally and returns a random, one-use key. Atomic consumption prevents replay.