### PR TITLE
fix: clean up stored continuations after aborted writes

### DIFF
--- a/packages/run/src/continuation-codec.test.ts
+++ b/packages/run/src/continuation-codec.test.ts
@@ -359,4 +359,66 @@ describe('continuation codecs', () => {
     });
     await expect(codec.encode(state)).rejects.toThrow('storage unavailable');
   });
+
+  it('removes a stored continuation when persistence finishes after an abort', async () => {
+    const { storage, values } = createMemoryStorage();
+    const setStarted = createPromiseWithResolvers<null>();
+    const finishSet = createPromiseWithResolvers<null>();
+    const codec = createStoredContinuationCodec({
+      storage: {
+        ...storage,
+        async set(key, value) {
+          values.set(key, value);
+          setStarted.resolve(null);
+          await finishSet.promise;
+        },
+      },
+    });
+    const abortController = new AbortController();
+    const encoding = codec.encode(state, {
+      abortSignal: abortController.signal,
+      deadlineMs: Date.now() + 1000,
+    });
+
+    await setStarted.promise;
+    abortController.abort();
+    finishSet.resolve(null);
+
+    await expect(encoding).rejects.toMatchObject({ name: 'AbortError' });
+    expect(values.size).toBe(0);
+  });
+
+  it('preserves the abort when stored continuation cleanup fails', async () => {
+    const setStarted = createPromiseWithResolvers<null>();
+    const finishSet = createPromiseWithResolvers<null>();
+    const abortReason = new Error('operation cancelled');
+    const codec = createStoredContinuationCodec({
+      storage: {
+        acquire() {
+          throw new Error('cleanup unavailable');
+        },
+        consume() {
+          throw new Error('not used');
+        },
+        release() {
+          throw new Error('not used');
+        },
+        async set() {
+          setStarted.resolve(null);
+          await finishSet.promise;
+        },
+      },
+    });
+    const abortController = new AbortController();
+    const encoding = codec.encode(state, {
+      abortSignal: abortController.signal,
+      deadlineMs: Date.now() + 1000,
+    });
+
+    await setStarted.promise;
+    abortController.abort(abortReason);
+    finishSet.resolve(null);
+
+    await expect(encoding).rejects.toBe(abortReason);
+  });
 });

--- a/packages/run/src/continuation-codec.ts
+++ b/packages/run/src/continuation-codec.ts
@@ -381,6 +381,23 @@ export const createStoredContinuationCodec = ({
       state: decodedState,
     };
   };
+  const discardStoredContinuation = async (key: string): Promise<void> => {
+    const claimId = randomBytes(32).toString('base64url');
+    const stored = await storage.acquire(key, claimId);
+    if (stored === undefined) {
+      return;
+    }
+    try {
+      await storage.consume(key, claimId);
+    } catch (error) {
+      try {
+        await storage.release(key, claimId);
+      } catch {
+        // Claims expire, so preserve the cleanup failure from consume.
+      }
+      throw error;
+    }
+  };
   return {
     async decode(key, context) {
       const transaction = await decodeTransaction(key, context);
@@ -399,7 +416,16 @@ export const createStoredContinuationCodec = ({
         },
         context,
       );
-      throwIfOperationAborted(context);
+      try {
+        throwIfOperationAborted(context);
+      } catch (error) {
+        try {
+          await discardStoredContinuation(key);
+        } catch {
+          // Preserve the abort; stored continuations expire if cleanup fails.
+        }
+        throw error;
+      }
       return key;
     },
   };


### PR DESCRIPTION
## Why

before, `encode()` persisted a continuation, then threw if cancellation occurred during `storage.set()`. the generated key was never returned, leaving the stored record unreachable until TTL (time to live) expiry

## What

now we reclaim and consumes the newly stored continuation before rethrowing the original abort