### PR TITLE
feat: prevent continuation loss during aborted storage reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ coverage/
 # Logs
 *.log
 pnpm-debug.log*
+.deepsec
+/findings

--- a/content/docs/advanced/04-continuations.mdx
+++ b/content/docs/advanced/04-continuations.mdx
@@ -187,11 +187,19 @@ const storage: ContinuationStorage = {
       signal: context?.abortSignal,
     });
   },
-  async take(key, context) {
-    return continuationStore.take(key, {
+  async acquire(key, claimId, context) {
+    return continuationStore.claim(key, {
+      claimId,
+      claimMs: 30_000,
       deadlineMs: context?.deadlineMs,
       signal: context?.abortSignal,
     });
+  },
+  async consume(key, claimId) {
+    await continuationStore.deleteIfClaimedBy(key, claimId);
+  },
+  async release(key, claimId) {
+    await continuationStore.releaseIfClaimedBy(key, claimId);
   },
 };
 
@@ -204,16 +212,25 @@ const runner = createRunner({
 });
 ```
 
-`take()` must atomically read and remove the stored value. A normal read
-followed by a separate delete can allow two processes to consume the same
-continuation.
+These methods implement a temporary claim. `acquire()` must atomically allow
+only one caller to claim a continuation without deleting it. `consume()` and
+`release()` must only modify a record when the supplied claim identifier
+matches its current claim.
 
-The codec consumes the stored value before later replay validation. If replay
-then fails because the source, bindings, context, or resolutions changed, that
-token has already been used.
+The codec manages this lifecycle automatically:
+
+1. It calls `acquire()` before decoding.
+2. It calls `release()` when decoding is cancelled or replay validation fails.
+3. It calls `consume()` after replay validation succeeds, before the worker
+   resumes execution.
+
+Claims must expire automatically after a bounded interval. If the host process
+crashes before cleanup, expiry makes the continuation available for another
+attempt instead of leaving it permanently unavailable.
 
 Storage implementations should honor the supplied abort signal and operation
-deadline.
+deadline during `set()` and `acquire()`. Cleanup operations intentionally do not
+receive the aborted context.
 
 ## Scope
 

--- a/content/docs/reference/05-create-stored-continuation-codec.mdx
+++ b/content/docs/reference/05-create-stored-continuation-codec.mdx
@@ -13,10 +13,33 @@ import { createStoredContinuationCodec } from 'run';
 const continuationCodec = createStoredContinuationCodec({
   storage: {
     set: (key, value) => store.set(key, value),
-    take: key => store.getAndDelete(key),
+    acquire: (key, claimId, context) =>
+      store.claim(key, {
+        claimId,
+        claimMs: 30_000,
+        signal: context?.abortSignal,
+      }),
+    consume: (key, claimId) => store.deleteIfClaimedBy(key, claimId),
+    release: (key, claimId) => store.releaseIfClaimedBy(key, claimId),
   },
 });
 ```
+
+The storage methods describe a temporary claim on a continuation:
+
+- `acquire()` gives one caller exclusive access without deleting the value.
+- `consume()` permanently deletes the value after validation succeeds.
+- `release()` makes the value available again after cancellation or validation
+  failure.
+
+The codec calls these methods automatically. Application code does not need to
+choose when to consume or release a continuation.
+
+`acquire()` must create a claim that expires automatically after a bounded
+interval. Automatic expiry makes the continuation available again if the
+process crashes before it can call `consume()` or `release()`. Both finalization
+methods must only modify the record when the supplied claim identifier matches
+the record's current claim.
 
 ## Import
 
@@ -33,7 +56,7 @@ import { createStoredContinuationCodec } from 'run';
   {
     "name": "storage",
     "type": "ContinuationStorage",
-    "description": "The storage adapter used to save and atomically consume continuation state.",
+    "description": "The storage adapter used to save, temporarily claim, and atomically consume continuation state.",
     "properties": [
       {
         "type": "ContinuationStorage",
@@ -44,9 +67,19 @@ import { createStoredContinuationCodec } from 'run';
             "description": "Stores a continuation under the generated key."
           },
           {
-            "name": "take",
-            "type": "(key: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>",
-            "description": "Atomically reads and removes a continuation."
+            "name": "acquire",
+            "type": "(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>",
+            "description": "Atomically creates a temporary claim on a continuation without removing it."
+          },
+          {
+            "name": "consume",
+            "type": "(key: string, claimId: string) => void | Promise<void>",
+            "description": "Atomically removes a continuation when its claim identifier matches."
+          },
+          {
+            "name": "release",
+            "type": "(key: string, claimId: string) => void | Promise<void>",
+            "description": "Atomically releases a continuation when its claim identifier matches."
           }
         ]
       },

--- a/content/docs/reference/09-types.mdx
+++ b/content/docs/reference/09-types.mdx
@@ -560,9 +560,19 @@ import type {
             "description": "Stores a continuation."
           },
           {
-            "name": "take",
-            "type": "(key: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>",
-            "description": "Atomically reads and removes a continuation."
+            "name": "acquire",
+            "type": "(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>",
+            "description": "Atomically creates a temporary claim on a continuation without removing it."
+          },
+          {
+            "name": "consume",
+            "type": "(key: string, claimId: string) => void | Promise<void>",
+            "description": "Atomically removes a continuation when its claim identifier matches."
+          },
+          {
+            "name": "release",
+            "type": "(key: string, claimId: string) => void | Promise<void>",
+            "description": "Atomically releases a continuation when its claim identifier matches."
           }
         ]
       }

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -353,10 +353,10 @@ provide integrity, not confidentiality: source, arguments, results, errors,
 and interruption payloads are base64-encoded but not encrypted.
 
 For sensitive or at-most-once flows, use `createStoredContinuationCodec()`.
