### PR TITLE
fix: harden binding namespace validation

### DIFF
--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -96,6 +96,8 @@ const RESERVED_BINDING_NAMES = new Set([
   'then',
 ]);
 
+const BINDING_IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/u;
+
 const validateBindings = (bindings: Bindings): void => {
   for (const [namespace, group] of Object.entries(bindings)) {
     if (!Object.hasOwn(bindings, namespace)) {
@@ -103,11 +105,15 @@ const validateBindings = (bindings: Bindings): void => {
     }
     if (
       Buffer.byteLength(namespace) > 512 ||
-      !/^[A-Za-z_$][\w$]*$/u.test(namespace)
+      !BINDING_IDENTIFIER_PATTERN.test(namespace)
     ) {
       throw new TypeError(`Invalid binding namespace: ${namespace}`);
     }
-    if (RESERVED_GLOBALS.has(namespace) || namespace.startsWith('__run')) {
+    if (
+      RESERVED_GLOBALS.has(namespace) ||
+      RESERVED_BINDING_NAMES.has(namespace) ||
+      namespace.startsWith('__run')
+    ) {
       throw new TypeError(`Reserved binding namespace: ${namespace}`);
     }
     if (typeof group !== 'object' || group === null || Array.isArray(group)) {
@@ -120,9 +126,8 @@ const validateBindings = (bindings: Bindings): void => {
         continue;
       }
       if (
-        name.length === 0 ||
+        !BINDING_IDENTIFIER_PATTERN.test(name) ||
         Buffer.byteLength(`${namespace}.${name}`) > 1024 ||
-        name.includes('.') ||
         RESERVED_BINDING_NAMES.has(name) ||
         name.startsWith('__run')
       ) {

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -246,6 +246,18 @@ describe('guest sandbox hardening', () => {
     ).rejects.toThrow('Reserved binding namespace');
   });
 
+  it.each(['__proto__', 'constructor', 'prototype', 'then'])(
+    'rejects the reserved binding namespace %s',
+    async namespace => {
+      await expect(
+        run({
+          bindings: { [namespace]: { call: () => true } },
+          source: 'return 1;',
+        }),
+      ).rejects.toThrow(`Reserved binding namespace: ${namespace}`);
+    },
+  );
+
   it.each(['__proto__', 'constructor', 'prototype', 'then', '__runBridge'])(
     'rejects the dangerous declared binding name %s',
     async name => {
@@ -257,6 +269,34 @@ describe('guest sandbox hardening', () => {
       await expect(
         run({ bindings: { tools: group }, source: 'return 1;' }),
       ).rejects.toThrow('Invalid binding name');
+    },
+  );
+
+  it.each([
+    '',
+    '1call',
+    'call-name',
+    'call.name',
+    'call name',
+    'call\nname',
+    '\0call',
+    'café',
+    '🔧',
+  ])('rejects the invalid binding name %j', async name => {
+    await expect(
+      run({
+        bindings: { tools: { [name]: () => true } },
+        source: 'return 1;',
+      }),
+    ).rejects.toThrow('Invalid binding name');
+  });
+
+  it.each(['call', '_call', '$call', 'call2'])(
+    'accepts the valid binding name %s',
+    async name => {
+      await expectValue(`return await tools[${JSON.stringify(name)}]();`, {
+        tools: { [name]: () => true },
+      }).resolves.toBe(true);
     },
   );
 });


### PR DESCRIPTION
## Before

Reserved names (`then`, `constructor` etc) were rejected only as function names, not namespaces.
Function names accepted unsafe characters such as whitespace, control characters, Unicode, and hyphens

## Fix

Applied the reserved-name denylist to namespaces too