### PR TITLE
feat: add communication protocol between nodeJS and QuickJS

### DIFF
--- a/src/runtime/max-workers.test.ts
+++ b/src/runtime/max-workers.test.ts
@@ -1,0 +1,69 @@
+import os from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getMaxWorkers, setMaxWorkers } from './max-workers.js';
+
+describe('max workers', () => {
+  afterEach(() => {
+    setMaxWorkers(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it('honors an explicit process-wide cap', () => {
+    setMaxWorkers(7);
+    expect(getMaxWorkers({ activeWorkers: 0, memoryLimitBytes: 1 })).toBe(7);
+  });
+
+  it('admits at least one worker and caps the memory heuristic at 32', () => {
+    const workerBytes = 64 * 1024 * 1024;
+    vi.spyOn(process, 'availableMemory').mockReturnValue(workerBytes - 1);
+    expect(
+      getMaxWorkers({
+        activeWorkers: 0,
+        memoryLimitBytes: 16 * 1024 * 1024,
+      }),
+    ).toBe(1);
+
+    vi.mocked(process.availableMemory).mockReturnValue(workerBytes * 100);
+    expect(
+      getMaxWorkers({
+        activeWorkers: 0,
+        memoryLimitBytes: 16 * 1024 * 1024,
+      }),
+    ).toBe(32);
+  });
+
+  it('falls back to os.freemem when process.availableMemory is unavailable', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      process,
+      'availableMemory',
+    );
+    if (descriptor === undefined) {
+      throw new Error('Expected process.availableMemory to be defined.');
+    }
+    const workerBytes = 64 * 1024 * 1024;
+    vi.spyOn(os, 'freemem').mockReturnValue(workerBytes * 2);
+    try {
+      Object.defineProperty(process, 'availableMemory', {
+        configurable: true,
+        value: undefined,
+      });
+      expect(
+        getMaxWorkers({
+          activeWorkers: 0,
+          memoryLimitBytes: 16 * 1024 * 1024,
+        }),
+      ).toBe(2);
+    } finally {
+      Object.defineProperty(process, 'availableMemory', descriptor);
+    }
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid configured cap %s',
+    value => {
+      expect(() => setMaxWorkers(value)).toThrow(
+        'maxWorkers must be a positive integer',
+      );
+    },
+  );
+});

--- a/src/runtime/max-workers.ts
+++ b/src/runtime/max-workers.ts
@@ -1,0 +1,64 @@
+import os from 'node:os';
+
+const DEFAULT_MAX_WORKERS_CAP = 32;
+const DEFAULT_WORKER_OVERHEAD_BYTES = 48 * 1024 * 1024;
+
+let configuredMaxWorkers: number | undefined;
+
+const availableMemory = (): number => {
+  const processWithAvailableMemory = process as typeof process & {
+    availableMemory?: () => number;
+  };
+  const bytes =
+    typeof processWithAvailableMemory.availableMemory === 'function'
+      ? processWithAvailableMemory.availableMemory()
+      : os.freemem();
+  return Number.isFinite(bytes) && bytes > 0 ? bytes : 0;
+};
+
+/**
+ * Sets the process-global maximum number of active run workers.
+ *
+ * Pass `undefined` or call without an argument to restore the dynamic
+ * memory-based default. The default admits at least one invocation and admits
+ * additional workers only when available memory can cover another worker.
+ *
+ * @param maxWorkers - Positive integer worker cap, or `undefined` to reset.
+ */
+export const setMaxWorkers = (maxWorkers?: number): void => {
+  if (maxWorkers === undefined) {
+    configuredMaxWorkers = undefined;
+    return;
+  }
+  if (!Number.isInteger(maxWorkers) || maxWorkers <= 0) {
+    throw new TypeError('maxWorkers must be a positive integer.');
+  }
+  configuredMaxWorkers = maxWorkers;
+};
+
+/**
+ * Returns the currently effective worker cap.
+ *
+ * @internal
+ */
+export const getMaxWorkers = ({
+  memoryLimitBytes,
+  activeWorkers,
+}: {
+  memoryLimitBytes: number;
+  activeWorkers: number;
+}): number => {
+  if (configuredMaxWorkers !== undefined) {
+    return configuredMaxWorkers;
+  }
+
+  const estimatedBytesPerWorker =
+    memoryLimitBytes + DEFAULT_WORKER_OVERHEAD_BYTES;
+  const additionalWorkers = Math.floor(
+    availableMemory() / estimatedBytesPerWorker,
+  );
+  return Math.max(
+    1,
+    Math.min(DEFAULT_MAX_WORKERS_CAP, activeWorkers + additionalWorkers),
+  );
+};

--- a/src/runtime/protocol-validation.ts
+++ b/src/runtime/protocol-validation.ts
@@ -1,0 +1,254 @@
+import { Buffer } from 'node:buffer';
+import { RunProtocolError } from '../errors.js';
+import type { SerializableError } from '../types.js';
+import type { MainToWorkerMessage, WorkerToMainMessage } from './protocol.js';
+
+const invalidMessage = (kind: string): RunProtocolError =>
+  new RunProtocolError(`Invalid ${kind} worker protocol message.`);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isTimestamp = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) >= 0;
+
+const isIdentifier = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0 && value.length <= 512;
+
+const assertExactKeys = (
+  value: Record<string, unknown>,
+  expected: string[],
+): void => {
+  const actual = Object.keys(value).toSorted();
+  const sortedExpected = expected.toSorted();
+  if (
+    actual.length !== sortedExpected.length ||
+    actual.some((key, index) => key !== sortedExpected[index])
+  ) {
+    throw invalidMessage('object shape');
+  }
+};
+
+const isSerializableError = (value: unknown): value is SerializableError => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const allowed = new Set(['code', 'details', 'message', 'name', 'stack']);
+  if (Object.keys(value).some(key => !allowed.has(key))) {
+    return false;
+  }
+  return (
+    typeof value.name === 'string' &&
+    typeof value.message === 'string' &&
+    (value.stack === undefined || typeof value.stack === 'string') &&
+    (value.code === undefined || typeof value.code === 'string')
+  );
+};
+
+const isRunOptions = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  try {
+    assertExactKeys(value, [
+      'executionTimeoutMs',
+      'maxBindingInputBytes',
+      'maxConsoleOutputBytes',
+      'maxResultBytes',
+      'maxStackSizeBytes',
+      'memoryLimitBytes',
+      'timeoutMs',
+    ]);
+  } catch {
+    return false;
+  }
+  return Object.values(value).every(
+    item => Number.isSafeInteger(item) && (item as number) > 0,
+  );
+};
+
+const isDeterminism = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  try {
+    assertExactKeys(value, ['dateNowMs', 'randomSeed']);
+  } catch {
+    return false;
+  }
+  return (
+    isTimestamp(value.dateNowMs) &&
+    typeof value.randomSeed === 'string' &&
+    /^[0-9a-f]{32}$/u.test(value.randomSeed)
+  );
+};
+
+const assertReady = (value: Record<string, unknown>): void => {
+  assertExactKeys(value, ['invocationId', 'type']);
+  if (!isIdentifier(value.invocationId)) {
+    throw invalidMessage('ready');
+  }
+};
+
+const assertResult = (value: Record<string, unknown>): void => {
+  if (value.success === true) {
+    assertExactKeys(value, ['invocationId', 'success', 'type', 'valueJson']);
+    if (
+      !isIdentifier(value.invocationId) ||
+      typeof value.valueJson !== 'string' ||
+      value.valueJson.length === 0
+    ) {
+      throw invalidMessage('result');
+    }
+    return;
+  }
+  assertExactKeys(value, ['error', 'invocationId', 'success', 'type']);
+  if (
+    value.success !== false ||
+    !isIdentifier(value.invocationId) ||
+    !isSerializableError(value.error)
+  ) {
+    throw invalidMessage('result');
+  }
+};
+
+const assertBridgeIdle = (value: Record<string, unknown>): void => {
+  assertExactKeys(value, ['invocationId', 'requestCount', 'type']);
+  if (
+    !isIdentifier(value.invocationId) ||
+    !Number.isSafeInteger(value.requestCount) ||
+    (value.requestCount as number) < 0
+  ) {
+    throw invalidMessage('bridge-idle');
+  }
+};
+
+const assertBindingRequest = (value: Record<string, unknown>): void => {
+  assertExactKeys(value, [
+    'bindingName',
+    'inputJson',
+    'invocationId',
+    'requestId',
+    'type',
+  ]);
+  if (
+    !isIdentifier(value.invocationId) ||
+    !isIdentifier(value.requestId) ||
+    typeof value.bindingName !== 'string' ||
+    value.bindingName.length === 0 ||
+    Buffer.byteLength(value.bindingName) > 1024 ||
+    typeof value.inputJson !== 'string' ||
+    value.inputJson.length === 0
+  ) {
+    throw invalidMessage('binding-request');
+  }
+};
+
+const assertBridgeResponse = (value: Record<string, unknown>): void => {
+  const common =
+    isIdentifier(value.invocationId) &&
+    isIdentifier(value.requestId) &&
+    typeof value.success === 'boolean' &&
+    isTimestamp(value.dateNowMs);
+  if (value.success === true) {
+    assertExactKeys(value, [
+      'dateNowMs',
+      'invocationId',
+      'requestId',
+      'success',
+      'type',
+      'valueJson',
+    ]);
+    if (
+      !common ||
+      typeof value.valueJson !== 'string' ||
+      value.valueJson.length === 0
+    ) {
+      throw invalidMessage('bridge-response');
+    }
+    return;
+  }
+  assertExactKeys(value, [
+    'dateNowMs',
+    'error',
+    'invocationId',
+    'requestId',
+    'success',
+    'type',
+  ]);
+  if (!common || !isSerializableError(value.error)) {
+    throw invalidMessage('bridge-response');
+  }
+};
+
+type AssertMainToWorkerMessage = (
+  value: unknown,
+) => asserts value is MainToWorkerMessage;
+
+export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    throw invalidMessage('main-to-worker');
+  }
+  if (value.type === 'run') {
+    assertExactKeys(value, [
+      'bindingNamespaces',
+      'determinism',
+      'invocationId',
+      'options',
+      'source',
+      'type',
+    ]);
+    if (
+      !isIdentifier(value.invocationId) ||
+      typeof value.source !== 'string' ||
+      !Array.isArray(value.bindingNamespaces) ||
+      value.bindingNamespaces.some(item => !isIdentifier(item)) ||
+      new Set(value.bindingNamespaces).size !==
+        value.bindingNamespaces.length ||
+      !isDeterminism(value.determinism) ||
+      !isRunOptions(value.options)
+    ) {
+      throw invalidMessage('run');
+    }
+    return;
+  }
+  if (value.type === 'bridge-response') {
+    assertBridgeResponse(value);
+    return;
+  }
+  if (value.type === 'cancel') {
+    assertExactKeys(value, ['invocationId', 'type']);
+    if (!isIdentifier(value.invocationId)) {
+      throw invalidMessage('cancel');
+    }
+    return;
+  }
+  throw invalidMessage('main-to-worker');
+};
+
+type AssertWorkerToMainMessage = (
+  value: unknown,
+) => asserts value is WorkerToMainMessage;
+
+export const assertWorkerToMainMessage: AssertWorkerToMainMessage = value => {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    throw invalidMessage('worker-to-main');
+  }
+  if (value.type === 'binding-request') {
+    assertBindingRequest(value);
+    return;
+  }
+  if (value.type === 'bridge-idle') {
+    assertBridgeIdle(value);
+    return;
+  }
+  if (value.type === 'result') {
+    assertResult(value);
+    return;
+  }
+  if (value.type === 'ready') {
+    assertReady(value);
+    return;
+  }
+  throw invalidMessage('worker-to-main');
+};