-Its storage contract atomically consumes a token during decode and enforces
-expiry. Because `take()` happens before later replay validation, any subsequent
-failure burns that continuation. Storage implementations should honor the
-operation `AbortSignal` and deadline.
+Its storage contract temporarily claims a token during decode and enforces
+expiry. Cancellation and replay-validation failures release the claim; valid
+continuations are consumed before worker execution. Claims must expire after a
+bounded interval so process failure cannot permanently strand a token.
 
 > A custom continuation codec used across a trust boundary must authenticate
 > its state and reject tampering. An unauthenticated codec lets an attacker

--- a/packages/run/src/continuation-codec.test.ts
+++ b/packages/run/src/continuation-codec.test.ts
@@ -51,7 +51,7 @@ const createMemoryStorage = (): {
     storage: {
       acquire(key, leaseId) {
         if (leases.has(key)) {
-          return undefined;
+          return;
         }
         const value = values.get(key);
         if (value !== undefined) {
@@ -119,7 +119,7 @@ describe('continuation codecs', () => {
       storage: {
         async acquire(key, leaseId) {
           if (leases.has(key)) {
-            return undefined;
+            return;
           }
           const value = values.get(key);
           if (value !== undefined) {

--- a/packages/run/src/continuation-codec.test.ts
+++ b/packages/run/src/continuation-codec.test.ts
@@ -4,8 +4,12 @@ import {
   createSignedContinuationCodec,
   createStoredContinuationCodec,
 } from './continuation-codec.js';
-import type { StoredContinuation } from './continuation-codec.js';
+import type {
+  ContinuationStorage,
+  StoredContinuation,
+} from './continuation-codec.js';
 import type { RunContinuationState } from './types.js';
+import { createPromiseWithResolvers } from './utils/promise-with-resolvers.js';
 
 const state: RunContinuationState = {
   determinism: {
@@ -37,22 +41,50 @@ const tokenBody = (token: string): string => {
   return body;
 };
 
+const createMemoryStorage = (): {
+  storage: ContinuationStorage;
+  values: Map<string, StoredContinuation>;
+} => {
+  const values = new Map<string, StoredContinuation>();
+  const leases = new Map<string, string>();
+  return {
+    storage: {
+      acquire(key, leaseId) {
+        if (leases.has(key)) {
+          return undefined;
+        }
+        const value = values.get(key);
+        if (value !== undefined) {
+          leases.set(key, leaseId);
+        }
+        return value;
+      },
+      consume(key, leaseId) {
+        if (leases.get(key) === leaseId) {
+          leases.delete(key);
+          values.delete(key);
+        }
+      },
+      release(key, leaseId) {
+        if (leases.get(key) === leaseId) {
+          leases.delete(key);
+        }
+      },
+      set(key, value) {
+        values.set(key, value);
+      },
+    },
+    values,
+  };
+};
+
 afterEach(() => vi.useRealTimers());
 
 describe('continuation codecs', () => {
   it('atomically consumes stored continuations', async () => {
-    const values = new Map<string, StoredContinuation>();
+    const { storage } = createMemoryStorage();
     const codec = createStoredContinuationCodec({
-      storage: {
-        set(key, value) {
-          values.set(key, value);
-        },
-        take(key) {
-          const value = values.get(key);
-          values.delete(key);
-          return value;
-        },
-      },
+      storage,
     });
     const token = await codec.encode(state);
     await expect(codec.decode(token)).resolves.toEqual(state);
@@ -62,19 +94,9 @@ describe('continuation codecs', () => {
   });
 
   it('allows exactly one of many concurrent stored continuation consumers', async () => {
-    const values = new Map<string, StoredContinuation>();
+    const { storage } = createMemoryStorage();
     const codec = createStoredContinuationCodec({
-      storage: {
-        set(key, value) {
-          values.set(key, value);
-        },
-        async take(key) {
-          const value = values.get(key);
-          values.delete(key);
-          await Promise.resolve();
-          return value;
-        },
-      },
+      storage,
     });
     const token = await codec.encode(state);
     const results = await Promise.allSettled(
@@ -88,22 +110,63 @@ describe('continuation codecs', () => {
     );
   });
 
-  it('enforces stored continuation expiry itself', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1000);
+  it('releases a stored continuation when acquire finishes after an abort', async () => {
     const values = new Map<string, StoredContinuation>();
+    const leases = new Map<string, string>();
+    const acquireStarted = createPromiseWithResolvers<null>();
+    const finishAcquire = createPromiseWithResolvers<null>();
     const codec = createStoredContinuationCodec({
-      maxAgeMs: 10,
       storage: {
+        async acquire(key, leaseId) {
+          if (leases.has(key)) {
+            return undefined;
+          }
+          const value = values.get(key);
+          if (value !== undefined) {
+            leases.set(key, leaseId);
+          }
+          acquireStarted.resolve(null);
+          await finishAcquire.promise;
+          return value;
+        },
+        consume(key, leaseId) {
+          if (leases.get(key) === leaseId) {
+            leases.delete(key);
+            values.delete(key);
+          }
+        },
+        release(key, leaseId) {
+          if (leases.get(key) === leaseId) {
+            leases.delete(key);
+          }
+        },
         set(key, value) {
           values.set(key, value);
         },
-        take(key) {
-          const value = values.get(key);
-          values.delete(key);
-          return value;
-        },
       },
+    });
+    const token = await codec.encode(state);
+    const abortController = new AbortController();
+    const decode = codec.decode(token, {
+      abortSignal: abortController.signal,
+      deadlineMs: Date.now() + 1000,
+    });
+
+    await acquireStarted.promise;
+    abortController.abort();
+    finishAcquire.resolve(null);
+
+    await expect(decode).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(codec.decode(token)).resolves.toEqual(state);
+  });
+
+  it('enforces stored continuation expiry itself', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const { storage } = createMemoryStorage();
+    const codec = createStoredContinuationCodec({
+      maxAgeMs: 10,
+      storage,
     });
     const token = await codec.encode(state);
     vi.setSystemTime(1011);
@@ -262,24 +325,35 @@ describe('continuation codecs', () => {
     'a'.repeat(257),
     'bad!key',
   ])('rejects malformed stored key %j before storage access', async key => {
-    const take = vi.fn();
+    const acquire = vi.fn();
     const codec = createStoredContinuationCodec({
-      storage: { set: () => {}, take },
+      storage: {
+        acquire,
+        consume: () => {},
+        release: () => {},
+        set: () => {},
+      },
     });
     await expect(codec.decode(key)).rejects.toMatchObject({
       code: 'RUN_PROTOCOL_ERROR',
     });
-    expect(take).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
   });
 
   it('does not issue a stored key before persistence succeeds', async () => {
     const codec = createStoredContinuationCodec({
       storage: {
+        acquire() {
+          throw new Error('not used');
+        },
+        consume() {
+          throw new Error('not used');
+        },
+        release() {
+          throw new Error('not used');
+        },
         set() {
           throw new Error('storage unavailable');
-        },
-        take() {
-          throw new Error('not used');
         },
       },
     });

--- a/packages/run/src/continuation-codec.ts
+++ b/packages/run/src/continuation-codec.ts
@@ -344,17 +344,23 @@ export const createStoredContinuationCodec = ({
           promise: Promise<void>;
         }
       | undefined;
+    const commitClaim = async (): Promise<void> => {
+      try {
+        await storage.consume(key, claimId);
+      } catch (error) {
+        await storage.release(key, claimId);
+        throw error;
+      }
+    };
+    const rollbackClaim = async (): Promise<void> => {
+      await storage.release(key, claimId);
+    };
     return {
       commit() {
         if (finalization === undefined) {
           finalization = {
             kind: 'commit',
-            promise: Promise.resolve()
-              .then(() => storage.consume(key, claimId))
-              .catch(async error => {
-                await storage.release(key, claimId);
-                throw error;
-              }),
+            promise: commitClaim(),
           };
         } else if (finalization.kind === 'rollback') {
           throw new RunProtocolError(
@@ -367,9 +373,7 @@ export const createStoredContinuationCodec = ({
         if (finalization === undefined) {
           finalization = {
             kind: 'rollback',
-            promise: Promise.resolve().then(() =>
-              storage.release(key, claimId),
-            ),
+            promise: rollbackClaim(),
           };
         }
         return finalization.promise;

--- a/packages/run/src/continuation-codec.ts
+++ b/packages/run/src/continuation-codec.ts
@@ -3,6 +3,7 @@ import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import { RunProtocolError } from './errors.js';
 import type {
   ContinuationCodec,
+  ContinuationDecodeTransaction,
   ContinuationOperationContext,
   RunContinuationState,
 } from './types.js';
@@ -40,11 +41,19 @@ export interface ContinuationStorage {
     value: StoredContinuation,
     context?: ContinuationOperationContext,
   ): void | Promise<void>;
-  /** Atomically reads and removes a continuation. */
-  take(
+  /**
+   * Atomically claims a continuation without removing it. Claims must become
+   * available again after a bounded interval if neither consume nor release runs.
+   */
+  acquire(
     key: string,
+    claimId: string,
     context?: ContinuationOperationContext,
   ): StoredContinuation | undefined | Promise<StoredContinuation | undefined>;
+  /** Atomically removes a continuation only when its claim identifier matches. */
+  consume(key: string, claimId: string): void | Promise<void>;
+  /** Atomically releases a continuation only when its claim identifier matches. */
+  release(key: string, claimId: string): void | Promise<void>;
 }
 
 export interface StoredContinuation {
@@ -290,33 +299,91 @@ export const createStoredContinuationCodec = ({
   if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0) {
     throw new TypeError('Continuation maxAgeMs must be a positive integer.');
   }
+  const decodeTransaction = async (
+    key: string,
+    context?: ContinuationOperationContext,
+  ): Promise<ContinuationDecodeTransaction> => {
+    throwIfOperationAborted(context);
+    if (
+      typeof key !== 'string' ||
+      !/^[A-Za-z0-9_-]{43}$/u.test(key) ||
+      Buffer.from(key, 'base64url').toString('base64url') !== key
+    ) {
+      throw new RunProtocolError('Stored continuation key is invalid.');
+    }
+    const claimId = randomBytes(32).toString('base64url');
+    const stored = await storage.acquire(key, claimId, context);
+    try {
+      throwIfOperationAborted(context);
+    } catch (error) {
+      if (stored !== undefined) {
+        await storage.release(key, claimId);
+      }
+      throw error;
+    }
+    if (stored === undefined) {
+      throw new RunProtocolError('Stored continuation was not found.');
+    }
+    if (
+      !isPlainRecord(stored) ||
+      !hasExactKeys(stored, ['expiresAtMs', 'state']) ||
+      !Number.isSafeInteger(stored.expiresAtMs)
+    ) {
+      await storage.consume(key, claimId);
+      throw new RunProtocolError('Stored continuation envelope is invalid.');
+    }
+    if (stored.expiresAtMs <= Date.now()) {
+      await storage.consume(key, claimId);
+      throw new RunProtocolError('Stored continuation has expired.');
+    }
+    const decodedState = structuredClone(stored.state);
+    throwIfOperationAborted(context);
+    let finalization:
+      | {
+          kind: 'commit' | 'rollback';
+          promise: Promise<void>;
+        }
+      | undefined;
+    return {
+      commit() {
+        if (finalization === undefined) {
+          finalization = {
+            kind: 'commit',
+            promise: Promise.resolve()
+              .then(() => storage.consume(key, claimId))
+              .catch(async error => {
+                await storage.release(key, claimId);
+                throw error;
+              }),
+          };
+        } else if (finalization.kind === 'rollback') {
+          throw new RunProtocolError(
+            'Cannot commit a released continuation transaction.',
+          );
+        }
+        return finalization.promise;
+      },
+      rollback() {
+        if (finalization === undefined) {
+          finalization = {
+            kind: 'rollback',
+            promise: Promise.resolve().then(() =>
+              storage.release(key, claimId),
+            ),
+          };
+        }
+        return finalization.promise;
+      },
+      state: decodedState,
+    };
+  };
   return {
     async decode(key, context) {
-      throwIfOperationAborted(context);
-      if (
-        typeof key !== 'string' ||
-        !/^[A-Za-z0-9_-]{43}$/u.test(key) ||
-        Buffer.from(key, 'base64url').toString('base64url') !== key
-      ) {
-        throw new RunProtocolError('Stored continuation key is invalid.');
-      }
-      const stored = await storage.take(key, context);
-      throwIfOperationAborted(context);
-      if (stored === undefined) {
-        throw new RunProtocolError('Stored continuation was not found.');
-      }
-      if (
-        !isPlainRecord(stored) ||
-        !hasExactKeys(stored, ['expiresAtMs', 'state']) ||
-        !Number.isSafeInteger(stored.expiresAtMs)
-      ) {
-        throw new RunProtocolError('Stored continuation envelope is invalid.');
-      }
-      if (stored.expiresAtMs <= Date.now()) {
-        throw new RunProtocolError('Stored continuation has expired.');
-      }
-      return structuredClone(stored.state);
+      const transaction = await decodeTransaction(key, context);
+      await transaction.commit();
+      return transaction.state;
     },
+    decodeTransaction,
     async encode(state, context) {
       const key = randomBytes(32).toString('base64url');
       throwIfOperationAborted(context);

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -27,6 +27,7 @@ export type {
   BindingResumeContext,
   Bindings,
   ContinuationCodec,
+  ContinuationDecodeTransaction,
   ContinuationOperationContext,
   RunCompletedResult,
   RunContinuationState,

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createRunner,
   createSignedContinuationCodec,
+  createStoredContinuationCodec,
   getBindingContext,
   run,
   setMaxWorkers,
 } from './index.js';
-import type { RunInterruptedResult, RunInterruption } from './index.js';
+import type {
+  ContinuationStorage,
+  RunInterruptedResult,
+  RunInterruption,
+  StoredContinuation,
+} from './index.js';
 import { createPromiseWithResolvers } from './utils/promise-with-resolvers.js';
 
 const firstInterruption = (result: RunInterruptedResult): RunInterruption => {
@@ -21,6 +27,43 @@ const sleep = async (delay: number): Promise<void> => {
   const deferred = createPromiseWithResolvers<null>();
   setTimeout(() => deferred.resolve(null), delay);
   await deferred.promise;
+};
+
+const createMemoryContinuationStorage = (): {
+  storage: ContinuationStorage;
+  values: Map<string, StoredContinuation>;
+} => {
+  const values = new Map<string, StoredContinuation>();
+  const leases = new Map<string, string>();
+  return {
+    storage: {
+      acquire(key, leaseId) {
+        if (leases.has(key)) {
+          return undefined;
+        }
+        const value = values.get(key);
+        if (value !== undefined) {
+          leases.set(key, leaseId);
+        }
+        return value;
+      },
+      consume(key, leaseId) {
+        if (leases.get(key) === leaseId) {
+          leases.delete(key);
+          values.delete(key);
+        }
+      },
+      release(key, leaseId) {
+        if (leases.get(key) === leaseId) {
+          leases.delete(key);
+        }
+      },
+      set(key, value) {
+        values.set(key, value);
+      },
+    },
+    values,
+  };
 };
 
 describe('run', () => {
@@ -589,6 +632,80 @@ describe('run', () => {
     abortController.abort();
     await expect(result).rejects.toMatchObject({ code: 'RUN_ABORTED' });
     expect(codecSignal?.aborted).toBe(true);
+  });
+
+  it('rolls back a continuation transaction that finishes after abort', async () => {
+    const decodeStarted = createPromiseWithResolvers<null>();
+    const finishDecode = createPromiseWithResolvers<null>();
+    const rollback = vi.fn();
+    const runner = createRunner({
+      continuationCodec: {
+        decode: () => {
+          throw new Error('transactional decode should be used');
+        },
+        async decodeTransaction() {
+          decodeStarted.resolve(null);
+          await finishDecode.promise;
+          return {
+            commit: vi.fn(),
+            rollback,
+            state: {} as never,
+          };
+        },
+        encode: () => 'unused',
+      },
+      limits: { timeoutMs: 1000 },
+    });
+    const abortController = new AbortController();
+    const result = runner.run({
+      abortSignal: abortController.signal,
+      continuation: 'pending',
+      source: 'return 1;',
+    });
+
+    await decodeStarted.promise;
+    abortController.abort();
+    await expect(result).rejects.toMatchObject({ code: 'RUN_ABORTED' });
+    finishDecode.resolve(null);
+    await vi.waitFor(() => expect(rollback).toHaveBeenCalledOnce());
+  });
+
+  it('releases stored continuations rejected by replay validation', async () => {
+    const { storage } = createMemoryContinuationStorage();
+    const runner = createRunner({
+      continuationCodec: createStoredContinuationCodec({ storage }),
+    });
+    const source = 'return await tools.pause();';
+    const bindings = {
+      tools: {
+        pause: () => {
+          const context = getBindingContext();
+          if (context.resume === undefined) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await runner.run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+    const resume = {
+      bindings,
+      continuation: interrupted.continuation,
+      resolutions: [
+        { interruptionId: firstInterruption(interrupted).id, value: true },
+      ],
+    };
+
+    await expect(
+      runner.run({ ...resume, source: 'return "changed";' }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    await expect(runner.run({ ...resume, source })).resolves.toEqual({
+      status: 'completed',
+      value: true,
+    });
   });
 
   it('enforces aggregate continuation limits', async () => {

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -39,7 +39,7 @@ const createMemoryContinuationStorage = (): {
     storage: {
       acquire(key, leaseId) {
         if (leases.has(key)) {
-          return undefined;
+          return;
         }
         const value = values.get(key);
         if (value !== undefined) {

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -65,6 +65,11 @@ interface ManagedWorkerRun {
   result: Promise<RunResult>;
 }
 
+interface DecodedContinuation {
+  state: unknown;
+  transaction?: ContinuationDecodeTransaction;
+}
+
 let invocationCounter = 0;
 let activeInvocations = 0;
 let terminatingWorkers = 0;
@@ -118,77 +123,16 @@ async function readContinuation(
     return undefined;
   }
   assertContinuationTokenSize(input.continuation, options.maxContinuationBytes);
-  let state: unknown;
-  let transaction: ContinuationDecodeTransaction | undefined;
-  try {
-    if (input.continuationCodec.decodeTransaction === undefined) {
-      state = await raceContinuationOperation(
-        context => input.continuationCodec.decode(input.continuation, context),
-        input.abortSignal,
-        deadlineMs,
-        options.timeoutMs,
-      );
-    } else {
-      transaction = await raceContinuationOperation(
-        context =>
-          input.continuationCodec.decodeTransaction?.(
-            input.continuation,
-            context,
-          ) as Promise<ContinuationDecodeTransaction>,
-        input.abortSignal,
-        deadlineMs,
-        options.timeoutMs,
-        discarded => discarded.rollback(),
-      );
-      state = transaction.state;
-    }
-  } catch (error) {
-    if (RunError.isInstance(error)) {
-      throw error;
-    }
-    throw new RunProtocolError('Continuation codec failed to decode token.', {
-      cause: error instanceof Error ? error.message : String(error),
-    });
-  }
+  const { state, transaction } = await decodeContinuation(
+    input,
+    input.continuation,
+    deadlineMs,
+    options.timeoutMs,
+  );
   let commitStarted = false;
   try {
     assertContinuationState(state, input.source, scopeHash, options);
-    const pendingIds = new Set(
-      state.ledger
-        .filter(entry => entry.status === 'interrupted')
-        .map(entry => entry.interruptionId),
-    );
-    const seen = new Set<string>();
-    for (const resolution of input.resolutions ?? []) {
-      if (
-        !isPlainRecord(resolution) ||
-        !hasExactOwnKeys(resolution, ['interruptionId', 'value'])
-      ) {
-        throw new RunProtocolError('An interruption resolution is malformed.');
-      }
-      if (
-        typeof resolution.interruptionId !== 'string' ||
-        !pendingIds.has(resolution.interruptionId) ||
-        seen.has(resolution.interruptionId)
-      ) {
-        throw new RunProtocolError(
-          'A resolution does not match exactly one pending interruption.',
-          { interruptionId: resolution.interruptionId },
-        );
-      }
-      toJsonPayload(
-        resolution.value,
-        options.maxBindingOutputBytes,
-        `Resolution "${resolution.interruptionId}"`,
-      );
-      seen.add(resolution.interruptionId);
-    }
-    if (pendingIds.size === 0 || seen.size !== pendingIds.size) {
-      throw new RunProtocolError(
-        'A continuation requires exactly one resolution for every pending interruption.',
-        { pending: pendingIds.size, received: seen.size },
-      );
-    }
+    assertContinuationResolutions(state, input, options);
     if (transaction !== undefined) {
       if (input.abortSignal?.aborted) {
         throw new RunAbortedError();
@@ -206,6 +150,91 @@ async function readContinuation(
     }
     throw error;
   }
+}
+
+async function decodeContinuation(
+  input: InternalRunInput,
+  token: unknown,
+  deadlineMs: number,
+  timeoutMs: number,
+): Promise<DecodedContinuation> {
+  try {
+    const { continuationCodec } = input;
+    const { decodeTransaction } = continuationCodec;
+    if (decodeTransaction === undefined) {
+      const state = await raceContinuationOperation(
+        context => continuationCodec.decode(token, context),
+        input.abortSignal,
+        deadlineMs,
+        timeoutMs,
+      );
+      return { state };
+    }
+    const transaction = await raceContinuationOperation(
+      context => decodeTransaction.call(continuationCodec, token, context),
+      input.abortSignal,
+      deadlineMs,
+      timeoutMs,
+      rollbackDiscardedTransaction,
+    );
+    return { state: transaction.state, transaction };
+  } catch (error) {
+    if (RunError.isInstance(error)) {
+      throw error;
+    }
+    throw new RunProtocolError('Continuation codec failed to decode token.', {
+      cause: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function assertContinuationResolutions(
+  state: RunContinuationState,
+  input: InternalRunInput,
+  options: NormalizedRunOptions,
+): void {
+  const pendingIds = new Set(
+    state.ledger
+      .filter(entry => entry.status === 'interrupted')
+      .map(entry => entry.interruptionId),
+  );
+  const seen = new Set<string>();
+  for (const resolution of input.resolutions ?? []) {
+    if (
+      !isPlainRecord(resolution) ||
+      !hasExactOwnKeys(resolution, ['interruptionId', 'value'])
+    ) {
+      throw new RunProtocolError('An interruption resolution is malformed.');
+    }
+    if (
+      typeof resolution.interruptionId !== 'string' ||
+      !pendingIds.has(resolution.interruptionId) ||
+      seen.has(resolution.interruptionId)
+    ) {
+      throw new RunProtocolError(
+        'A resolution does not match exactly one pending interruption.',
+        { interruptionId: resolution.interruptionId },
+      );
+    }
+    toJsonPayload(
+      resolution.value,
+      options.maxBindingOutputBytes,
+      `Resolution "${resolution.interruptionId}"`,
+    );
+    seen.add(resolution.interruptionId);
+  }
+  if (pendingIds.size === 0 || seen.size !== pendingIds.size) {
+    throw new RunProtocolError(
+      'A continuation requires exactly one resolution for every pending interruption.',
+      { pending: pendingIds.size, received: seen.size },
+    );
+  }
+}
+
+async function rollbackDiscardedTransaction(
+  transaction: ContinuationDecodeTransaction,
+): Promise<void> {
+  await transaction.rollback();
 }
 
 async function raceContinuationOperation<T>(
@@ -231,12 +260,14 @@ async function raceContinuationOperation<T>(
     operationAbortController.abort(new RunTimeoutError(timeoutMs));
     timedOut.reject(new RunTimeoutError(timeoutMs));
   }, remainingMs);
-  const operationPromise = Promise.resolve().then(() =>
-    operation({
+  const startOperation = async (): Promise<T> => {
+    await Promise.resolve();
+    return operation({
       abortSignal: operationAbortController.signal,
       deadlineMs,
-    }),
-  );
+    });
+  };
+  const operationPromise = startOperation();
   try {
     return await Promise.race([
       operationPromise,
@@ -248,16 +279,26 @@ async function raceContinuationOperation<T>(
       operationAbortController.signal.aborted &&
       onDiscardedResult !== undefined
     ) {
-      void operationPromise
-        .then(result => onDiscardedResult(result))
-        .catch(() => {
-          // Storage leases recover abandoned claims if asynchronous cleanup fails.
-        });
+      runInBackground(
+        discardContinuationOperationResult(operationPromise, onDiscardedResult),
+      );
     }
     throw error;
   } finally {
     clearTimeout(timeoutHandle);
     abortSignal?.removeEventListener('abort', rejectOnAbort);
+  }
+}
+
+async function discardContinuationOperationResult<T>(
+  operation: Promise<T>,
+  onDiscardedResult: (result: T) => void | Promise<void>,
+): Promise<void> {
+  try {
+    const result = await operation;
+    await onDiscardedResult(result);
+  } catch {
+    // Expiring storage claims recover abandoned work if cleanup cannot finish.
   }
 }
 

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -38,6 +38,7 @@ import type {
   InternalRunInput,
   NormalizedRunOptions,
   RunContinuationState,
+  ContinuationDecodeTransaction,
   RunDeterminismState,
   RunInterruptedResult,
   RunLedgerEntry,
@@ -118,13 +119,29 @@ async function readContinuation(
   }
   assertContinuationTokenSize(input.continuation, options.maxContinuationBytes);
   let state: unknown;
+  let transaction: ContinuationDecodeTransaction | undefined;
   try {
-    state = await raceContinuationOperation(
-      context => input.continuationCodec.decode(input.continuation, context),
-      input.abortSignal,
-      deadlineMs,
-      options.timeoutMs,
-    );
+    if (input.continuationCodec.decodeTransaction === undefined) {
+      state = await raceContinuationOperation(
+        context => input.continuationCodec.decode(input.continuation, context),
+        input.abortSignal,
+        deadlineMs,
+        options.timeoutMs,
+      );
+    } else {
+      transaction = await raceContinuationOperation(
+        context =>
+          input.continuationCodec.decodeTransaction?.(
+            input.continuation,
+            context,
+          ) as Promise<ContinuationDecodeTransaction>,
+        input.abortSignal,
+        deadlineMs,
+        options.timeoutMs,
+        discarded => discarded.rollback(),
+      );
+      state = transaction.state;
+    }
   } catch (error) {
     if (RunError.isInstance(error)) {
       throw error;
@@ -133,44 +150,62 @@ async function readContinuation(
       cause: error instanceof Error ? error.message : String(error),
     });
   }
-  assertContinuationState(state, input.source, scopeHash, options);
-  const pendingIds = new Set(
-    state.ledger
-      .filter(entry => entry.status === 'interrupted')
-      .map(entry => entry.interruptionId),
-  );
-  const seen = new Set<string>();
-  for (const resolution of input.resolutions ?? []) {
-    if (
-      !isPlainRecord(resolution) ||
-      !hasExactOwnKeys(resolution, ['interruptionId', 'value'])
-    ) {
-      throw new RunProtocolError('An interruption resolution is malformed.');
+  let commitStarted = false;
+  try {
+    assertContinuationState(state, input.source, scopeHash, options);
+    const pendingIds = new Set(
+      state.ledger
+        .filter(entry => entry.status === 'interrupted')
+        .map(entry => entry.interruptionId),
+    );
+    const seen = new Set<string>();
+    for (const resolution of input.resolutions ?? []) {
+      if (
+        !isPlainRecord(resolution) ||
+        !hasExactOwnKeys(resolution, ['interruptionId', 'value'])
+      ) {
+        throw new RunProtocolError('An interruption resolution is malformed.');
+      }
+      if (
+        typeof resolution.interruptionId !== 'string' ||
+        !pendingIds.has(resolution.interruptionId) ||
+        seen.has(resolution.interruptionId)
+      ) {
+        throw new RunProtocolError(
+          'A resolution does not match exactly one pending interruption.',
+          { interruptionId: resolution.interruptionId },
+        );
+      }
+      toJsonPayload(
+        resolution.value,
+        options.maxBindingOutputBytes,
+        `Resolution "${resolution.interruptionId}"`,
+      );
+      seen.add(resolution.interruptionId);
     }
-    if (
-      typeof resolution.interruptionId !== 'string' ||
-      !pendingIds.has(resolution.interruptionId) ||
-      seen.has(resolution.interruptionId)
-    ) {
+    if (pendingIds.size === 0 || seen.size !== pendingIds.size) {
       throw new RunProtocolError(
-        'A resolution does not match exactly one pending interruption.',
-        { interruptionId: resolution.interruptionId },
+        'A continuation requires exactly one resolution for every pending interruption.',
+        { pending: pendingIds.size, received: seen.size },
       );
     }
-    toJsonPayload(
-      resolution.value,
-      options.maxBindingOutputBytes,
-      `Resolution "${resolution.interruptionId}"`,
-    );
-    seen.add(resolution.interruptionId);
+    if (transaction !== undefined) {
+      if (input.abortSignal?.aborted) {
+        throw new RunAbortedError();
+      }
+      if (Date.now() >= deadlineMs) {
+        throw new RunTimeoutError(options.timeoutMs);
+      }
+      commitStarted = true;
+      await transaction.commit();
+    }
+    return state;
+  } catch (error) {
+    if (transaction !== undefined && !commitStarted) {
+      await transaction.rollback();
+    }
+    throw error;
   }
-  if (pendingIds.size === 0 || seen.size !== pendingIds.size) {
-    throw new RunProtocolError(
-      'A continuation requires exactly one resolution for every pending interruption.',
-      { pending: pendingIds.size, received: seen.size },
-    );
-  }
-  return state;
 }
 
 async function raceContinuationOperation<T>(
@@ -178,6 +213,7 @@ async function raceContinuationOperation<T>(
   abortSignal: AbortSignal | undefined,
   deadlineMs: number,
   timeoutMs: number,
+  onDiscardedResult?: (result: T) => void | Promise<void>,
 ): Promise<T> {
   if (abortSignal?.aborted) {
     throw new RunAbortedError();
@@ -195,17 +231,30 @@ async function raceContinuationOperation<T>(
     operationAbortController.abort(new RunTimeoutError(timeoutMs));
     timedOut.reject(new RunTimeoutError(timeoutMs));
   }, remainingMs);
+  const operationPromise = Promise.resolve().then(() =>
+    operation({
+      abortSignal: operationAbortController.signal,
+      deadlineMs,
+    }),
+  );
   try {
     return await Promise.race([
-      Promise.resolve().then(() =>
-        operation({
-          abortSignal: operationAbortController.signal,
-          deadlineMs,
-        }),
-      ),
+      operationPromise,
       aborted.promise,
       timedOut.promise,
     ]);
+  } catch (error) {
+    if (
+      operationAbortController.signal.aborted &&
+      onDiscardedResult !== undefined
+    ) {
+      void operationPromise
+        .then(result => onDiscardedResult(result))
+        .catch(() => {
+          // Storage leases recover abandoned claims if asynchronous cleanup fails.
+        });
+    }
+    throw error;
   } finally {
     clearTimeout(timeoutHandle);
     abortSignal?.removeEventListener('abort', rejectOnAbort);

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -142,6 +142,21 @@ export interface ContinuationCodec<TOKEN = unknown> {
     token: TOKEN,
     context?: ContinuationOperationContext,
   ): RunContinuationState | Promise<RunContinuationState>;
+  /**
+   * Optionally acquires a continuation for validation before consuming it.
+   * The runtime commits valid continuations and rolls back failed or cancelled
+   * decode attempts.
+   */
+  decodeTransaction?(
+    token: TOKEN,
+    context?: ContinuationOperationContext,
+  ): ContinuationDecodeTransaction | Promise<ContinuationDecodeTransaction>;
+}
+
+export interface ContinuationDecodeTransaction {
+  state: RunContinuationState;
+  commit(): void | Promise<void>;
+  rollback(): void | Promise<void>;
 }
 
 export interface ContinuationOperationContext {


### PR DESCRIPTION
## Why

Stored continuations previously used a destructive take() operation that atomically read and deleted the continuation.

If a request was aborted or timed out while take() was pending, storage could still delete and return the continuation after the runtime had already rejected the request. The returned state was then discarded, leaving the continuation permanently unavailable even though replay never started.

This is especially relevant for approval and long-running workflows.

## What

Replaced `take()` with a temporary claim lifecycle:

- `acquire()` reserves a continuation without deleting it.
- `consume()` deletes it after replay validation succeeds.
- `release()` makes it available after cancellation or validation failure.
- Added optional transactional decoding through decodeTransaction()