### PR TITLE
feat: add the public api

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,6 +2,9 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "extends": ["./node_modules/ultracite/config/oxlint/core/.oxlintrc.json"],
   "ignorePatterns": ["dist/**"],
+  "rules": {
+    "func-style": "off"
+  },
   "overrides": [
     {
       "files": ["src/runtime/manager.ts", "src/runtime/worker.ts"],

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { RunError } from './index.js';
+
+describe('RunError', () => {
+  it('identifies errors created by a duplicate package module', async () => {
+    const duplicateModule = (await import(
+      `${new URL('./errors/run-error.js', import.meta.url).href}?duplicate`
+    )) as { RunError: typeof RunError };
+    const duplicateError = new duplicateModule.RunError('failure');
+
+    expect(duplicateError).not.toBeInstanceOf(RunError);
+    expect(RunError.isInstance(duplicateError)).toBe(true);
+  });
+
+  it('rejects unrelated values and false markers', () => {
+    expect(RunError.isInstance(new Error('failure'))).toBe(false);
+    expect(
+      RunError.isInstance({
+        [Symbol.for('vercel.run.error.RunError')]: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,42 @@
+export {
+  RunAbortedError,
+  RunBindingError,
+  RunBridgeLimitError,
+  RunConcurrencyError,
+  RunDetachedBridgeRequestError,
+  RunError,
+  RunProtocolError,
+  RunSourceTooLargeError,
+  RunTimeoutError,
+} from './errors.js';
+export {
+  createSignedContinuationCodec,
+  createStoredContinuationCodec,
+  type ContinuationStorage,
+  type SignedContinuationCodecOptions,
+  type StoredContinuation,
+} from './continuation-codec.js';
+export { createRunner, run } from './run.js';
+export { getBindingContext } from './binding-context.js';
+export { isRunInterruptedResult } from './is-interrupted.js';
+export { setMaxWorkers } from './runtime/max-workers.js';
+export type {
+  BindingContext,
+  BindingFunction,
+  BindingGroup,
+  BindingResumeContext,
+  Bindings,
+  ContinuationCodec,
+  ContinuationOperationContext,
+  RunCompletedResult,
+  RunContinuationState,
+  RunInput,
+  RunInterruptedResult,
+  RunInterruption,
+  RunLedgerEntry,
+  RunLimits,
+  RunResolution,
+  Runner,
+  RunnerOptions,
+  RunResult,
+} from './types.js';

--- a/src/replay-hardening.test.ts
+++ b/src/replay-hardening.test.ts
@@ -1,0 +1,523 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRunner, getBindingContext, run } from './index.js';
+import type { RunContinuationState, RunInterruptedResult } from './index.js';
+import { createPromiseWithResolvers } from './utils/promise-with-resolvers.js';
+
+const firstInterruptionId = (result: RunInterruptedResult): string => {
+  const interruption = result.interruptions.at(0);
+  if (interruption === undefined) {
+    throw new Error('Expected an interruption.');
+  }
+  return interruption.id;
+};
+
+const createPrng = (initialState: number): (() => number) => {
+  let state = initialState;
+  return () => {
+    const signedState = Math.imul(1_664_525, state) + 1_013_904_223;
+    state = signedState < 0 ? signedState + 2 ** 32 : signedState;
+    return state;
+  };
+};
+
+describe('continuation replay hardening', () => {
+  it('preserves a long time/random trace across multiple interruption rounds', async () => {
+    const traces: unknown[] = [];
+    const source = `
+      const trace = [];
+      for (let i = 0; i < 64; i++) trace.push([Date.now(), Math.random()]);
+      await tools.record(trace);
+      const first = await tools.pause({ round: 1 });
+      for (let i = 0; i < 64; i++) trace.push([Date.now(), Math.random()]);
+      await tools.record(trace);
+      const second = await tools.pause({ round: 2 });
+      return { trace, first, second };
+    `;
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'pause' });
+          }
+          return context.resume?.resolution;
+        },
+        record: (trace: unknown) => traces.push(trace),
+      },
+    };
+
+    const first = await run({ bindings, source });
+    if (first.status !== 'interrupted') {
+      throw new Error('Expected round one.');
+    }
+    const second = await run({
+      bindings,
+      continuation: first.continuation,
+      resolutions: [
+        { interruptionId: firstInterruptionId(first), value: 'one' },
+      ],
+      source,
+    });
+    if (second.status !== 'interrupted') {
+      throw new Error('Expected round two.');
+    }
+    const completed = await run({
+      bindings,
+      continuation: second.continuation,
+      resolutions: [
+        { interruptionId: firstInterruptionId(second), value: 'two' },
+      ],
+      source,
+    });
+    expect(completed).toMatchObject({
+      status: 'completed',
+      value: { first: 'one', second: 'two' },
+    });
+    expect(traces).toHaveLength(2);
+    if (completed.status === 'completed') {
+      expect((completed.value as { trace: unknown }).trace).toEqual(traces[1]);
+      expect((traces[1] as unknown[]).slice(0, 64)).toEqual(traces[0]);
+    }
+  });
+
+  it('keeps explicit Date behavior while replacing ambient time', async () => {
+    const result = await run({
+      source: `
+        const explicit = new Date('2020-01-02T03:04:05.000Z');
+        return {
+          explicit: explicit.toISOString(),
+          parsed: Date.parse('2020-01-02T03:04:05.000Z'),
+          utc: Date.UTC(2020, 0, 2, 3, 4, 5),
+          invalid: String(new Date('invalid')),
+          constructor: explicit.constructor === Date,
+          monotonic: Date.now() + 1 === Date.now(),
+        };
+      `,
+    });
+    expect(result).toEqual({
+      status: 'completed',
+      value: {
+        constructor: true,
+        explicit: '2020-01-02T03:04:05.000Z',
+        invalid: 'Invalid Date',
+        monotonic: true,
+        parsed: 1_577_934_245_000,
+        utc: 1_577_934_245_000,
+      },
+    });
+  });
+
+  it('rejects duplicate, unknown, missing, and extra resolutions before effects', async () => {
+    const effect = vi.fn();
+    const source = `
+      return await Promise.all([tools.pause(1), tools.pause(2)]);
+    `;
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'pause' });
+          }
+          effect(context.resume?.interruptionId);
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected pause.');
+    }
+    const [first, second] = interrupted.interruptions;
+    if (first === undefined || second === undefined) {
+      throw new Error('Expected two interruptions.');
+    }
+
+    for (const resolutions of [
+      [],
+      [{ interruptionId: first.id, value: true }],
+      [
+        { interruptionId: first.id, value: true },
+        { interruptionId: first.id, value: false },
+      ],
+      [
+        { interruptionId: first.id, value: true },
+        { interruptionId: 'unknown', value: true },
+      ],
+      [
+        { interruptionId: first.id, value: true },
+        { interruptionId: second.id, value: true },
+        { interruptionId: 'extra', value: true },
+      ],
+    ]) {
+      await expect(
+        run({
+          bindings,
+          continuation: interrupted.continuation,
+          resolutions,
+          source,
+        }),
+      ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    }
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it.each(['first', 'middle', 'last'] as const)(
+    'detects replay divergence at the %s ledger entry',
+    async position => {
+      let saved: RunContinuationState | undefined;
+      let mutate = false;
+      const runner = createRunner({
+        continuationCodec: {
+          decode() {
+            if (!saved) {
+              throw new Error('missing state');
+            }
+            const state = structuredClone(saved);
+            if (mutate) {
+              let index = state.ledger.length - 1;
+              if (position === 'first') {
+                index = 0;
+              } else if (position === 'middle') {
+                index = 1;
+              }
+              const entry = state.ledger[index];
+              if (entry === undefined) {
+                throw new Error('Expected a ledger entry.');
+              }
+              entry.inputJson = '"diverged"';
+            }
+            return state;
+          },
+          encode(state) {
+            saved = structuredClone(state);
+            return 'token';
+          },
+        },
+      });
+      const source = `
+        await tools.effect('first');
+        await tools.effect('middle');
+        return await tools.pause('last');
+      `;
+      const bindings = {
+        tools: {
+          effect: (input: unknown) => input,
+          pause: () => {
+            const context = getBindingContext();
+            if (!context.resume) {
+              context.interrupt({ kind: 'pause' });
+            }
+            return context.resume?.resolution;
+          },
+        },
+      };
+      const interrupted = await runner.run({ bindings, source });
+      if (interrupted.status !== 'interrupted') {
+        throw new Error('Expected pause.');
+      }
+      mutate = true;
+      await expect(
+        runner.run({
+          bindings,
+          continuation: interrupted.continuation,
+          resolutions: [
+            { interruptionId: firstInterruptionId(interrupted), value: true },
+          ],
+          source,
+        }),
+      ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    },
+  );
+
+  it('preserves caught rejection and Promise.race ordering across replay', async () => {
+    const effects = vi.fn(async ({ id }: { id: string }) => {
+      await Promise.resolve();
+      if (id === 'failure') {
+        throw new Error('expected failure');
+      }
+      return id;
+    });
+    const source = `
+      const failure = tools.effect({ id: 'failure' }).catch(error => error.message);
+      const success = tools.effect({ id: 'success' });
+      const race = await Promise.race([failure, success]);
+      const all = await Promise.all([failure, success]);
+      const resolution = await tools.pause();
+      return { race, all, resolution };
+    `;
+    const bindings = {
+      tools: {
+        effect: effects,
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'pause' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected pause.');
+    }
+    await expect(
+      run({
+        bindings,
+        continuation: interrupted.continuation,
+        resolutions: [
+          { interruptionId: firstInterruptionId(interrupted), value: true },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: {
+        all: ['Host binding failed.', 'success'],
+        race: 'Host binding failed.',
+        resolution: true,
+      },
+    });
+    expect(effects).toHaveBeenCalledTimes(2);
+  });
+
+  it('replays a maximum-length completed ledger without duplicate effects', async () => {
+    const effect = vi.fn((input: number) => input * 2);
+    const count = 64;
+    const source = `
+      const values = [];
+      for (let index = 0; index < ${count}; index++) {
+        values.push(await tools.effect(index));
+      }
+      const resolution = await tools.pause();
+      return { values, resolution };
+    `;
+    const bindings = {
+      tools: {
+        effect,
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'pause' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await run({
+      bindings,
+      limits: { maxBridgeRequests: count + 1 },
+      source,
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected pause.');
+    }
+    await expect(
+      run({
+        bindings,
+        continuation: interrupted.continuation,
+        limits: { maxBridgeRequests: count + 1 },
+        resolutions: [
+          {
+            interruptionId: firstInterruptionId(interrupted),
+            value: 'done',
+          },
+        ],
+        source,
+      }),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      value: { resolution: 'done' },
+    });
+    expect(effect).toHaveBeenCalledTimes(count);
+  });
+
+  it('keeps a stable idempotency key when a signed continuation is retried', async () => {
+    const interruptionIds: string[] = [];
+    const source = 'return await tools.write();';
+    const bindings = {
+      tools: {
+        write: () => {
+          const context = getBindingContext();
+          const { resume } = context;
+          if (resume === undefined) {
+            return context.interrupt({ kind: 'approval' });
+          }
+          interruptionIds.push(resume.interruptionId);
+          return true;
+        },
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected pause.');
+    }
+    const input = {
+      bindings,
+      continuation: interrupted.continuation,
+      resolutions: [
+        { interruptionId: firstInterruptionId(interrupted), value: true },
+      ],
+      source,
+    };
+    await run(input);
+    await run(input);
+    expect(interruptionIds).toEqual(['interrupt-1', 'interrupt-1']);
+  });
+
+  it('times out or reports custom codec encode failure and releases the slot', async () => {
+    const hanging = createRunner({
+      continuationCodec: {
+        decode: () => {
+          throw new Error('not used');
+        },
+        encode: () => createPromiseWithResolvers<never>().promise,
+      },
+      limits: { timeoutMs: 50 },
+    });
+    await expect(
+      hanging.run({
+        bindings: {
+          tools: {
+            pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+          },
+        },
+        source: 'return await tools.pause();',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_TIMEOUT' });
+    await expect(run({ source: 'return 1;' })).resolves.toEqual({
+      status: 'completed',
+      value: 1,
+    });
+
+    const failing = createRunner({
+      continuationCodec: {
+        decode: () => {
+          throw new Error('not used');
+        },
+        encode: () => {
+          throw new Error('encode failed');
+        },
+      },
+    });
+    await expect(
+      failing.run({
+        bindings: {
+          tools: {
+            pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+          },
+        },
+        source: 'return await tools.pause();',
+      }),
+    ).rejects.toThrow('encode failed');
+  });
+
+  it('checks 100,000 generated traces against a replay effect model', () => {
+    const next = createPrng(0x9E_37_79_B9);
+    for (let trace = 0; trace < 100_000; trace += 1) {
+      const actions = Array.from({ length: 1 + (next() % 16) }, () => {
+        if (next() % 5 === 0) {
+          return 'interrupted';
+        }
+        return next() % 4 === 0 ? 'rejected' : 'fulfilled';
+      });
+      const effects = Array.from({ length: actions.length }, () => 0);
+      const ledger = new Set<number>();
+      let pending: number | undefined;
+
+      do {
+        pending = undefined;
+        for (const [index, action] of actions.entries()) {
+          if (ledger.has(index)) {
+            continue;
+          }
+          const effectCount = effects[index];
+          if (effectCount === undefined) {
+            throw new Error('Expected an effect counter.');
+          }
+          effects[index] = effectCount + 1;
+          if (action === 'interrupted' && effects[index] === 1) {
+            pending = index;
+            break;
+          }
+          ledger.add(index);
+        }
+      } while (pending !== undefined);
+
+      expect(ledger.size, `trace ${trace}`).toBe(actions.length);
+      expect(effects, `trace ${trace}`).toEqual(
+        actions.map(action => (action === 'interrupted' ? 2 : 1)),
+      );
+    }
+  });
+
+  it('matches production replay to generated sequential effect traces', async () => {
+    const next = createPrng(0xC0_DE_CA_FE);
+    for (let trace = 0; trace < 16; trace += 1) {
+      let interruptionCount = 0;
+      const actions = Array.from(
+        { length: 1 + (next() % 6) },
+        (_value, index) => {
+          let status: 'fulfilled' | 'rejected' | 'interrupted';
+          if (interruptionCount < 2 && next() % 3 === 0) {
+            status = 'interrupted';
+            interruptionCount += 1;
+          } else {
+            status = next() % 4 === 0 ? 'rejected' : 'fulfilled';
+          }
+          return { index, status };
+        },
+      );
+      const calls = Array.from({ length: actions.length }, () => 0);
+      const source = `
+        const output = [];
+        for (const action of ${JSON.stringify(actions)}) {
+          try { output.push(await tools.effect(action)); }
+          catch { output.push('rejected'); }
+        }
+        return output;
+      `;
+      const bindings = {
+        tools: {
+          effect: (action: (typeof actions)[number]) => {
+            const context = getBindingContext();
+            const callCount = calls[action.index];
+            if (callCount === undefined) {
+              throw new Error('Expected a call counter.');
+            }
+            calls[action.index] = callCount + 1;
+            if (action.status === 'rejected') {
+              throw new Error('expected');
+            }
+            if (action.status === 'interrupted' && !context.resume) {
+              context.interrupt({ index: action.index });
+            }
+            return action.index;
+          },
+        },
+      };
+
+      let result = await run({ bindings, source });
+      while (result.status === 'interrupted') {
+        result = await run({
+          bindings,
+          continuation: result.continuation,
+          resolutions: result.interruptions.map(interruption => ({
+            interruptionId: interruption.id,
+            value: true,
+          })),
+          source,
+        });
+      }
+      expect(result.value, `trace ${trace}`).toEqual(
+        actions.map(action =>
+          action.status === 'rejected' ? 'rejected' : action.index,
+        ),
+      );
+      expect(calls, `trace ${trace}`).toEqual(
+        actions.map(action => (action.status === 'interrupted' ? 2 : 1)),
+      );
+    }
+  });
+});

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,0 +1,919 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createRunner,
+  createSignedContinuationCodec,
+  getBindingContext,
+  run,
+  setMaxWorkers,
+} from './index.js';
+import type { RunInterruptedResult, RunInterruption } from './index.js';
+import { createPromiseWithResolvers } from './utils/promise-with-resolvers.js';
+
+const firstInterruption = (result: RunInterruptedResult): RunInterruption => {
+  const interruption = result.interruptions.at(0);
+  if (interruption === undefined) {
+    throw new Error('Expected an interruption.');
+  }
+  return interruption;
+};
+
+const sleep = async (delay: number): Promise<void> => {
+  const deferred = createPromiseWithResolvers<null>();
+  setTimeout(() => deferred.resolve(null), delay);
+  await deferred.promise;
+};
+
+describe('run', () => {
+  it('keeps concurrent worker realms and binding closures isolated', async () => {
+    setMaxWorkers(4);
+    const releases: (() => void)[] = [];
+    const started = createPromiseWithResolvers<null>();
+    try {
+      const executions = Array.from({ length: 4 }, (_, index) =>
+        run<number>({
+          bindings: {
+            tools: {
+              wait: async () => {
+                const release = createPromiseWithResolvers<null>();
+                releases.push(() => release.resolve(null));
+                if (releases.length === 4) {
+                  started.resolve(null);
+                }
+                await release.promise;
+              },
+            },
+          },
+          source: `
+            globalThis.marker = ${index};
+            await tools.wait();
+            return globalThis.marker;
+          `,
+        }),
+      );
+      await started.promise;
+      for (const release of releases) {
+        release();
+      }
+      await expect(Promise.all(executions)).resolves.toEqual(
+        Array.from({ length: 4 }, (_, value) => ({
+          status: 'completed',
+          value,
+        })),
+      );
+    } finally {
+      setMaxWorkers(undefined);
+    }
+  });
+
+  it('executes JavaScript and returns a completed result', async () => {
+    await expect(run({ source: 'return 2 + 3;' })).resolves.toEqual({
+      status: 'completed',
+      value: 5,
+    });
+  });
+
+  it('exposes named binding groups as guest globals', async () => {
+    const add = vi.fn(({ a, b }: { a: number; b: number }) => a + b);
+
+    await expect(
+      run({
+        bindings: { tools: { add } },
+        source: 'return await tools.add({ a: 2, b: 3 });',
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 5 });
+    expect(add).toHaveBeenCalledWith({ a: 2, b: 3 });
+  });
+
+  it('maps every guest argument to the host binding signature', async () => {
+    const sum = vi.fn((...values: number[]) =>
+      values.reduce((total, value) => total + value, 0),
+    );
+
+    await expect(
+      run({
+        bindings: { tools: { sum } },
+        source: 'return await tools.sum(1, 2, 3, 4);',
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 10 });
+    expect(sum).toHaveBeenCalledWith(1, 2, 3, 4);
+  });
+
+  it('scopes binding context through async work and invalidates it after settlement', async () => {
+    const requestIds = new Map<string, string>();
+    const result = await run<string[]>({
+      bindings: {
+        tools: {
+          inspect: async (label: string) => {
+            const before = getBindingContext();
+            await Promise.resolve();
+            const after = getBindingContext();
+            expect(after).toBe(before);
+            requestIds.set(label, before.requestId);
+            return `${label}:${before.requestId}`;
+          },
+        },
+      },
+      source: `
+        return await Promise.all([
+          tools.inspect('first'),
+          tools.inspect('second'),
+        ]);
+      `,
+    });
+    expect(result.status).toBe('completed');
+    if (result.status === 'completed') {
+      expect(new Set(result.value).size).toBe(2);
+    }
+    expect(requestIds.get('first')).not.toBe(requestIds.get('second'));
+    expect(() => getBindingContext()).toThrow(
+      'getBindingContext() can only be called while executing a run binding.',
+    );
+  });
+
+  it('invalidates context in detached async work after binding settlement', async () => {
+    const detachedGate = createPromiseWithResolvers<null>();
+    const detachedContext = createPromiseWithResolvers<unknown>();
+
+    await expect(
+      run({
+        bindings: {
+          tools: {
+            detach: () => {
+              const inspectDetachedContext = async () => {
+                await detachedGate.promise;
+                try {
+                  detachedContext.resolve(getBindingContext());
+                } catch (error) {
+                  detachedContext.resolve(error);
+                }
+              };
+              inspectDetachedContext().catch(detachedContext.resolve);
+              return 'done';
+            },
+          },
+        },
+        source: 'return await tools.detach();',
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 'done' });
+    detachedGate.resolve(null);
+    await expect(detachedContext.promise).resolves.toMatchObject({
+      message:
+        'getBindingContext() can only be called while executing a run binding.',
+    });
+  });
+
+  it('invalidates binding context when an invocation is aborted', async () => {
+    const abortController = new AbortController();
+    const bindingStarted = createPromiseWithResolvers<null>();
+    const detachedGate = createPromiseWithResolvers<null>();
+    const detachedContext = createPromiseWithResolvers<unknown>();
+    const execution = run({
+      abortSignal: abortController.signal,
+      bindings: {
+        tools: {
+          wait: () => {
+            const inspectDetachedContext = async () => {
+              await detachedGate.promise;
+              try {
+                detachedContext.resolve(getBindingContext());
+              } catch (error) {
+                detachedContext.resolve(error);
+              }
+            };
+            inspectDetachedContext().catch(detachedContext.resolve);
+            bindingStarted.resolve(null);
+            return createPromiseWithResolvers<never>().promise;
+          },
+        },
+      },
+      source: 'return await tools.wait();',
+    });
+    await bindingStarted.promise;
+    abortController.abort();
+    await expect(execution).rejects.toMatchObject({ code: 'RUN_ABORTED' });
+    detachedGate.resolve(null);
+    await expect(detachedContext.promise).resolves.toMatchObject({
+      message:
+        'getBindingContext() can only be called while executing a run binding.',
+    });
+  });
+
+  it('supports concurrent binding calls', async () => {
+    const result = await run<number[]>({
+      bindings: {
+        functions: { double: (value: number) => value * 2 },
+      },
+      source: `
+        return await Promise.all([
+          functions.double(2),
+          functions.double(3),
+        ]);
+      `,
+    });
+
+    if (result.status !== 'completed') {
+      throw new Error('Expected completed result.');
+    }
+    expect(result.value).toEqual([4, 6]);
+  });
+
+  it('strips TypeScript syntax from function-body source', async () => {
+    const result = await run<number>({
+      source: 'const value: number = 42; return value;',
+    });
+    if (result.status !== 'completed') {
+      throw new Error('Expected completed result.');
+    }
+    expect(result.value).toBe(42);
+  });
+
+  it('rejects unknown bindings', async () => {
+    await expect(
+      run({
+        bindings: { tools: {} },
+        source: 'return await tools.missing();',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+  });
+
+  it('does not invoke inherited binding group properties', async () => {
+    const inherited = vi.fn(() => 'should not run');
+    const group = Object.assign(Object.create({ inherited }), {
+      safe: () => 'safe',
+    });
+
+    await expect(
+      run({
+        bindings: { tools: group },
+        source: 'return await tools.inherited({ attacker: true });',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+    expect(inherited).not.toHaveBeenCalled();
+  });
+
+  it.each(['constructor', 'hasOwnProperty', 'valueOf'])(
+    'does not expose Object.prototype.%s as a binding',
+    async name => {
+      await expect(
+        run({
+          bindings: { tools: { safe: () => 'safe' } },
+          source: `return await tools.${name}({ attacker: true });`,
+        }),
+      ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+    },
+  );
+
+  it('rechecks that a binding is a function at invocation time', async () => {
+    const group = {
+      mutate: () => {
+        (group as Record<string, unknown>).target = 'not a function';
+      },
+      target: () => 'should not run',
+    };
+
+    await expect(
+      run({
+        bindings: { tools: group },
+        source: 'await tools.mutate(); return await tools.target();',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+  });
+
+  it('rejects reserved guest namespaces', async () => {
+    await expect(
+      run({
+        bindings: { console: { log: () => {} } },
+        source: 'return 1;',
+      }),
+    ).rejects.toThrow('Reserved binding namespace: console');
+  });
+
+  it('resumes an interrupted binding without repeating completed effects', async () => {
+    const effect = vi.fn(() => 'created');
+    const approve = vi.fn(() => {
+      const context = getBindingContext();
+      if (context.resume === undefined) {
+        context.interrupt({ kind: 'approval', message: 'Allow it?' });
+      }
+      return context.resume?.resolution;
+    });
+    const input = {
+      bindings: { tools: { approve, effect } },
+      source: `
+        const created = await tools.effect();
+        const approved = await tools.approve();
+        return { created, approved };
+      `,
+    };
+
+    const interrupted = await run(input);
+    expect(interrupted).toMatchObject({
+      interruptions: [
+        {
+          arguments: [],
+          bindingName: 'tools.approve',
+          id: 'interrupt-2',
+          payload: { kind: 'approval', message: 'Allow it?' },
+        },
+      ],
+      status: 'interrupted',
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+
+    await expect(
+      run({
+        ...input,
+        continuation: interrupted.continuation,
+        resolutions: [
+          { interruptionId: firstInterruption(interrupted).id, value: true },
+        ],
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: { approved: true, created: 'created' },
+    });
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(approve).toHaveBeenCalledTimes(2);
+  });
+
+  it('batches concurrent interruptions into one continuation', async () => {
+    const approval = vi.fn((input: { name: string }) => {
+      const context = getBindingContext();
+      if (context.resume === undefined) {
+        context.interrupt({ kind: 'approval', name: input.name });
+      }
+      return context.resume?.resolution;
+    });
+    const input = {
+      bindings: { tools: { approval } },
+      source: `
+        return await Promise.all([
+          tools.approval({ name: 'first' }),
+          tools.approval({ name: 'second' }),
+        ]);
+      `,
+    };
+
+    const interrupted = await run(input);
+    expect(interrupted.status).toBe('interrupted');
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    expect(interrupted.interruptions).toHaveLength(2);
+
+    await expect(
+      run({
+        ...input,
+        continuation: interrupted.continuation,
+        resolutions: [
+          {
+            interruptionId: firstInterruption(interrupted).id,
+            value: 'only one',
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+
+    await expect(
+      run({
+        ...input,
+        continuation: interrupted.continuation,
+        resolutions: interrupted.interruptions.map((item, index) => ({
+          interruptionId: item.id,
+          value: index === 0 ? 'yes' : 'also yes',
+        })),
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: ['yes', 'also yes'],
+    });
+  });
+
+  it('rejects tampered signed continuations', async () => {
+    const interrupted = await run({
+      bindings: {
+        tools: {
+          pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+        },
+      },
+      source: 'return await tools.pause();',
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    const token = interrupted.continuation as string;
+    await expect(
+      run({
+        bindings: { tools: { pause: () => {} } },
+        continuation: `${token[0] === 'A' ? 'B' : 'A'}${token.slice(1)}`,
+        source: 'return await tools.pause();',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+  });
+
+  it('replays Date and Math.random deterministically across bindings', async () => {
+    const effectInputs: unknown[] = [];
+    const source = `
+      const before = { now: Date.now(), random: Math.random() };
+      await tools.effect(before);
+      const between = { now: Date.now(), random: Math.random() };
+      const approved = await tools.approve(between);
+      return {
+        before,
+        between,
+        after: { now: Date.now(), random: Math.random() },
+        approved,
+      };
+    `;
+    const bindings = {
+      tools: {
+        approve: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+        effect: (input: unknown) => {
+          effectInputs.push(input);
+        },
+      },
+    };
+
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    const completed = await run({
+      bindings,
+      continuation: interrupted.continuation,
+      resolutions: [
+        { interruptionId: firstInterruption(interrupted).id, value: true },
+      ],
+      source,
+    });
+    expect(completed).toMatchObject({ status: 'completed' });
+    expect(effectInputs).toHaveLength(1);
+    if (completed.status === 'completed') {
+      expect(completed.value).toMatchObject({
+        approved: true,
+        before: effectInputs[0],
+      });
+    }
+  });
+
+  it('supports sequential interruption rounds', async () => {
+    const source = `
+      const first = await tools.pause({ step: 1 });
+      const second = await tools.pause({ step: 2 });
+      return [first, second];
+    `;
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const first = await run({ bindings, source });
+    if (first.status !== 'interrupted') {
+      throw new Error('Expected first round.');
+    }
+    const second = await run({
+      bindings,
+      continuation: first.continuation,
+      resolutions: [
+        { interruptionId: firstInterruption(first).id, value: 'a' },
+      ],
+      source,
+    });
+    if (second.status !== 'interrupted') {
+      throw new Error('Expected second round.');
+    }
+    await expect(
+      run({
+        bindings,
+        continuation: second.continuation,
+        resolutions: [
+          { interruptionId: firstInterruption(second).id, value: 'b' },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: ['a', 'b'] });
+  });
+
+  it('replays rejected bindings without reinvoking them', async () => {
+    const fail = vi.fn(() => {
+      throw new Error('secret failure');
+    });
+    const source = `
+      let failure;
+      try { await tools.fail(); } catch (error) { failure = error.message; }
+      const approved = await tools.approve();
+      return { failure, approved };
+    `;
+    const bindings = {
+      tools: {
+        approve: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+        fail,
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    await run({
+      bindings,
+      continuation: interrupted.continuation,
+      resolutions: [
+        { interruptionId: firstInterruption(interrupted).id, value: true },
+      ],
+      source,
+    });
+    expect(fail).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed decoded state and times out hanging codecs', async () => {
+    const malformedRunner = createRunner({
+      continuationCodec: {
+        decode: () => ({ version: 1 }) as never,
+        encode: () => 'unused',
+      },
+    });
+    await expect(
+      malformedRunner.run({ continuation: 'bad', source: 'return 1;' }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+
+    const hangingRunner = createRunner({
+      continuationCodec: {
+        decode: () => createPromiseWithResolvers<never>().promise,
+        encode: () => 'unused',
+      },
+      limits: { timeoutMs: 20 },
+    });
+    await expect(
+      hangingRunner.run({ continuation: 'pending', source: 'return 1;' }),
+    ).rejects.toMatchObject({ code: 'RUN_TIMEOUT' });
+  });
+
+  it('aborts a hanging continuation decode', async () => {
+    let codecSignal: AbortSignal | undefined;
+    const runner = createRunner({
+      continuationCodec: {
+        decode: (_token, context) => {
+          codecSignal = context?.abortSignal;
+          return createPromiseWithResolvers<never>().promise;
+        },
+        encode: () => 'unused',
+      },
+      limits: { timeoutMs: 1000 },
+    });
+    const abortController = new AbortController();
+    const result = runner.run({
+      abortSignal: abortController.signal,
+      continuation: 'pending',
+      source: 'return 1;',
+    });
+    abortController.abort();
+    await expect(result).rejects.toMatchObject({ code: 'RUN_ABORTED' });
+    expect(codecSignal?.aborted).toBe(true);
+  });
+
+  it('enforces aggregate continuation limits', async () => {
+    await expect(
+      run({
+        bindings: {
+          tools: {
+            pause: () =>
+              getBindingContext().interrupt({
+                detail: 'x'.repeat(200),
+                kind: 'approval',
+              }),
+          },
+        },
+        limits: { maxContinuationBytes: 128 },
+        source: 'return await tools.pause("large-input");',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+  });
+
+  it('batches a larger concurrent interruption set at the worker barrier', async () => {
+    const source = `
+      return await Promise.all(
+        Array.from({ length: 16 }, (_value, index) => tools.pause(index))
+      );
+    `;
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    expect(interrupted.interruptions).toHaveLength(16);
+    await expect(
+      run({
+        bindings,
+        continuation: interrupted.continuation,
+        resolutions: interrupted.interruptions.map((item, index) => ({
+          interruptionId: item.id,
+          value: index,
+        })),
+        source,
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: Array.from({ length: 16 }, (_value, index) => index),
+    });
+  });
+
+  it('preserves concurrent binding settlement order during replay', async () => {
+    const delayed = vi.fn(
+      async ({ id, delay }: { id: string; delay: number }) => {
+        await sleep(delay);
+        return id;
+      },
+    );
+    const source = `
+      const slow = tools.delayed({ id: 'slow', delay: 20 });
+      const fast = tools.delayed({ id: 'fast', delay: 0 });
+      const winner = await Promise.race([slow, fast]);
+      const all = await Promise.all([slow, fast]);
+      const approved = await tools.pause();
+      return { winner, all, approved };
+    `;
+    const bindings = {
+      tools: {
+        delayed,
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    await expect(
+      run({
+        bindings,
+        continuation: interrupted.continuation,
+        resolutions: [
+          { interruptionId: firstInterruption(interrupted).id, value: true },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: { all: ['slow', 'fast'], approved: true, winner: 'fast' },
+    });
+    expect(delayed).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an observed interruption after the worker is already ready', async () => {
+    const signed = createSignedContinuationCodec({ secret: 's'.repeat(32) });
+    const runner = createRunner({
+      continuationCodec: {
+        decode: signed.decode,
+        async encode(state, context) {
+          await sleep(20);
+          return signed.encode(state, context);
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        bindings: {
+          tools: {
+            pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+          },
+        },
+        source: `
+          return await Promise.race([
+            tools.pause(),
+            Promise.resolve('fast'),
+          ]);
+        `,
+      }),
+    ).resolves.toMatchObject({ status: 'interrupted' });
+  });
+
+  it('binds continuations to audience, caller context, and binding manifest', async () => {
+    const codec = createSignedContinuationCodec({ secret: 'x'.repeat(32) });
+    const source = 'return await tools.pause();';
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          const { resume } = context;
+          if (resume === undefined) {
+            return context.interrupt({ kind: 'pause' });
+          }
+          return resume.resolution;
+        },
+      },
+    };
+    const runner = createRunner({
+      continuationAudience: 'endpoint-a',
+      continuationCodec: codec,
+    });
+    const first = await runner.run({
+      bindings,
+      continuationContext: { tenantId: 'tenant-a' },
+      source,
+    });
+    if (first.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    const resume = {
+      bindings,
+      continuation: first.continuation,
+      resolutions: [
+        { interruptionId: firstInterruption(first).id, value: true },
+      ],
+      source,
+    };
+
+    await expect(
+      createRunner({
+        continuationAudience: 'endpoint-b',
+        continuationCodec: codec,
+      }).run({
+        ...resume,
+        continuationContext: { tenantId: 'tenant-a' },
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    await expect(
+      runner.run({
+        ...resume,
+        continuationContext: { tenantId: 'tenant-b' },
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    await expect(
+      runner.run({
+        ...resume,
+        bindings: { tools: { ...bindings.tools, extra: () => true } },
+        continuationContext: { tenantId: 'tenant-a' },
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+  });
+
+  it('rejects non-exact resolution envelopes', async () => {
+    const source = 'return await tools.pause();';
+    const bindings = {
+      tools: {
+        pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+      },
+    };
+    const first = await run({ bindings, source });
+    if (first.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    await expect(
+      run({
+        bindings,
+        continuation: first.continuation,
+        resolutions: [
+          {
+            extra: true,
+            interruptionId: firstInterruption(first).id,
+            value: true,
+          } as never,
+        ],
+        source,
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+  });
+
+  it('requires signing configuration only when a continuation is used', async () => {
+    const previous = process.env.RUN_CONTINUATION_SECRET;
+    delete process.env.RUN_CONTINUATION_SECRET;
+    const runner = createRunner();
+    if (previous !== undefined) {
+      process.env.RUN_CONTINUATION_SECRET = previous;
+    }
+
+    await expect(runner.run({ source: 'return 1;' })).resolves.toEqual({
+      status: 'completed',
+      value: 1,
+    });
+    await expect(
+      runner.run({
+        bindings: {
+          tools: {
+            pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+          },
+        },
+        source: 'return await tools.pause();',
+      }),
+    ).rejects.toThrow('Continuation signing is not configured');
+  });
+
+  it('resumes across runners that share a continuation secret', async () => {
+    const firstRunner = createRunner({ continuationSecret: 'a'.repeat(32) });
+    const secondRunner = createRunner({ continuationSecret: 'a'.repeat(32) });
+    const input = {
+      bindings: {
+        tools: {
+          pause: () => {
+            const context = getBindingContext();
+            const { resume } = context;
+            if (resume === undefined) {
+              return context.interrupt({ kind: 'pause' });
+            }
+            return resume.resolution;
+          },
+        },
+      },
+      source: 'return await tools.pause();',
+    };
+    const interrupted = await firstRunner.run(input);
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    await expect(
+      secondRunner.run({
+        ...input,
+        continuation: interrupted.continuation,
+        resolutions: [
+          {
+            interruptionId: firstInterruption(interrupted).id,
+            value: 'approved',
+          },
+        ],
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 'approved' });
+  });
+
+  it('uses RUN_CONTINUATION_SECRET across independently created runners', async () => {
+    const firstRunner = createRunner();
+    const secondRunner = createRunner();
+    const source = 'return await tools.pause("environment");';
+    const bindings = {
+      tools: {
+        pause: (label: string) => {
+          const context = getBindingContext();
+          const { resume } = context;
+          if (resume === undefined) {
+            return context.interrupt({ label });
+          }
+          return resume.resolution;
+        },
+      },
+    };
+    const interrupted = await firstRunner.run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    expect(firstInterruption(interrupted).arguments).toEqual(['environment']);
+    await expect(
+      secondRunner.run({
+        bindings,
+        continuation: interrupted.continuation,
+        resolutions: [
+          {
+            interruptionId: firstInterruption(interrupted).id,
+            value: 'resumed',
+          },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 'resumed' });
+  });
+
+  it('rejects conflicting continuation signing options', () => {
+    expect(() =>
+      createRunner({
+        continuationCodec: createSignedContinuationCodec({
+          secret: 'b'.repeat(32),
+        }),
+        continuationSecret: 'a'.repeat(32),
+      }),
+    ).toThrow('cannot be used together');
+  });
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,199 @@
+import { Buffer } from 'node:buffer';
+import { runManaged } from './runtime/manager.js';
+import { createSignedContinuationCodec } from './continuation-codec.js';
+import type {
+  Bindings,
+  ContinuationCodec,
+  RunInput,
+  Runner,
+  RunnerOptions,
+  RunResult,
+} from './types.js';
+
+function missingContinuationCodec<TOKEN>(): ContinuationCodec<TOKEN> {
+  const message =
+    'Continuation signing is not configured. Set RUN_CONTINUATION_SECRET or pass continuationSecret or continuationCodec to createRunner().';
+  const error = (): never => {
+    throw new TypeError(message);
+  };
+  return { decode: error, encode: error };
+}
+
+const RESERVED_GLOBALS = new Set([
+  'AggregateError',
+  'Array',
+  'ArrayBuffer',
+  'Atomics',
+  'BigInt',
+  'BigInt64Array',
+  'BigUint64Array',
+  'Boolean',
+  'DataView',
+  'Date',
+  'Error',
+  'EvalError',
+  'FinalizationRegistry',
+  'Float16Array',
+  'Float32Array',
+  'Float64Array',
+  'Infinity',
+  'Int16Array',
+  'Int32Array',
+  'Int8Array',
+  'InternalError',
+  'Intl',
+  'Iterator',
+  'JSON',
+  'Map',
+  'Math',
+  'NaN',
+  'Number',
+  'Object',
+  'Promise',
+  'Proxy',
+  'RangeError',
+  'ReferenceError',
+  'Reflect',
+  'RegExp',
+  'Set',
+  'SharedArrayBuffer',
+  'String',
+  'Symbol',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'Uint16Array',
+  'Uint32Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'WeakMap',
+  'WeakRef',
+  'WeakSet',
+  'WebAssembly',
+  'console',
+  'decodeURI',
+  'decodeURIComponent',
+  'encodeURI',
+  'encodeURIComponent',
+  'escape',
+  'eval',
+  'Function',
+  'globalThis',
+  'isFinite',
+  'isNaN',
+  'parseFloat',
+  'parseInt',
+  'performance',
+  'crypto',
+  'undefined',
+  'unescape',
+]);
+
+const RESERVED_BINDING_NAMES = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  'then',
+]);
+
+const validateBindings = (bindings: Bindings): void => {
+  for (const [namespace, group] of Object.entries(bindings)) {
+    if (!Object.hasOwn(bindings, namespace)) {
+      continue;
+    }
+    if (
+      Buffer.byteLength(namespace) > 512 ||
+      !/^[A-Za-z_$][\w$]*$/u.test(namespace)
+    ) {
+      throw new TypeError(`Invalid binding namespace: ${namespace}`);
+    }
+    if (RESERVED_GLOBALS.has(namespace) || namespace.startsWith('__run')) {
+      throw new TypeError(`Reserved binding namespace: ${namespace}`);
+    }
+    if (typeof group !== 'object' || group === null || Array.isArray(group)) {
+      throw new TypeError(
+        `Binding namespace "${namespace}" must be an object.`,
+      );
+    }
+    for (const [name, binding] of Object.entries(group)) {
+      if (!Object.hasOwn(group, name)) {
+        continue;
+      }
+      if (
+        name.length === 0 ||
+        Buffer.byteLength(`${namespace}.${name}`) > 1024 ||
+        name.includes('.') ||
+        RESERVED_BINDING_NAMES.has(name) ||
+        name.startsWith('__run')
+      ) {
+        throw new TypeError(`Invalid binding name: ${namespace}.${name}`);
+      }
+      if (typeof binding !== 'function') {
+        throw new TypeError(
+          `Binding "${namespace}.${name}" must be a function.`,
+        );
+      }
+    }
+  }
+};
+
+/** Creates a runner with shared defaults. */
+export const createRunner = <TOKEN = string>(
+  options: RunnerOptions<TOKEN> = {},
+): Runner<TOKEN> => {
+  if (
+    options.continuationCodec !== undefined &&
+    options.continuationSecret !== undefined
+  ) {
+    throw new TypeError(
+      'Runner continuationCodec and continuationSecret cannot be used together.',
+    );
+  }
+  const configuredSecret =
+    options.continuationSecret ?? process.env.RUN_CONTINUATION_SECRET;
+  const continuationCodec =
+    options.continuationCodec ??
+    (configuredSecret === undefined
+      ? missingContinuationCodec<TOKEN>()
+      : (createSignedContinuationCodec({
+          secret: configuredSecret,
+        }) as ContinuationCodec<TOKEN>));
+  const continuationAudience = options.continuationAudience ?? 'run';
+  if (
+    continuationAudience.length === 0 ||
+    Buffer.byteLength(continuationAudience) > 512
+  ) {
+    throw new TypeError(
+      'Runner continuationAudience must contain between 1 and 512 bytes.',
+    );
+  }
+  return {
+    async run<OUTPUT = unknown>(
+      input: RunInput<TOKEN>,
+    ): Promise<RunResult<OUTPUT, TOKEN>> {
+      const bindings = input.bindings ?? {};
+      validateBindings(bindings);
+      const value = await runManaged({
+        ...input,
+        bindings,
+        continuationAudience,
+        continuationCodec,
+        limits: {
+          ...options.limits,
+          ...input.limits,
+        },
+      });
+      return value as RunResult<OUTPUT, TOKEN>;
+    },
+  };
+};
+
+let defaultRunner: Runner<string> | undefined;
+
+/** Executes JavaScript in a fresh, hardened QuickJS context. */
+export const run = async <OUTPUT = unknown>(
+  input: RunInput<string>,
+): Promise<RunResult<OUTPUT, string>> => {
+  defaultRunner ??= createRunner({ continuationAudience: 'run' });
+  return await defaultRunner.run<OUTPUT>(input);
+};

--- a/src/security-hardening.test.ts
+++ b/src/security-hardening.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { getBindingContext, run } from './index.js';
+import type { Bindings } from './index.js';
+
+async function value(source: string, bindings?: Bindings): Promise<unknown> {
+  const result = await run({
+    source,
+    ...(bindings === undefined ? {} : { bindings }),
+  });
+  if (result.status !== 'completed') {
+    throw new Error('Unexpected interruption.');
+  }
+  return result.value;
+}
+
+function expectValue(source: string, bindings?: Bindings) {
+  return expect(value(source, bindings));
+}
+
+describe('guest sandbox hardening', () => {
+  it('exposes only the reviewed global surface', async () => {
+    await expectValue(
+      'return Object.getOwnPropertyNames(globalThis).sort();',
+    ).resolves.toEqual([
+      'AggregateError',
+      'Array',
+      'ArrayBuffer',
+      'BigInt',
+      'BigInt64Array',
+      'BigUint64Array',
+      'Boolean',
+      'DataView',
+      'Date',
+      'Error',
+      'EvalError',
+      'FinalizationRegistry',
+      'Float16Array',
+      'Float32Array',
+      'Float64Array',
+      'Function',
+      'Infinity',
+      'Int16Array',
+      'Int32Array',
+      'Int8Array',
+      'InternalError',
+      'Iterator',
+      'JSON',
+      'Map',
+      'Math',
+      'NaN',
+      'Number',
+      'Object',
+      'Promise',
+      'Proxy',
+      'RangeError',
+      'ReferenceError',
+      'Reflect',
+      'RegExp',
+      'Set',
+      'String',
+      'Symbol',
+      'SyntaxError',
+      'TypeError',
+      'URIError',
+      'Uint16Array',
+      'Uint32Array',
+      'Uint8Array',
+      'Uint8ClampedArray',
+      'WeakMap',
+      'WeakRef',
+      'WeakSet',
+      '__runAssertNoDetachedBridgeCalls',
+      '__runCreateBridgePromise',
+      '__runSerializeJsonPayload',
+      'console',
+      'decodeURI',
+      'decodeURIComponent',
+      'encodeURI',
+      'encodeURIComponent',
+      'escape',
+      'eval',
+      'globalThis',
+      'isFinite',
+      'isNaN',
+      'parseFloat',
+      'parseInt',
+      'undefined',
+      'unescape',
+    ]);
+  });
+
+  it('does not expose ambient host authority or nondeterministic APIs', async () => {
+    await expectValue(`
+      return Object.fromEntries([
+        'process', 'require', 'module', 'Buffer', 'fetch', 'XMLHttpRequest',
+        'WebSocket', 'crypto', 'performance', 'setTimeout', 'setInterval',
+        'queueMicrotask', 'WebAssembly', 'SharedArrayBuffer', 'Deno', 'Bun'
+      ].map(name => [name, typeof globalThis[name]]));
+    `).resolves.toEqual({
+      Buffer: 'undefined',
+      Bun: 'undefined',
+      Deno: 'undefined',
+      SharedArrayBuffer: 'undefined',
+      WebAssembly: 'undefined',
+      WebSocket: 'undefined',
+      XMLHttpRequest: 'undefined',
+      crypto: 'undefined',
+      fetch: 'undefined',
+      module: 'undefined',
+      performance: 'undefined',
+      process: 'undefined',
+      queueMicrotask: 'undefined',
+      require: 'undefined',
+      setInterval: 'undefined',
+      setTimeout: 'undefined',
+    });
+  });
+
+  it('blocks the dynamic-code constructor corpus', async () => {
+    const results = (await value(`
+      const results = [];
+      for (const attempt of [
+        () => eval('1'),
+        () => (0, eval)('1'),
+        () => globalThis.eval('1'),
+        () => Function('return 1')(),
+        () => new Function('return 1')(),
+        () => Reflect.construct(Function, ['return 1'])(),
+        () => (async function(){}).constructor('return 1')(),
+        () => Object.getPrototypeOf(async function(){}).constructor('return 1')(),
+        () => (function*(){}).constructor('yield 1')().next(),
+        () => Object.getPrototypeOf(function*(){}).constructor('yield 1')().next(),
+        () => (async function*(){}).constructor('yield 1')().next(),
+        () => Object.getPrototypeOf(async function*(){}).constructor('yield 1')().next(),
+        () => (() => {}).constructor('return 1')(),
+        () => (function(){}).bind(null).constructor('return 1')(),
+        () => (class {}).constructor('return 1')(),
+        () => Object.constructor('return 1')(),
+        () => Object.getPrototypeOf(Function).constructor('return 1')(),
+        () => console.log.constructor('return 1')(),
+        () => Object.getPrototypeOf(console.log).constructor('return 1')(),
+        () => globalThis.constructor.constructor('return 1')()
+      ]) {
+        try { attempt(); results.push('allowed'); }
+        catch (error) { results.push(String(error.message)); }
+      }
+      return results;
+    `)) as string[];
+    expect(results).toHaveLength(20);
+    expect(results).not.toContain('allowed');
+  });
+
+  it('rejects dynamic module loading', async () => {
+    await expect(
+      run({ source: "return await import('node:fs');" }),
+    ).rejects.toThrow();
+  });
+
+  it('freezes builtins, binding proxies, and internal helpers', async () => {
+    await expectValue(
+      `
+      const attempts = [
+        () => { Object.prototype.polluted = true; },
+        () => { Array.prototype.polluted = true; },
+        () => { Promise.prototype.polluted = true; },
+        () => { JSON.parse = () => ({ polluted: true }); },
+        () => { Math.random = () => 1; },
+        () => { Date.now = () => 1; },
+        () => { globalThis.Map = function FakeMap() {}; },
+        () => { globalThis.Set = function FakeSet() {}; },
+        () => { globalThis.__runSerializeJsonPayload = () => '"polluted"'; },
+        () => { tools = {}; },
+      ];
+      for (const attempt of attempts) { try { attempt(); } catch {} }
+      return {
+        object: Boolean(({}).polluted),
+        array: Boolean([].polluted),
+        promise: Boolean(Promise.prototype.polluted),
+        json: JSON.parse('{"ok":true}'),
+        randomWasReplaced: Math.random() === 1,
+        dateWasReplaced: Date.now() === 1,
+        mapName: Map.name,
+        setName: Set.name,
+        toolsType: typeof tools,
+      };
+      `,
+      { tools: { ok: () => true } },
+    ).resolves.toMatchObject({
+      array: false,
+      dateWasReplaced: false,
+      json: { ok: true },
+      mapName: 'Map',
+      object: false,
+      promise: false,
+      randomWasReplaced: false,
+      setName: 'Set',
+      toolsType: 'function',
+    });
+  });
+
+  it('starts with a clean realm after mutation, failure, and interruption', async () => {
+    await expectValue(`
+      try { Object.prototype.leaked = 'yes'; } catch {}
+      try { globalThis.leaked = 'yes'; } catch {}
+      return true;
+    `).resolves.toBe(true);
+
+    await expect(
+      run({ source: "throw new Error('terminal');" }),
+    ).rejects.toThrow('terminal');
+
+    const interrupted = await run({
+      bindings: {
+        tools: {
+          pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+        },
+      },
+      source: 'return await tools.pause();',
+    });
+    expect(interrupted.status).toBe('interrupted');
+
+    await expectValue(`
+      return {
+        object: ({}).leaked,
+        global: globalThis.leaked,
+      };
+    `).resolves.toEqual({});
+  });
+
+  it.each([
+    'Object',
+    'Promise',
+    'JSON',
+    'Math',
+    'Date',
+    'Iterator',
+    'InternalError',
+    'console',
+    'globalThis',
+  ])('rejects a binding namespace that collides with %s', async namespace => {
+    await expect(
+      run({
+        bindings: { [namespace]: { call: () => true } },
+        source: 'return 1;',
+      }),
+    ).rejects.toThrow('Reserved binding namespace');
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype', 'then', '__runBridge'])(
+    'rejects the dangerous declared binding name %s',
+    async name => {
+      const group = Object.create(null) as Record<string, () => boolean>;
+      Object.defineProperty(group, name, {
+        enumerable: true,
+        value: () => true,
+      });
+      await expect(
+        run({ bindings: { tools: group }, source: 'return 1;' }),
+      ).rejects.toThrow('Invalid binding name');
+    },
+  );
+});

--- a/src/serde-roundtrip.test.ts
+++ b/src/serde-roundtrip.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getBindingContext, run } from './index.js';
+
+interface RichResult {
+  alias: unknown;
+  bigint: bigint;
+  bytes: Uint8Array;
+  cycle: { self: unknown };
+  date: Date;
+  error: TypeError & { cause?: unknown };
+  map: Map<string, unknown>;
+  regexp: RegExp;
+  set: Set<unknown>;
+  shared: unknown;
+  sparse: unknown[];
+  specialNumbers: number[];
+  undefinedValue?: unknown;
+  view: DataView;
+}
+
+interface ExchangeInput {
+  error: RangeError & { cause?: unknown };
+  exact: bigint;
+  self: unknown;
+  set: Set<unknown>;
+}
+
+interface ExchangeResult {
+  identity: boolean;
+  output: {
+    alias: unknown;
+    bytes: Uint16Array;
+    cycle: { self: unknown };
+    map: Map<string, unknown>;
+    shared: unknown;
+  };
+}
+
+interface ResolutionValue {
+  approved: Set<string>;
+  self: unknown;
+}
+
+describe('run-js-v1 serialization', () => {
+  it('preserves rich final results and graph identity', async () => {
+    const result = await run({
+      source: `
+        const shared = { value: 1 };
+        const cycle = { label: 'cycle' };
+        cycle.self = cycle;
+        return {
+          undefinedValue: undefined,
+          specialNumbers: [NaN, Infinity, -Infinity, -0],
+          bigint: 9007199254740993n,
+          date: new Date(0),
+          regexp: /run+/gi,
+          map: new Map([['shared', shared]]),
+          set: new Set([shared]),
+          bytes: new Uint8Array([0, 127, 255]),
+          view: new DataView(new Uint8Array([1, 2, 3]).buffer),
+          sparse: [, 'value'],
+          shared,
+          alias: shared,
+          cycle,
+          error: new TypeError('invalid', { cause: shared }),
+        };
+      `,
+    });
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') {
+      return;
+    }
+    const value = result.value as RichResult;
+    expect(Object.hasOwn(value, 'undefinedValue')).toBe(true);
+    expect(value.undefinedValue).toBeUndefined();
+    expect(Number.isNaN(value.specialNumbers[0])).toBe(true);
+    expect(value.specialNumbers.slice(1, 3)).toEqual([Infinity, -Infinity]);
+    expect(Object.is(value.specialNumbers[3], -0)).toBe(true);
+    expect(value.bigint).toBe(9_007_199_254_740_993n);
+    expect(value.date).toEqual(new Date(0));
+    expect(value.regexp).toEqual(/run+/gi);
+    expect(value.bytes).toEqual(new Uint8Array([0, 127, 255]));
+    expect(value.view).toBeInstanceOf(DataView);
+    expect(value.view.getUint8(1)).toBe(2);
+    expect(0 in value.sparse).toBe(false);
+    expect(value.shared).toBe(value.alias);
+    expect(value.map.get('shared')).toBe(value.shared);
+    expect([...value.set]).toEqual([value.shared]);
+    expect(value.cycle.self).toBe(value.cycle);
+    expect(value.error).toBeInstanceOf(TypeError);
+    expect(value.error).toMatchObject({
+      message: 'invalid',
+      name: 'TypeError',
+    });
+    expect(value.error.cause).toBe(value.shared);
+    expect(value.error.stack).not.toContain('run.js');
+  });
+
+  it('uses the same rich codec in both binding directions', async () => {
+    const execute = vi.fn((input: ExchangeInput) => {
+      expect(input.self).toBe(input);
+      expect(input.set).toBeInstanceOf(Set);
+      expect(input.exact).toBe(42n);
+      expect(input.error).toBeInstanceOf(RangeError);
+      expect(input.error.cause).toBe(input);
+
+      const shared = { origin: 'host' };
+      const cycle: Record<string, unknown> = { shared };
+      cycle.self = cycle;
+      return {
+        alias: shared,
+        bytes: new Uint16Array([1, 65_535]),
+        cycle,
+        map: new Map([['shared', shared]]),
+        shared,
+      };
+    });
+
+    const result = await run({
+      bindings: { tools: { exchange: execute } },
+      source: `
+        const input = { set: new Set([1, 2]), exact: 42n };
+        input.self = input;
+        input.error = new RangeError('range', { cause: input });
+        const output = await tools.exchange(input);
+        return {
+          identity: output.shared === output.alias &&
+            output.map.get('shared') === output.shared &&
+            output.cycle.self === output.cycle,
+          output,
+        };
+      `,
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') {
+      return;
+    }
+    const value = result.value as ExchangeResult;
+    expect(value.identity).toBe(true);
+    expect(value.output.shared).toBe(value.output.alias);
+    expect(value.output.cycle.self).toBe(value.output.cycle);
+    expect(value.output.map.get('shared')).toBe(value.output.shared);
+    expect(value.output.bytes).toEqual(new Uint16Array([1, 65_535]));
+  });
+
+  it('preserves rich interruption payloads and resolutions through replay', async () => {
+    const source = 'return await tools.pause();';
+    const observed: unknown[] = [];
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          const { resume } = context;
+          if (resume === undefined) {
+            const shared = { kind: 'approval' };
+            const payload: Record<string, unknown> = {
+              alias: shared,
+              exact: 7n,
+              shared,
+            };
+            payload.self = payload;
+            return context.interrupt(payload);
+          }
+          observed.push(resume.resolution);
+          return resume.resolution;
+        },
+      },
+    };
+
+    const interrupted = await run({ bindings, source });
+    expect(interrupted.status).toBe('interrupted');
+    if (interrupted.status !== 'interrupted') {
+      return;
+    }
+    const interruption = interrupted.interruptions.at(0);
+    if (interruption === undefined) {
+      throw new Error('Expected an interruption.');
+    }
+    const payload = interruption.payload as Record<string, unknown>;
+    expect(payload.shared).toBe(payload.alias);
+    expect(payload.self).toBe(payload);
+    expect(payload.exact).toBe(7n);
+
+    const resolution: Record<string, unknown> = {
+      approved: new Set(['one', 'two']),
+    };
+    resolution.self = resolution;
+    const completed = await run({
+      bindings,
+      continuation: interrupted.continuation,
+      resolutions: [
+        {
+          interruptionId: interruption.id,
+          value: resolution,
+        },
+      ],
+      source,
+    });
+    expect(completed.status).toBe('completed');
+    if (completed.status !== 'completed') {
+      return;
+    }
+    const value = completed.value as ResolutionValue;
+    expect(value.self).toBe(value);
+    expect(value.approved).toEqual(new Set(['one', 'two']));
+    const observedResolution = observed.at(0) as ResolutionValue;
+    expect(observedResolution.self).toBe(observedResolution);
+    expect(observedResolution.approved).toEqual(new Set(['one', 'two']));
+  });
+
+  it('reports the path of unsupported values', async () => {
+    await expect(
+      run({ source: 'return { nested: { callback() {} } };' }),
+    ).rejects.toMatchObject({
+      code: 'RUN_SERIALIZATION_ERROR',
+      message: expect.stringMatching(/nested\.callback|function/u),
+    });
+  });
+});

--- a/src/serialization-hardening.test.ts
+++ b/src/serialization-hardening.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  RunBindingError,
+  createRunner,
+  getBindingContext,
+  run,
+} from './index.js';
+import type { BindingContext, RunContinuationState } from './index.js';
+import { invokeHostBinding } from './binding-invocation.js';
+import { serializeError } from './errors.js';
+import { serializeRunValue } from './utils/serde.js';
+
+function bindingContext(): BindingContext {
+  return {
+    abortSignal: new AbortController().signal,
+    bindingName: 'tools.echo',
+    interrupt: () => {
+      throw new Error('not used');
+    },
+    invocationId: 'invocation-1',
+    logicalRunId: 'logical-run-1',
+    requestId: 'request-1',
+    requestIndex: 1,
+  };
+}
+
+function state(): RunContinuationState {
+  return {
+    determinism: {
+      dateNowMs: 1_700_000_000_000,
+      randomSeed: '01'.repeat(16),
+    },
+    ledger: [
+      {
+        bindingName: 'tools.pause',
+        inputJson: '[[]]',
+        interruptionId: 'interrupt-1',
+        payloadJson: '[{"kind":1},"pause"]',
+        status: 'interrupted',
+      },
+    ],
+    logicalRunId: '03'.repeat(16),
+    runtime: 'run-replay-v2',
+    scopeHash: '02'.repeat(32),
+    serde: 'run-js-v1',
+    source: 'return await tools.pause();',
+    version: 2,
+  };
+}
+
+class NonSerializableValue {
+  readonly value = true;
+}
+
+const NON_SERIALIZABLE_OUTPUTS: [string, () => unknown][] = [
+  ['function output', (): unknown => () => {}],
+  ['symbol output', (): unknown => Symbol('value')],
+  ['class instance output', (): unknown => new NonSerializableValue()],
+];
+
+describe('serialization boundaries', () => {
+  it.each(['ascii', 'é', '🧪', '\uD800'])(
+    'measures binding arguments as UTF-8 bytes: %s',
+    async text => {
+      const inputJson = serializeRunValue([text]);
+      const exactBytes = Buffer.byteLength(inputJson);
+      const binding = vi.fn((input: unknown) => input);
+
+      await expect(
+        invokeHostBinding({
+          bindingName: 'tools.echo',
+          bindings: { tools: { echo: binding } },
+          context: bindingContext(),
+          inputJson,
+          maxBindingInputBytes: exactBytes,
+          maxBindingOutputBytes: 1024,
+        }),
+      ).resolves.toMatchObject({ status: 'fulfilled' });
+
+      await expect(
+        invokeHostBinding({
+          bindingName: 'tools.echo',
+          bindings: { tools: { echo: binding } },
+          context: bindingContext(),
+          inputJson,
+          maxBindingInputBytes: exactBytes - 1,
+          maxBindingOutputBytes: 1024,
+        }),
+      ).rejects.toBeInstanceOf(RunBindingError);
+    },
+  );
+
+  it.each(['ascii', 'é', '🧪'])(
+    'enforces exact result byte boundaries: %s',
+    async text => {
+      const encodedBytes = Buffer.byteLength(serializeRunValue(text));
+      await expect(
+        run({
+          limits: { maxResultBytes: encodedBytes },
+          source: `return ${JSON.stringify(text)};`,
+        }),
+      ).resolves.toEqual({ status: 'completed', value: text });
+      await expect(
+        run({
+          limits: { maxResultBytes: encodedBytes - 1 },
+          source: `return ${JSON.stringify(text)};`,
+        }),
+      ).rejects.toMatchObject({ code: 'RUN_SERIALIZATION_ERROR' });
+    },
+  );
+
+  it('preserves prototype-sensitive keys without polluting prototypes', async () => {
+    const observe = vi.fn((input: Record<string, unknown>) => ({
+      hasOwnProto: Object.hasOwn(input, '__proto__'),
+      input,
+      polluted: ({} as { polluted?: unknown }).polluted,
+    }));
+    const result = await run({
+      bindings: { tools: { observe } },
+      source: `
+        return await tools.observe(
+          JSON.parse('{"__proto__":{"polluted":true},"constructor":"value","prototype":"value"}')
+        );
+      `,
+    });
+    expect(result).toMatchObject({
+      status: 'completed',
+      value: {
+        hasOwnProto: true,
+        input: {
+          __proto__: { polluted: true },
+          constructor: 'value',
+          prototype: 'value',
+        },
+      },
+    });
+    expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it('preserves edge values across binding and result boundaries', async () => {
+    const result = await run({
+      bindings: { tools: { values: input => input } },
+      source: `
+        return await tools.values({
+          array: [undefined, NaN, Infinity, -Infinity],
+          object: { omitted: undefined, nan: NaN, infinity: Infinity }
+        });
+      `,
+    });
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') {
+      return;
+    }
+    const value = result.value as {
+      array: unknown[];
+      object: Record<string, unknown>;
+    };
+    expect(value.array[0]).toBeUndefined();
+    expect(Number.isNaN(value.array[1])).toBe(true);
+    expect(value.array.slice(2)).toEqual([Infinity, -Infinity]);
+    expect(Object.hasOwn(value.object, 'omitted')).toBe(true);
+    expect(value.object.omitted).toBeUndefined();
+    expect(Number.isNaN(value.object.nan)).toBe(true);
+    expect(value.object.infinity).toBe(Infinity);
+  });
+
+  it.each(NON_SERIALIZABLE_OUTPUTS)(
+    'rejects a non-serializable binding %s',
+    async (_name, output) => {
+      await expect(
+        run({
+          bindings: { tools: { output } },
+          source: 'return await tools.output();',
+        }),
+      ).rejects.toMatchObject({ code: 'RUN_SERIALIZATION_ERROR' });
+    },
+  );
+
+  it('preserves rich values in resolutions', async () => {
+    const observed: unknown[] = [];
+    const source = 'return await tools.pause();';
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          if (!context.resume) {
+            context.interrupt({ kind: 'pause' });
+          }
+          observed.push(context.resume?.resolution);
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const first = await run({ bindings, source });
+    if (first.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    const interruption = first.interruptions.at(0);
+    if (interruption === undefined) {
+      throw new Error('Expected an interruption.');
+    }
+    const date = new Date('2025-01-02T03:04:05.000Z');
+    await expect(
+      run({
+        bindings,
+        continuation: first.continuation,
+        resolutions: [{ interruptionId: interruption.id, value: date }],
+        source,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: date });
+    expect(observed).toEqual([date]);
+  });
+
+  it('rejects custom codec state with accessors, cycles, or non-plain values', async () => {
+    const malformedStates: unknown[] = [];
+    const accessor = state();
+    Object.defineProperty(accessor, 'ledger', {
+      get() {
+        throw new Error('accessor executed');
+      },
+    });
+    malformedStates.push(accessor);
+    const cyclic = state() as RunContinuationState & { cycle?: unknown };
+    cyclic.cycle = cyclic;
+    malformedStates.push(cyclic);
+    malformedStates.push({ ...state(), determinism: new Date() });
+
+    for (const malformed of malformedStates) {
+      const runner = createRunner({
+        continuationCodec: {
+          decode: () => malformed as never,
+          encode: () => 'unused',
+        },
+      });
+      await expect(
+        runner.run({ continuation: 'token', source: state().source }),
+      ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    }
+  });
+
+  it('bounds and sanitizes serialized errors and hostile properties', () => {
+    const error = new Error('x'.repeat(100_000));
+    Object.defineProperty(error, 'details', {
+      get() {
+        throw new Error('details getter');
+      },
+    });
+    error.stack = `Error: secret\n    at data:text/javascript;base64,${'a'.repeat(100_000)}`;
+    const serialized = serializeError(error);
+    expect(Buffer.byteLength(JSON.stringify(serialized))).toBeLessThanOrEqual(
+      64 * 1024,
+    );
+    expect(serialized.stack).not.toContain('data:text/javascript;base64');
+    expect(serialized.details).toBeUndefined();
+  });
+});


### PR DESCRIPTION
adds:
- run() to execute JS/type-stripped TS in hardened QuickJS.
- createRunner() for shared limits and continuation configuration.
- Host binding validation and reserved-name protection.
- Signed/custom continuation support for interruption and deterministic replay.