--- a/src/runtime/protocol.test.ts
+++ b/src/runtime/protocol.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertMainToWorkerMessage,
+  assertWorkerToMainMessage,
+} from './protocol-validation.js';
+
+const WORKER_OPTIONS = {
+  executionTimeoutMs: 950,
+  maxBindingInputBytes: 1024 * 1024,
+  maxConsoleOutputBytes: 64 * 1024,
+  maxResultBytes: 1024 * 1024,
+  maxStackSizeBytes: 2 * 1024 * 1024,
+  memoryLimitBytes: 64 * 1024 * 1024,
+  timeoutMs: 1000,
+};
+
+const DETERMINISM = {
+  dateNowMs: 1_700_000_000_000,
+  randomSeed: '00000000000000000000000000000001',
+};
+
+const createRunMessage = (invocationId: string) => ({
+  bindingNamespaces: ['tools'],
+  determinism: DETERMINISM,
+  invocationId,
+  options: WORKER_OPTIONS,
+  source: 'return await tools.echo({ value: 1 });',
+  type: 'run',
+});
+
+const requireEntry = <T>(values: readonly T[], index: number): T => {
+  const value = values[index];
+  if (value === undefined) {
+    throw new Error(`Missing generated value at index ${index}.`);
+  }
+  return value;
+};
+
+describe('worker protocol hardening', () => {
+  it.each([
+    null,
+    {},
+    { type: 'unknown' },
+    { ...createRunMessage('invocation-a'), extra: true },
+    { ...createRunMessage('invocation-a'), invocationId: '' },
+    { extra: true, invocationId: '', type: 'cancel' },
+    { invocationId: '', type: 'cancel' },
+    {
+      ...createRunMessage('invocation-a'),
+      bindingNamespaces: ['tools', 'tools'],
+    },
+    {
+      ...createRunMessage('invocation-a'),
+      options: { ...WORKER_OPTIONS, timeoutMs: 0 },
+    },
+    {
+      invocationId: 'invocation-a',
+      requestId: 'request-a',
+      success: true,
+      type: 'bridge-response',
+      valueJson: '',
+    },
+  ])('rejects malformed main-to-worker messages %#', value => {
+    expect(() => assertMainToWorkerMessage(value)).toThrowError(
+      expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }),
+    );
+  });
+
+  it.each([
+    null,
+    {},
+    { type: 'unknown' },
+    { extra: true, invocationId: 'run-1', type: 'ready' },
+    { invocationId: 'run-1', requestCount: -1, type: 'bridge-idle' },
+    {
+      bindingName: '',
+      inputJson: '[]',
+      invocationId: 'run-1',
+      requestId: 'request-1',
+      type: 'binding-request',
+    },
+    { invocationId: 'run-1', success: true, type: 'result' },
+    {
+      error: { message: 'failure', name: 'Error', unexpected: true },
+      invocationId: 'run-1',
+      success: false,
+      type: 'result',
+    },
+  ])('rejects malformed worker-to-main messages %#', value => {
+    expect(() => assertWorkerToMainMessage(value)).toThrowError(
+      expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }),
+    );
+  });
+
+  it('fails closed for 10,000 generated malformed protocol values', () => {
+    let randomState = 305_419_896;
+    const next = (): number => {
+      randomState = (randomState * 1_664_525 + 1_013_904_223) % 4_294_967_296;
+      return randomState;
+    };
+    const generatedValue = (depth: number): unknown => {
+      const choice = next() % (depth > 2 ? 5 : 8);
+      if (choice === 0) {
+        return null;
+      }
+      if (choice === 1) {
+        return next();
+      }
+      if (choice === 2) {
+        return `value-${next()}`;
+      }
+      if (choice === 3) {
+        return next() % 2 === 1;
+      }
+      if (choice === 4) {
+        return undefined;
+      }
+      if (choice === 5) {
+        return Array.from({ length: next() % 4 }, () =>
+          generatedValue(depth + 1),
+        );
+      }
+      const result: Record<string, unknown> = {};
+      for (let item = 0; item < next() % 5; item += 1) {
+        result[`key-${next() % 12}`] = generatedValue(depth + 1);
+      }
+      return result;
+    };
+    const validators: ((value: unknown) => void)[] = [
+      value => assertMainToWorkerMessage(value),
+      value => assertWorkerToMainMessage(value),
+    ];
+
+    for (let index = 0; index < 10_000; index += 1) {
+      const value = generatedValue(0);
+      for (const validate of validators) {
+        try {
+          validate(value);
+        } catch (error) {
+          expect(error).toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+        }
+      }
+    }
+  });
+
+  it('rejects every generated mutation of known-valid messages', () => {
+    let randomState = 1_374_775_901;
+    const next = (): number => {
+      randomState = (randomState * 1_664_525 + 1_013_904_223) % 4_294_967_296;
+      return randomState;
+    };
+    const validMessages = [
+      { direction: 'main', value: createRunMessage('run-a') },
+      { direction: 'main', value: { invocationId: 'run-a', type: 'cancel' } },
+      {
+        direction: 'main',
+        value: {
+          dateNowMs: DETERMINISM.dateNowMs,
+          invocationId: 'run-a',
+          requestId: 'request-a',
+          success: true,
+          type: 'bridge-response',
+          valueJson: 'null',
+        },
+      },
+      { direction: 'worker', value: { invocationId: 'run-a', type: 'ready' } },
+      {
+        direction: 'worker',
+        value: {
+          bindingName: 'tools.echo',
+          inputJson: 'null',
+          invocationId: 'run-a',
+          requestId: 'request-a',
+          type: 'binding-request',
+        },
+      },
+      {
+        direction: 'worker',
+        value: {
+          invocationId: 'run-a',
+          success: true,
+          type: 'result',
+          valueJson: 'null',
+        },
+      },
+    ] as const;
+
+    for (let iteration = 0; iteration < 10_000; iteration += 1) {
+      const candidate = requireEntry(
+        validMessages,
+        next() % validMessages.length,
+      );
+      let mutation = structuredClone(candidate.value) as Record<
+        string,
+        unknown
+      >;
+      if (next() % 2 === 0) {
+        const keys = Object.keys(mutation);
+        const removedKey = requireEntry(keys, next() % keys.length);
+        mutation = Object.fromEntries(
+          Object.entries(mutation).filter(([key]) => key !== removedKey),
+        );
+      } else {
+        mutation[`unexpected-${next()}`] = true;
+      }
+      const validate =
+        candidate.direction === 'main'
+          ? assertMainToWorkerMessage
+          : assertWorkerToMainMessage;
+      expect(
+        () => validate(mutation),
+        `seed iteration ${iteration}`,
+      ).toThrowError(expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }));
+    }
+  });
+});

