### PR TITLE
fix: cap max resource limit for integer

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -239,10 +239,12 @@ invocation and is available through `getBindingContext()`.
 | Concurrent bridge requests             |         32 |
 | Continuation                           |     32 MiB |
 
-All limits must be positive integers. The process-wide worker cap rejects
-excess invocations with `RunConcurrencyError`; `run` does not retain an
-unbounded queue. The cap and worker pool are shared by every runner and by
-packages such as `@ai-sdk/code-mode` in the same process.
+All limits must be positive integers no greater than `2_147_483_647`. Values
+above this ceiling are rejected instead of being passed to platform APIs that
+cannot represent them safely. The process-wide worker cap rejects excess
+invocations with `RunConcurrencyError`; `run` does not retain an unbounded
+queue. The cap and worker pool are shared by every runner and by packages such
+as `@ai-sdk/code-mode` in the same process.
 
 ## Continuations
 

--- a/packages/run/src/resource-hardening.test.ts
+++ b/packages/run/src/resource-hardening.test.ts
@@ -8,9 +8,11 @@ import { getBindingContext } from './binding-context.js';
 import { run } from './run.js';
 import { getRuntimeDiagnostics } from './runtime/manager.js';
 import type { RunLimits } from './types.js';
+import { normalizeOptions } from './utils/options.js';
 import { createPromiseWithResolvers } from './utils/promise-with-resolvers.js';
 
 const deferred = createPromiseWithResolvers;
+const MAX_LIMIT_VALUE = 2_147_483_647;
 
 const LIMIT_NAMES = [
   'timeoutMs',
@@ -40,6 +42,28 @@ describe('resource and lifecycle hardening', () => {
       }
     },
   );
+
+  it.each(LIMIT_NAMES)(
+    'rejects %s values above the supported ceiling before worker creation',
+    async name => {
+      await expect(
+        run({
+          limits: { [name]: MAX_LIMIT_VALUE + 1 },
+          source: 'return 1;',
+        }),
+      ).rejects.toThrow(`${name} must be at most ${MAX_LIMIT_VALUE}`);
+    },
+  );
+
+  it('accepts the supported ceiling for every normalized limit', () => {
+    const limits = Object.fromEntries(
+      LIMIT_NAMES.map(name => [name, MAX_LIMIT_VALUE]),
+    ) as RunLimits;
+
+    expect(Object.values(normalizeOptions(limits))).toEqual(
+      Array.from({ length: LIMIT_NAMES.length }, () => MAX_LIMIT_VALUE),
+    );
+  });
 
   it('terminates CPU, recursion, allocation, and microtask storms', async () => {
     const cases: { source: string; limits?: RunLimits }[] = [

--- a/packages/run/src/utils/options.ts
+++ b/packages/run/src/utils/options.ts
@@ -11,15 +11,20 @@ const DEFAULT_MAX_TOOL_OUTPUT_BYTES = 4 * 1024 * 1024;
 const DEFAULT_MAX_BRIDGE_REQUESTS = 256;
 const DEFAULT_MAX_IN_FLIGHT_BRIDGE_REQUESTS = 32;
 const DEFAULT_MAX_CONTINUATION_BYTES = 32 * 1024 * 1024;
+const MAX_LIMIT_VALUE = 2_147_483_647;
 
 const positiveInteger = (
   value: number | undefined,
   fallback: number,
   path: string,
+  max = MAX_LIMIT_VALUE,
 ): number => {
   const resolved = value ?? fallback;
   if (!Number.isInteger(resolved) || resolved <= 0) {
     throw new TypeError(`${path} must be a positive integer.`);
+  }
+  if (resolved > max) {
+    throw new TypeError(`${path} must be at most ${max}.`);
   }
   return resolved;
 };


### PR DESCRIPTION
## Before

- any positive integer was accepted, including huge values
- `timeoutMs: 2_147_483_648` overflowed Node’s timer and became ~1 ms, causing an immediate timeout

## After:

- every limit must be between 1 and 2_147_483_647
- oversized values fail immediately with an explicit type error