### PR TITLE
fix: prevent guest errors from forging host runtime codes

### DIFF
--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -779,7 +779,16 @@ async function resolveQuickJSPromise(
   }
 }
 
-function toError(value: unknown): Error {
+const GUEST_FORBIDDEN_ERROR_CODES = new Set([
+  'RUN_ABORTED',
+  'RUN_CONCURRENCY_LIMIT',
+  'RUN_DETACHED_BRIDGE_REQUEST',
+  'RUN_PROTOCOL_ERROR',
+  'RUN_SOURCE_TOO_LARGE',
+  'RUN_TIMEOUT',
+]);
+
+function toError(value: unknown, filterGuestCode = false): Error {
   if (
     typeof value === 'object' &&
     value !== null &&
@@ -804,7 +813,12 @@ function toError(value: unknown): Error {
     ) {
       error.stack = (value as { stack: string }).stack;
     }
-    if (errorValue.code !== undefined) {
+    if (
+      errorValue.code !== undefined &&
+      (!filterGuestCode ||
+        typeof errorValue.code !== 'string' ||
+        !GUEST_FORBIDDEN_ERROR_CODES.has(errorValue.code))
+    ) {
       Object.defineProperty(error, 'code', {
         enumerable: true,
         value: errorValue.code,
@@ -822,7 +836,7 @@ function toError(value: unknown): Error {
 }
 
 function toUserSourceError(value: unknown, source: string): Error {
-  const error = toError(value);
+  const error = toError(value, true);
   error.stack = normalizeUserSourceStack({
     message: error.message,
     name: error.name,

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -227,6 +227,23 @@ describe('guest sandbox hardening', () => {
     `).resolves.toEqual({});
   });
 
+  it('does not allow guest errors to forge reserved runtime codes', async () => {
+    await expect(
+      run({
+        source: `
+          const error = new Error('guest failure');
+          error.code = 'RUN_TIMEOUT';
+          error.details = { timeoutMs: 1 };
+          throw error;
+        `,
+      }),
+    ).rejects.toMatchObject({
+      code: 'RUN_ERROR',
+      details: { timeoutMs: 1 },
+      message: 'guest failure',
+    });
+  });
+
   it.each([
     'Object',
     'Promise',


### PR DESCRIPTION
Before, guest code could throw an error with a forged runtime code such as `RUN_TIMEOUT.` The worker copied that code, and the host deserializer reconstructed a real `RunTimeoutError.` Applications could therefore mistake guest failure for timeout, cancellation or protocol failure.

The bug occurred when sandboxed source threw/rejected with a crafted code; `toError()` trusted it, and `deserializeError()` dispatched on it.

## After
We now filter host-only codes specifically when converting user-source errors. Without the forged code, the host reconstructs a generic `RunError` with `RUN_ERROR.` internal runtime errors remain unchanged