### PR TITLE
fix: reject uppercase seeds when validating

### DIFF
--- a/packages/run/src/continuation-validation-hardening.test.ts
+++ b/packages/run/src/continuation-validation-hardening.test.ts
@@ -90,6 +90,30 @@ describe('continuation state validation hardening', () => {
     }
   });
 
+  it('rejects uppercase hex random seeds at the validation boundary', () => {
+    const lowercaseSeed = validState();
+    lowercaseSeed.determinism.randomSeed = 'ab'.repeat(16);
+    expect(() =>
+      assertContinuationState(
+        lowercaseSeed,
+        source,
+        scopeHash,
+        normalizeOptions(),
+      ),
+    ).not.toThrow();
+
+    const uppercaseSeed = validState();
+    uppercaseSeed.determinism.randomSeed = 'AB'.repeat(16);
+    expect(() =>
+      assertContinuationState(
+        uppercaseSeed,
+        source,
+        scopeHash,
+        normalizeOptions(),
+      ),
+    ).toThrowError('Continuation determinism state is invalid.');
+  });
+
   it('rejects sparse arrays, cycles, accessors, and non-plain objects', () => {
     const sparse = validState();
     sparse.ledger = [];

--- a/packages/run/src/continuation-validation.ts
+++ b/packages/run/src/continuation-validation.ts
@@ -267,7 +267,7 @@ const hasValidDeterminism = (value: unknown): boolean =>
   Number.isSafeInteger(value.dateNowMs) &&
   (value.dateNowMs as number) >= 0 &&
   typeof value.randomSeed === 'string' &&
-  /^[0-9a-f]{32}$/iu.test(value.randomSeed);
+  /^[0-9a-f]{32}$/u.test(value.randomSeed);
 
 const addSettledOrder = (orders: Set<number>, order: number): void => {
   if (orders.has(order)) {


### PR DESCRIPTION
## Before

uppercase hex randomSeed values passed host continuation validation, then failed later in worker validation with RunProtocolError

## After

host validation immediately rejects uppercase seeds