### PR TITLE
feat: use original source hash for continuation

### DIFF
--- a/packages/run/src/runtime/manager-admission.test.ts
+++ b/packages/run/src/runtime/manager-admission.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { run, setMaxWorkers } from '../index.js';
+import { getBindingContext, run, setMaxWorkers } from '../index.js';
 import { createPromiseWithResolvers } from '../utils/promise-with-resolvers.js';
 import * as sourceCache from '../utils/source-cache.js';
+
+const originalTransformSource = sourceCache.transformSource;
 
 describe('run admission and source transformation', () => {
   const transformSourceSpy = vi.spyOn(sourceCache, 'transformSource');
@@ -64,5 +66,43 @@ describe('run admission and source transformation', () => {
       status: 'completed',
       value: 2,
     });
+  });
+
+  it('resumes when TypeScript transform output changes between hosts', async () => {
+    const source =
+      'const approved: boolean = await tools.approve(); return approved;';
+    const bindings = {
+      tools: {
+        approve: () => {
+          const context = getBindingContext();
+          if (context.resume === undefined) {
+            context.interrupt({ kind: 'approval' });
+          }
+          return context.resume?.resolution;
+        },
+      },
+    };
+    const interrupted = await run({ bindings, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected interruption.');
+    }
+
+    transformSourceSpy.mockImplementationOnce(
+      value => `${originalTransformSource(value)}\n`,
+    );
+
+    await expect(
+      run({
+        bindings,
+        continuation: interrupted.continuation,
+        resolutions: [
+          {
+            interruptionId: interrupted.interruptions[0]?.id ?? '',
+            value: true,
+          },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: true });
   });
 });

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -319,11 +319,7 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
   try {
     assertSourceSize(input.source, normalizedOptions.maxSourceBytes);
     const transformedSource = transformSource(input.source);
-    const scopeHash = createContinuationScopeHash(
-      input,
-      normalizedOptions,
-      transformedSource,
-    );
+    const scopeHash = createContinuationScopeHash(input, normalizedOptions);
     const continuationState = await readContinuation(
       input,
       normalizedOptions,
@@ -1137,7 +1133,6 @@ function startWorkerRun({
 function createContinuationScopeHash(
   input: InternalRunInput,
   options: NormalizedRunOptions,
-  transformedSource: string,
 ): string {
   const continuationContext = normalizeJsonPayload(
     input.continuationContext,
@@ -1159,8 +1154,11 @@ function createContinuationScopeHash(
           audience: input.continuationAudience,
           bindingManifest,
           continuationContext,
+          // Keep the existing key so continuations whose transform was an
+          // identity remain valid across this change. The original source is
+          // stable across hosts and is also exact-matched during validation.
           transformedSourceHash: createHash('sha256')
-            .update(transformedSource)
+            .update(input.source)
             .digest('hex'),
         },
         Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
## Why

continuations could fail to resume when node produced different transformed typescript bytes

## What

Scope hashes now use the original source, so transform-version differences no longer invalidate continuations. Source changes remain rejected