### PR TITLE
feat: protect against DoS attacks

### DIFF
--- a/packages/run/src/runtime/manager-admission.test.ts
+++ b/packages/run/src/runtime/manager-admission.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { run, setMaxWorkers } from '../index.js';
+import { createPromiseWithResolvers } from '../utils/promise-with-resolvers.js';
+import * as sourceCache from '../utils/source-cache.js';
+
+describe('run admission and source transformation', () => {
+  const transformSourceSpy = vi.spyOn(sourceCache, 'transformSource');
+
+  afterEach(() => {
+    setMaxWorkers(undefined);
+    transformSourceSpy.mockClear();
+  });
+
+  it('transforms sources above the cache entry limit only once', async () => {
+    const source = `/* ${'x'.repeat(70_000)} */ return 1;`;
+
+    await expect(run({ source })).resolves.toEqual({
+      status: 'completed',
+      value: 1,
+    });
+    expect(transformSourceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an invocation at capacity before transforming its source', async () => {
+    setMaxWorkers(1);
+    const bindingStarted = createPromiseWithResolvers<null>();
+    const releaseBinding = createPromiseWithResolvers<null>();
+    const activeRun = run({
+      bindings: {
+        tools: {
+          wait: async () => {
+            bindingStarted.resolve(null);
+            await releaseBinding.promise;
+          },
+        },
+      },
+      source: 'return await tools.wait();',
+    });
+
+    try {
+      await bindingStarted.promise;
+      transformSourceSpy.mockClear();
+
+      await expect(
+        run({ source: 'const value: number = 1; return value;' }),
+      ).rejects.toMatchObject({ code: 'RUN_CONCURRENCY_LIMIT' });
+      expect(transformSourceSpy).not.toHaveBeenCalled();
+    } finally {
+      releaseBinding.resolve(null);
+      await activeRun;
+    }
+  });
+
+  it('releases the admission slot when source transformation fails', async () => {
+    setMaxWorkers(1);
+    transformSourceSpy.mockImplementationOnce(() => {
+      throw new Error('transform failed');
+    });
+
+    await expect(run({ source: 'return 1;' })).rejects.toThrow(
+      'transform failed',
+    );
+    await expect(run({ source: 'return 2;' })).resolves.toEqual({
+      status: 'completed',
+      value: 2,
+    });
+  });
+});

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -308,38 +308,43 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
   if (input.abortSignal?.aborted) {
     throw new RunAbortedError();
   }
-  assertSourceSize(input.source, normalizedOptions.maxSourceBytes);
-  const scopeHash = createContinuationScopeHash(input, normalizedOptions);
-  const continuationState = await readContinuation(
-    input,
-    normalizedOptions,
-    deadlineMs,
-    scopeHash,
-  );
-  const normalizedResolutions = (input.resolutions ?? []).map(resolution => ({
-    interruptionId: resolution.interruptionId,
-    value: toJsonPayload(
-      resolution.value,
-      normalizedOptions.maxBindingOutputBytes,
-      `Resolution "${resolution.interruptionId}"`,
-    ),
-  }));
-  if (input.abortSignal?.aborted) {
-    throw new RunAbortedError();
-  }
-  const workerOptions = {
-    ...normalizedOptions,
-    timeoutMs: Math.max(1, deadlineMs - Date.now()),
-  };
   const maxWorkers = getMaxWorkers({
     activeWorkers: activeInvocations,
-    memoryLimitBytes: workerOptions.memoryLimitBytes,
+    memoryLimitBytes: normalizedOptions.memoryLimitBytes,
   });
   if (activeInvocations >= maxWorkers) {
     throw new RunConcurrencyError(maxWorkers);
   }
   activeInvocations += 1;
   try {
+    assertSourceSize(input.source, normalizedOptions.maxSourceBytes);
+    const transformedSource = transformSource(input.source);
+    const scopeHash = createContinuationScopeHash(
+      input,
+      normalizedOptions,
+      transformedSource,
+    );
+    const continuationState = await readContinuation(
+      input,
+      normalizedOptions,
+      deadlineMs,
+      scopeHash,
+    );
+    const normalizedResolutions = (input.resolutions ?? []).map(resolution => ({
+      interruptionId: resolution.interruptionId,
+      value: toJsonPayload(
+        resolution.value,
+        normalizedOptions.maxBindingOutputBytes,
+        `Resolution "${resolution.interruptionId}"`,
+      ),
+    }));
+    if (input.abortSignal?.aborted) {
+      throw new RunAbortedError();
+    }
+    const workerOptions = {
+      ...normalizedOptions,
+      timeoutMs: Math.max(1, deadlineMs - Date.now()),
+    };
     const run = startWorkerRun({
       ...input,
       ...(continuationState === undefined ? {} : { continuationState }),
@@ -349,7 +354,7 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
       originalSource: input.source,
       resolutions: normalizedResolutions,
       scopeHash,
-      source: transformSource(input.source),
+      source: transformedSource,
       timeoutErrorMs: normalizedOptions.timeoutMs,
     });
     return await run.result;
@@ -1132,6 +1137,7 @@ function startWorkerRun({
 function createContinuationScopeHash(
   input: InternalRunInput,
   options: NormalizedRunOptions,
+  transformedSource: string,
 ): string {
   const continuationContext = normalizeJsonPayload(
     input.continuationContext,
@@ -1154,7 +1160,7 @@ function createContinuationScopeHash(
           bindingManifest,
           continuationContext,
           transformedSourceHash: createHash('sha256')
-            .update(transformSource(input.source))
+            .update(transformedSource)
             .digest('hex'),
         },
         Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
## Why

Source transformation happened before the concurrency limit, so rejected requests could still block the host event loop

An attacker could repeatedly submit expensive source while all workers were occupied, consuming host CPU and delaying unrelated requests

## What

- Reserve a concurrency slot before validation/transformation. and then release it with try/finally, including on preprocessing failure
- We also fixed duplicate parsing. Previously, the transformed source was generated once for the continuation hash and again for worker execution. Now it is stored in transformedSource and reused for both purposes