### PR TITLE
fix: avoid memory overcommit during concurrent bursts

### DIFF
--- a/packages/run/src/runtime/manager-admission.test.ts
+++ b/packages/run/src/runtime/manager-admission.test.ts
@@ -53,6 +53,45 @@ describe('run admission and source transformation', () => {
     }
   });
 
+  it('reserves memory capacity before a concurrent worker allocates', async () => {
+    const estimatedWorkerBytes = (64 + 48) * 1024 * 1024;
+    const availableMemorySpy = vi
+      .spyOn(process, 'availableMemory')
+      .mockReturnValue(estimatedWorkerBytes);
+    const bindingStarted = createPromiseWithResolvers<null>();
+    const releaseBinding = createPromiseWithResolvers<null>();
+    const activeRun = run({
+      bindings: {
+        tools: {
+          wait: async () => {
+            bindingStarted.resolve(null);
+            await releaseBinding.promise;
+          },
+        },
+      },
+      source: 'return await tools.wait();',
+    });
+
+    try {
+      await bindingStarted.promise;
+
+      await expect(run({ source: 'return 2;' })).rejects.toMatchObject({
+        code: 'RUN_CONCURRENCY_LIMIT',
+      });
+      releaseBinding.resolve(null);
+      await activeRun;
+
+      await expect(run({ source: 'return 3;' })).resolves.toEqual({
+        status: 'completed',
+        value: 3,
+      });
+    } finally {
+      releaseBinding.resolve(null);
+      await activeRun.catch(() => {});
+      availableMemorySpy.mockRestore();
+    }
+  });
+
   it('releases the admission slot when source transformation fails', async () => {
     setMaxWorkers(1);
     transformSourceSpy.mockImplementationOnce(() => {

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -45,7 +45,11 @@ import type {
   RunResult,
   ContinuationOperationContext,
 } from '../types.js';
-import { getMaxWorkers } from './max-workers.js';
+import {
+  getMaxWorkers,
+  releaseWorkerMemory,
+  reserveWorkerMemory,
+} from './max-workers.js';
 import type {
   MainToWorkerMessage,
   WorkerBridgeResponse,
@@ -309,11 +313,16 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
     throw new RunAbortedError();
   }
   const maxWorkers = getMaxWorkers({
-    activeWorkers: activeInvocations,
     memoryLimitBytes: normalizedOptions.memoryLimitBytes,
   });
   if (activeInvocations >= maxWorkers) {
     throw new RunConcurrencyError(maxWorkers);
+  }
+  const reservedMemoryBytes = reserveWorkerMemory(
+    normalizedOptions.memoryLimitBytes,
+  );
+  if (reservedMemoryBytes === undefined) {
+    throw new RunConcurrencyError(Math.max(1, activeInvocations));
   }
   activeInvocations += 1;
   try {
@@ -355,7 +364,10 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
     });
     return await run.result;
   } finally {
-    releaseInvocationSlot(normalizedOptions.memoryLimitBytes);
+    releaseInvocationSlot(
+      normalizedOptions.memoryLimitBytes,
+      reservedMemoryBytes,
+    );
   }
 }
 
@@ -1246,10 +1258,13 @@ function trimIdleWorkers(maxIdleWorkers: number): void {
   }
 }
 