--- a/src/runtime/protocol.ts
+++ b/src/runtime/protocol.ts
@@ -1,0 +1,77 @@
+import type {
+  NormalizedRunOptions,
+  RunDeterminismState,
+  SerializableError,
+} from '../types.js';
+
+export interface WorkerRunMessage {
+  type: 'run';
+  invocationId: string;
+  source: string;
+  bindingNamespaces: string[];
+  determinism: RunDeterminismState;
+  options: Pick<
+    NormalizedRunOptions,
+    | 'timeoutMs'
+    | 'memoryLimitBytes'
+    | 'maxStackSizeBytes'
+    | 'maxResultBytes'
+    | 'maxConsoleOutputBytes'
+    | 'maxBindingInputBytes'
+  > & {
+    executionTimeoutMs: number;
+  };
+}
+
+export interface WorkerCancelMessage {
+  type: 'cancel';
+  invocationId: string;
+}
+
+export interface WorkerBindingRequest {
+  type: 'binding-request';
+  invocationId: string;
+  requestId: string;
+  bindingName: string;
+  inputJson: string;
+}
+
+export interface WorkerBridgeResponse {
+  type: 'bridge-response';
+  invocationId: string;
+  requestId: string;
+  success: boolean;
+  dateNowMs: number;
+  valueJson?: string;
+  error?: SerializableError;
+}
+
+export interface WorkerResultMessage {
+  type: 'result';
+  invocationId: string;
+  success: boolean;
+  valueJson?: string;
+  error?: SerializableError;
+}
+
+export interface WorkerReadyMessage {
+  type: 'ready';
+  invocationId: string;
+}
+
+export interface WorkerBridgeIdleMessage {
+  type: 'bridge-idle';
+  invocationId: string;
+  requestCount: number;
+}
+
+export type WorkerToMainMessage =
+  | WorkerBindingRequest
+  | WorkerBridgeIdleMessage
+  | WorkerResultMessage
+  | WorkerReadyMessage;
+
+export type MainToWorkerMessage =
+  | WorkerRunMessage
+  | WorkerCancelMessage
+  | WorkerBridgeResponse;

