### PR TITLE
fix: prevent prototype-chain lookups when reviving errors

### DIFF
--- a/packages/run/src/serde-roundtrip.test.ts
+++ b/packages/run/src/serde-roundtrip.test.ts
@@ -97,6 +97,55 @@ describe('run-js-v1 serialization', () => {
     expect(value.error.stack).not.toContain('run.js');
   });
 
+  it.each(['constructor', 'toString', '__proto__'])(
+    'safely revives an Error with inherited object name %s',
+    async name => {
+      const result = await run({
+        source: `
+          const error = new Error('guest message');
+          error.name = ${JSON.stringify(name)};
+          return error;
+        `,
+      });
+
+      expect(result.status).toBe('completed');
+      if (result.status !== 'completed') {
+        return;
+      }
+      expect(result.value).toBeInstanceOf(Error);
+      expect(result.value).toMatchObject({
+        message: 'guest message',
+        name,
+      });
+    },
+  );
+
+  it('passes an Error named constructor to host bindings as an Error', async () => {
+    const inspect = vi.fn((input: unknown) => {
+      expect(input).toBeInstanceOf(Error);
+      expect(input).toMatchObject({
+        message: 'guest message',
+        name: 'constructor',
+      });
+      return input instanceof Error;
+    });
+
+    const result = await run({
+      bindings: { tools: { inspect } },
+      source: `
+        const error = new Error('guest message');
+        error.name = 'constructor';
+        return await tools.inspect(error);
+      `,
+    });
+
+    expect(inspect).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      status: 'completed',
+      value: true,
+    });
+  });
+
   it('uses the same rich codec in both binding directions', async () => {
     const execute = vi.fn((input: ExchangeInput) => {
       expect(input.self).toBe(input);

--- a/packages/run/src/utils/serde.ts
+++ b/packages/run/src/utils/serde.ts
@@ -40,6 +40,19 @@ const runReducers = {
   },
 };
 
+const errorConstructors = Object.assign(
+  Object.create(null) as Record<string, ErrorConstructor>,
+  {
+    Error,
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError,
+  },
+);
+
 const reviveOwnProtoObject = (value: unknown): object => {
   if (
     !Array.isArray(value) ||
@@ -102,19 +115,17 @@ const reviveError = (value: unknown): Error => {
   const options = record.hasCause ? { cause: record.cause } : undefined;
   let error: Error;
   if (record.errors === undefined) {
-    const constructors: Record<string, ErrorConstructor> = {
-      Error,
-      EvalError,
-      RangeError,
-      ReferenceError,
-      SyntaxError,
-      TypeError,
-      URIError,
-    };
-    const Constructor = constructors[record.name] ?? Error;
+    const candidate = errorConstructors[record.name];
+    const Constructor =
+      Object.hasOwn(errorConstructors, record.name) && candidate !== undefined
+        ? candidate
+        : Error;
     error = new Constructor(record.message, options);
   } else {
     error = new AggregateError(record.errors, record.message, options);
+  }
+  if (!(error instanceof Error)) {
+    throw new TypeError('Serialized Error value could not be revived.');
   }
   error.name = record.name;
   return error;


### PR DESCRIPTION
Before: 

a guest-returned error, binding argument or replayed value named "constructor" could cross the sandbox boundary as a boxed string while TypeScript claimed it was an `Error`

After: 

only explicitly supported own constructor names are dispatched; every custom or inherited name becomes a normal `Error` whose custom name remains preserved