-function releaseInvocationSlot(memoryLimitBytes: number): void {
+function releaseInvocationSlot(
+  memoryLimitBytes: number,
+  reservedMemoryBytes: number,
+): void {
   activeInvocations = Math.max(0, activeInvocations - 1);
+  releaseWorkerMemory(reservedMemoryBytes);
   const maxWorkers = getMaxWorkers({
-    activeWorkers: activeInvocations,
     memoryLimitBytes,
   });
   trimIdleWorkers(Math.max(0, maxWorkers - activeInvocations));

--- a/packages/run/src/runtime/max-workers.test.ts
+++ b/packages/run/src/runtime/max-workers.test.ts
@@ -1,6 +1,11 @@
 import os from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getMaxWorkers, setMaxWorkers } from './max-workers.js';
+import {
+  getMaxWorkers,
+  releaseWorkerMemory,
+  reserveWorkerMemory,
+  setMaxWorkers,
+} from './max-workers.js';
 
 describe('max workers', () => {
   afterEach(() => {
@@ -10,7 +15,7 @@ describe('max workers', () => {
 
   it('honors an explicit process-wide cap', () => {
     setMaxWorkers(7);
-    expect(getMaxWorkers({ activeWorkers: 0, memoryLimitBytes: 1 })).toBe(7);
+    expect(getMaxWorkers({ memoryLimitBytes: 1 })).toBe(7);
   });
 
   it('admits at least one worker and caps the memory heuristic at 32', () => {
@@ -18,7 +23,6 @@ describe('max workers', () => {
     vi.spyOn(process, 'availableMemory').mockReturnValue(workerBytes - 1);
     expect(
       getMaxWorkers({
-        activeWorkers: 0,
         memoryLimitBytes: 16 * 1024 * 1024,
       }),
     ).toBe(1);
@@ -26,7 +30,6 @@ describe('max workers', () => {
     vi.mocked(process.availableMemory).mockReturnValue(workerBytes * 100);
     expect(
       getMaxWorkers({
-        activeWorkers: 0,
         memoryLimitBytes: 16 * 1024 * 1024,
       }),
     ).toBe(32);
@@ -49,12 +52,37 @@ describe('max workers', () => {
       });
       expect(
         getMaxWorkers({
-          activeWorkers: 0,
           memoryLimitBytes: 16 * 1024 * 1024,
         }),
       ).toBe(2);
     } finally {
       Object.defineProperty(process, 'availableMemory', descriptor);
+    }
+  });
+
+  it('reserves mixed worker sizes against one memory snapshot', () => {
+    const mib = 1024 * 1024;
+    vi.spyOn(process, 'availableMemory').mockReturnValue(200 * mib);
+    const largeReservation = reserveWorkerMemory(128 * mib);
+    if (largeReservation === undefined) {
+      throw new Error('Expected the first worker reservation to succeed.');
+    }
+
+    try {
+      expect(largeReservation).toBe(176 * mib);
+      expect(reserveWorkerMemory(16 * mib)).toBeUndefined();
+    } finally {
+      releaseWorkerMemory(largeReservation);
+    }
+
+    const smallReservation = reserveWorkerMemory(16 * mib);
+    if (smallReservation === undefined) {
+      throw new Error('Expected released capacity to be reusable.');
+    }
+    try {
+      expect(smallReservation).toBe(64 * mib);
+    } finally {
+      releaseWorkerMemory(smallReservation);
     }
   });
 

--- a/packages/run/src/runtime/max-workers.ts
+++ b/packages/run/src/runtime/max-workers.ts
@@ -4,6 +4,8 @@ const DEFAULT_MAX_WORKERS_CAP = 32;
 const DEFAULT_WORKER_OVERHEAD_BYTES = 48 * 1024 * 1024;
 
 let configuredMaxWorkers: number | undefined;
+let memoryBudgetBytes: number | undefined;
+let reservedMemoryBytes = 0;
 
 const availableMemory = (): number => {
   const processWithAvailableMemory = process as typeof process & {
@@ -15,6 +17,9 @@ const availableMemory = (): number => {
       : os.freemem();
   return Number.isFinite(bytes) && bytes > 0 ? bytes : 0;
 };
+
+const estimatedWorkerBytes = (memoryLimitBytes: number): number =>
+  memoryLimitBytes + DEFAULT_WORKER_OVERHEAD_BYTES;
 
 /**
  * Sets the process-global maximum number of active run workers.
@@ -43,22 +48,54 @@ export const setMaxWorkers = (maxWorkers?: number): void => {
  */
 export const getMaxWorkers = ({
   memoryLimitBytes,
-  activeWorkers,
 }: {
   memoryLimitBytes: number;
-  activeWorkers: number;
 }): number => {
   if (configuredMaxWorkers !== undefined) {
     return configuredMaxWorkers;
   }
 
-  const estimatedBytesPerWorker =
-    memoryLimitBytes + DEFAULT_WORKER_OVERHEAD_BYTES;
-  const additionalWorkers = Math.floor(
-    availableMemory() / estimatedBytesPerWorker,
+  const memoryBasedMaxWorkers = Math.floor(
+    availableMemory() / estimatedWorkerBytes(memoryLimitBytes),
   );
-  return Math.max(
-    1,
-    Math.min(DEFAULT_MAX_WORKERS_CAP, activeWorkers + additionalWorkers),
-  );
+  return Math.max(1, Math.min(DEFAULT_MAX_WORKERS_CAP, memoryBasedMaxWorkers));
+};
+
+/**
+ * Reserves the estimated memory for an invocation before it can allocate.
+ *
+ * Returns the reservation size, zero when an explicit count cap is configured,
+ * or `undefined` when the dynamic memory budget is exhausted.
+ *
+ * @internal
+ */
+export const reserveWorkerMemory = (
+  memoryLimitBytes: number,
+): number | undefined => {
+  if (configuredMaxWorkers !== undefined) {
+    return 0;
+  }
+
+  const reservationBytes = estimatedWorkerBytes(memoryLimitBytes);
+  memoryBudgetBytes ??= Math.max(reservationBytes, availableMemory());
+  if (reservedMemoryBytes + reservationBytes > memoryBudgetBytes) {
+    return undefined;
+  }
+  reservedMemoryBytes += reservationBytes;
+  return reservationBytes;
+};
+
+/**
+ * Releases a reservation returned by `reserveWorkerMemory`.
+ *
+ * @internal
+ */
+export const releaseWorkerMemory = (reservationBytes: number): void => {
+  if (reservationBytes === 0) {
+    return;
+  }
+  reservedMemoryBytes = Math.max(0, reservedMemoryBytes - reservationBytes);
+  if (reservedMemoryBytes === 0) {
+    memoryBudgetBytes = undefined;
+  }
 };


### PR DESCRIPTION
before: each active worker increased the calculated limit, so bursts could admit workers up to the hard cap of 32 without reserving memory.

After: the limit is absolute, and each admission reserves its estimated memory. New runs are rejected when the worker-count or memory budget is exhausted; capacity is restored when a run finishes