### PR TITLE
fix: prevent worker crashes from unhandled message failures

### DIFF
--- a/packages/run/src/runtime/manager-protocol.test.ts
+++ b/packages/run/src/runtime/manager-protocol.test.ts
@@ -1,6 +1,8 @@
 import type { Worker } from 'node:worker_threads';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { run } from '../run.js';
+import { getBindingContext } from '../binding-context.js';
+import { createRunner, run } from '../run.js';
+import { createPromiseWithResolvers } from '../utils/promise-with-resolvers.js';
 import { setRuntimeWorkerFactoryForTest } from './manager.js';
 
 type WorkerListener = (value: unknown) => void;
@@ -194,4 +196,85 @@ describe('manager protocol state machine', () => {
       await expectCleanRun();
     },
   );
+
+  it('preserves an encoded interruption when the worker fails after its result', async () => {
+    const encodeStarted = createPromiseWithResolvers<null>();
+    const finishEncode = createPromiseWithResolvers<null>();
+    let emitWorker: WorkerEmit | undefined;
+    const postedMessages: unknown[] = [];
+    setRuntimeWorkerFactoryForTest(() =>
+      createWorkerDouble({
+        postMessage: (value, emit) => {
+          emitWorker = emit;
+          postedMessages.push(value);
+          const message = value as {
+            invocationId?: string;
+            type?: string;
+          };
+          if (message.type !== 'run' || message.invocationId === undefined) {
+            return;
+          }
+          queueMicrotask(() => {
+            emit('message', {
+              bindingName: 'tools.pause',
+              inputJson: '[[]]',
+              invocationId: message.invocationId,
+              requestId: `${message.invocationId}:bridge-1`,
+              type: 'binding-request',
+            });
+            emit('message', {
+              invocationId: message.invocationId,
+              requestCount: 1,
+              type: 'bridge-idle',
+            });
+          });
+        },
+      }),
+    );
+    const runner = createRunner({
+      continuationCodec: {
+        decode: () => {
+          throw new Error('not used');
+        },
+        async encode() {
+          encodeStarted.resolve(null);
+          await finishEncode.promise;
+          return 'encoded-interruption';
+        },
+      },
+    });
+
+    const result = runner.run({
+      bindings: {
+        tools: {
+          pause: () => getBindingContext().interrupt({ kind: 'pause' }),
+        },
+      },
+      source: 'return await tools.pause();',
+    });
+    await encodeStarted.promise;
+    const { invocationId } = postedMessages.find(
+      value => (value as { type?: string }).type === 'run',
+    ) as { invocationId: string };
+    emitWorker?.('message', {
+      invocationId,
+      success: true,
+      type: 'result',
+      valueJson: '[null]',
+    });
+    finishEncode.resolve(null);
+    const settlementTurn = createPromiseWithResolvers<null>();
+    setImmediate(() => settlementTurn.resolve(null));
+    await settlementTurn.promise;
+    expect(postedMessages).not.toContainEqual({
+      invocationId,
+      type: 'cancel',
+    });
+    emitWorker?.('error', new Error('late worker failure'));
+
+    await expect(result).resolves.toMatchObject({
+      continuation: 'encoded-interruption',
+      status: 'interrupted',
+    });
+  });
 });

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -633,6 +633,14 @@ function startWorkerRun({
   });
 
   const handleWorkerError = (error: Error) => {
+    if (interruptedResultPending !== undefined && resultMessage !== undefined) {
+      terminalReached = true;
+      const interruptedResult = interruptedResultPending;
+      runInBackground(
+        settleAfterWorkerCleanup(false, () => resolveResult(interruptedResult)),
+      );
+      return;
+    }
     failTerminal(error);
   };
   const onError = bindInvocationContext(handleWorkerError);