--- a/src/runtime/source-stack.test.ts
+++ b/src/runtime/source-stack.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeUserSourceStack,
+  USER_SOURCE_LINE_OFFSET,
+} from './source-stack.js';
+
+describe('user source stack normalization', () => {
+  it('maps generated wrapper lines back to user source', () => {
+    const source = ['const first = 1;', 'throw new Error("boom");'].join('\n');
+    const stack = [
+      'Error: boom',
+      `    at run.js:${USER_SOURCE_LINE_OFFSET + 2}:7`,
+      '    at run-setup.js:10:2',
+    ].join('\n');
+
+    expect(
+      normalizeUserSourceStack({
+        message: 'boom',
+        name: 'Error',
+        source,
+        stack,
+      }),
+    ).toBe('Error: boom\n    at run.js:2:7');
+  });
+
+  it('omits generated run.js frames outside the user source', () => {
+    expect(
+      normalizeUserSourceStack({
+        message: 'boom',
+        name: 'Error',
+        source: 'throw new Error("boom");',
+        stack: 'Error: boom\n    at run.js:1:1\n    at run.js:3:1',
+      }),
+    ).toBe('Error: boom\n    at run.js:1:1');
+  });
+
+  it('returns a stable header when no stack is available', () => {
+    expect(
+      normalizeUserSourceStack({
+        message: 'boom',
+        name: 'Error',
+        source: '',
+        stack: undefined,
+      }),
+    ).toBe('Error: boom');
+  });
+});

--- a/src/runtime/source-stack.ts
+++ b/src/runtime/source-stack.ts
@@ -1,0 +1,65 @@
+const USER_SOURCE_FILENAME = 'run.js';
+
+/** Number of generated lines before the first line of user source. */
+export const USER_SOURCE_LINE_OFFSET = 2;
+
+const isErrorHeader = (line: string, name: string, message: string): boolean =>
+  line === name || line === message || line === `${name}: ${message}`;
+
+/**
+ * Converts a QuickJS stack into a stable stack whose coordinates refer to the
+ * source passed to `run`. Frames belonging to the generated wrapper and guest
+ * runtime are intentionally omitted.
+ */
+export const normalizeUserSourceStack = ({
+  name,
+  message,
+  stack,
+  source,
+}: {
+  name: string;
+  message: string;
+  stack: string | undefined;
+  source: string;
+}): string => {
+  const header = `${name}: ${message}`;
+  if (stack === undefined || stack.length === 0) {
+    return header;
+  }
+
+  const sourceLineCount = source.split('\n').length;
+  const lines = stack.split('\n');
+  const frames: string[] = [];
+
+  for (const line of lines) {
+    if (
+      line.length === 0 ||
+      isErrorHeader(line, name, message) ||
+      line.includes('run-setup.js:')
+    ) {
+      continue;
+    }
+
+    let hasGeneratedSourceFrame = false;
+    let outsideUserSource = false;
+    const normalized = line.replaceAll(
+      /run\.js:(\d+):(\d+)/gu,
+      (_match, generatedLineText: string, column: string) => {
+        hasGeneratedSourceFrame = true;
+        const generatedLine = Number(generatedLineText);
+        const userLine = generatedLine - USER_SOURCE_LINE_OFFSET;
+        if (userLine < 1 || userLine > sourceLineCount) {
+          outsideUserSource = true;
+          return _match;
+        }
+        return `${USER_SOURCE_FILENAME}:${userLine}:${column}`;
+      },
+    );
+
+    if (!(hasGeneratedSourceFrame && outsideUserSource)) {
+      frames.push(normalized);
+    }
+  }
+
+  return [header, ...frames].join('\n');
+};


### PR DESCRIPTION
runtime protocol is the typed communication contract between the main Node.js process and the isolated QuickJS worker.

main -> worker:
- run: execute source with limits, bindings, and deterministic time/random state.
- cancel: stop a specific invocation.
- bridge-response: return a host-binding result or error.

worker -> main:
- ready: worker initialized.
- binding-request: guest code called a host binding.
- bridge-idle: all binding requests have settled.
- result: execution completed or failed.