@@ -1025,8 +1033,10 @@ function startWorkerRun({
         finalizeInterruptedResult(interruptedResult);
         return;
       }
-      // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
-      worker.postMessage({ invocationId, type: 'cancel' });
+      if (resultMessage === undefined) {
+        // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
+        worker.postMessage({ invocationId, type: 'cancel' });
+      }
     } catch (error) {
       failTerminal(error);
     }

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -1,0 +1,127 @@
+import { Buffer } from 'node:buffer';
+import { Worker } from 'node:worker_threads';
+import { expect, it } from 'vitest';
+import { createPromiseWithResolvers } from '../utils/promise-with-resolvers.js';
+import type { MainToWorkerMessage } from './protocol.js';
+import { INLINE_RUN_WORKER_SOURCE } from './worker-source.js';
+
+const createRunMessage = (
+  invocationId: string,
+  source: string,
+): MainToWorkerMessage => ({
+  bindingNamespaces: ['tools'],
+  determinism: {
+    dateNowMs: 1_700_000_000_000,
+    randomSeed: '00000000000000000000000000000001',
+  },
+  invocationId,
+  options: {
+    executionTimeoutMs: 950,
+    maxBindingInputBytes: 1024 * 1024,
+    maxConsoleOutputBytes: 64 * 1024,
+    maxResultBytes: 1024 * 1024,
+    maxStackSizeBytes: 2 * 1024 * 1024,
+    memoryLimitBytes: 64 * 1024 * 1024,
+    timeoutMs: 1000,
+  },
+  source,
+  type: 'run',
+});
+
+it('reports message failures and ignores late messages without crashing', async () => {
+  const workerUrl = new URL(
+    `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
+  );
+  const worker = new Worker(workerUrl, { execArgv: [] });
+  const postToWorker = (message: MainToWorkerMessage): void => {
+    // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
+    worker.postMessage(message);
+  };
+  const results: {
+    error?: { message?: string };
+    invocationId: string;
+    success: boolean;
+    type: 'result';
+    valueJson?: string;
+  }[] = [];
+
+  try {
+    const completed = createPromiseWithResolvers<null>();
+    worker.on('error', completed.reject);
+    worker.on('message', (value: unknown) => {
+      const message = value as {
+        invocationId?: string;
+        requestId?: string;
+        type?: string;
+      };
+      if (
+        message.type === 'binding-request' &&
+        message.invocationId !== undefined &&
+        message.requestId !== undefined
+      ) {
+        postToWorker({
+          dateNowMs: 1_700_000_000_001,
+          invocationId: message.invocationId,
+          requestId: message.requestId,
+          success: true,
+          type: 'bridge-response',
+          valueJson: '[null]',
+        });
+        return;
+      }
+      if (message.type === 'result') {
+        results.push(value as (typeof results)[number]);
+        return;
+      }
+      if (message.type !== 'ready') {
+        return;
+      }
+      if (message.invocationId === 'run-failure') {
+        postToWorker({
+          invocationId: 'run-failure',
+          type: 'cancel',
+        });
+        postToWorker({
+          dateNowMs: 1_700_000_000_002,
+          invocationId: 'run-failure',
+          requestId: 'run-failure:bridge-1',
+          success: true,
+          type: 'bridge-response',
+          valueJson: '[null]',
+        });
+        postToWorker(createRunMessage('run-next', 'return 42;'));
+        return;
+      }
+      if (message.invocationId === 'run-next') {
+        completed.resolve(null);
+      }
+    });
+    postToWorker(
+      createRunMessage(
+        'run-failure',
+        `
+          globalThis.Math = {
+            trunc() {
+              throw new Error('reset failed');
+            },
+          };
+          return await tools.echo();
+        `,
+      ),
+    );
+    await completed.promise;
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      error: { message: 'reset failed' },
+      invocationId: 'run-failure',
+      success: false,
+    });
+    expect(results[1]).toMatchObject({
+      invocationId: 'run-next',
+      success: true,
+    });
+  } finally {
+    await worker.terminate();
+  }
+});

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -42,10 +42,25 @@ let bridgeRequestCounter = 0;
 let bridgeIdleGeneration = 0;
 let embeddedQuickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
 let activeCancellation:
-  | { invocationId: string; cancel: () => void }
+  | {
+      invocationId: string;
+      cancel: () => void;
+      fail: (error: unknown) => void;
+    }
+  | undefined;
+let pendingInvocationFailure:
+  | { invocationId: string; error: unknown }
   | undefined;
 
 parentPort.on('message', async (value: unknown) => {
+  try {
+    await handleMainMessage(value);
+  } catch (error) {
+    handleMainMessageFailure(error);
+  }
+});
+
+async function handleMainMessage(value: unknown): Promise<void> {
   assertMainToWorkerMessage(value);
   const message = value;
   if (message.type === 'cancel') {
@@ -53,9 +68,7 @@ parentPort.on('message', async (value: unknown) => {
       activeInvocationId !== message.invocationId ||
       activeCancellation?.invocationId !== message.invocationId
     ) {
-      throw new RunProtocolError(
-        `Worker received cancellation for inactive invocation ${message.invocationId}.`,
-      );
+      return;
     }
     activeCancellation.cancel();
     return;
@@ -63,13 +76,7 @@ parentPort.on('message', async (value: unknown) => {
   if (message.type === 'bridge-response') {
     const pending = pendingBridgeRequests.get(message.requestId);
     if (!pending) {
-      throw new RunProtocolError(
-        `Unexpected bridge response requestId: ${message.requestId}.`,
-        {
-          invocationId: message.invocationId,
-          requestId: message.requestId,
-        },
-      );
+      return;
     }
 
     if (pending.invocationId !== message.invocationId) {
@@ -83,13 +90,13 @@ parentPort.on('message', async (value: unknown) => {
       );
     }
 
-    pendingBridgeRequests.delete(message.requestId);
     resolveBridgeResponse(
       pending.context,
       pending.deferred,
       message,
       pending.resetDateNow,
     );
+    pendingBridgeRequests.delete(message.requestId);
     return;
   }
 
@@ -111,9 +118,34 @@ parentPort.on('message', async (value: unknown) => {
       await run(message);
     } finally {
       activeInvocationId = undefined;
+      if (pendingInvocationFailure?.invocationId === message.invocationId) {
+        pendingInvocationFailure = undefined;
+      }
     }
   }
-});
+}
+
+function handleMainMessageFailure(error: unknown): void {
+  if (activeInvocationId === undefined) {
+    try {
+      writeSync(
+        2,
+        `${JSON.stringify({
+          error: serializeError(error),
+          type: 'run-worker-message-error',
+        })}\n`,
+      );
+    } catch {
+      // The worker has no active invocation to report the protocol error to.
+    }
+    return;
+  }
+  pendingInvocationFailure ??= {
+    error,
+    invocationId: activeInvocationId,
+  };
+  activeCancellation?.fail(error);
+}
 
 async function run(message: WorkerRunMessage): Promise<void> {
   try {
@@ -151,6 +183,9 @@ async function execute(message: WorkerRunMessage): Promise<string> {
   let resetDateNowHandle: QuickJSHandle | undefined;
   let cancelled = false;
   let executionTimedOut = false;
+  let executionFailure: { error: unknown } | undefined;
+  const getExecutionFailure = (): { error: unknown } | undefined =>
+    executionFailure;
 
   runtime.setMemoryLimit(message.options.memoryLimitBytes);
   runtime.setMaxStackSize(message.options.maxStackSizeBytes);
@@ -169,10 +204,26 @@ async function execute(message: WorkerRunMessage): Promise<string> {
         'Worker execution cancelled by host',
       );
     },
+    fail: error => {
+      executionFailure ??= { error };
+      cancelled = true;
+      rejectPendingBridgeRequests(
+        context,
+        message.invocationId,
+        'Worker message processing failed',
+      );
+    },
     invocationId: message.invocationId,
   };
+  if (pendingInvocationFailure?.invocationId === message.invocationId) {
+    activeCancellation.fail(pendingInvocationFailure.error);
+  }
 
   try {
+    const initialFailure = getExecutionFailure();
+    if (initialFailure !== undefined) {
+      throw initialFailure.error;
+    }
     consoleFormatter = installConsole(
       context,
       message.options.maxConsoleOutputBytes,
@@ -190,8 +241,16 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       determinismHandle,
     );
     const valueJson = await evaluateUserSource(context, message);
+    const completedFailure = getExecutionFailure();
+    if (completedFailure !== undefined) {
+      throw completedFailure.error;
+    }
     return valueJson;
   } catch (error) {
+    const messageFailure = getExecutionFailure();
+    if (messageFailure !== undefined) {
+      throw messageFailure.error;
+    }
     if (executionTimedOut) {
       throw new RunTimeoutError(message.options.timeoutMs);
     }


### PR DESCRIPTION
Before, the worker’s async `parentPort` handler could reject without being awaited or caught. Late cancellation/bridge messages or guest-triggered bridge-processing errors could therefore crash the worker

We fixed it by:

- Catching all message-handler failures and routing them through the active invocation’s normal error result
- Ignoring stale cancellation and bridge-response messages
- Keeping bridge requests pending until response processing succeeds
- Preventing the manager from cancelling after receiving a result