### PR TITLE
fix: capture and lock guest runtime intrinsics

### DIFF
--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -131,7 +131,7 @@ const HARDENING_SOURCE = `
   for (const name of [
     'Int8Array','Uint8Array','Uint8ClampedArray',
     'Int16Array','Uint16Array','Int32Array','Uint32Array',
-    'Float32Array','Float64Array',
+    'Float16Array','Float32Array','Float64Array',
     'BigInt64Array','BigUint64Array',
   ]) {
     if (g[name]) toFreeze.push(g[name], g[name].prototype);
@@ -144,10 +144,13 @@ const HARDENING_SOURCE = `
 
   for (const name of [
     'AggregateError','Array','ArrayBuffer','BigInt','Boolean','DataView','Error',
-    'EvalError','Float32Array','Float64Array','Int8Array','Int16Array','Int32Array',
-    'Map','Number','Object','RangeError','ReferenceError','RegExp','Set','String',
-    'SyntaxError','TypeError','Uint8Array','Uint8ClampedArray','Uint16Array',
-    'Uint32Array','URIError','WeakMap','WeakSet'
+    'EvalError','FinalizationRegistry','Float16Array','Float32Array','Float64Array',
+    'Int8Array','Int16Array','Int32Array','InternalError','Iterator','JSON','Map',
+    'Math','Number','Object','Promise','Proxy','RangeError','ReferenceError',
+    'Reflect','RegExp','Set','String','Symbol','SyntaxError','TypeError',
+    'Uint8Array','Uint8ClampedArray','Uint16Array','Uint32Array','URIError',
+    'WeakMap','WeakRef','WeakSet','BigInt64Array','BigUint64Array','console',
+    'globalThis'
   ]) {
     if (g[name] !== undefined) {
       try {
@@ -165,12 +168,12 @@ const HARDENING_SOURCE = `
 const DETERMINISTIC_APIS_SOURCE = `
 var __runResetDateNow = (function(config) {
   var OriginalDate = Date;
-  var dateNowMs = Number(config && config.dateNowMs);
-  if (!Number.isFinite(dateNowMs)) dateNowMs = 0;
+  var dateNowMs = __runOriginalNumber(config && config.dateNowMs);
+  if (!__runOriginalNumber.isFinite(dateNowMs)) dateNowMs = 0;
 
   function resetDateNow(value) {
-    var next = Number(value);
-    if (Number.isFinite(next)) dateNowMs = Math.trunc(next);
+    var next = __runOriginalNumber(value);
+    if (__runOriginalNumber.isFinite(next)) dateNowMs = __runOriginalMath.trunc(next);
   }
 
   function nextDateMs() {
@@ -182,7 +185,7 @@ var __runResetDateNow = (function(config) {
   function RunDate() {
     if (new.target) {
       if (arguments.length === 0) return new OriginalDate(nextDateMs());
-      return Reflect.construct(OriginalDate, arguments, new.target);
+      return __runOriginalReflect.construct(OriginalDate, arguments, new.target);
     }
     return new OriginalDate(nextDateMs()).toString();
   }
@@ -241,7 +244,7 @@ var __runResetDateNow = (function(config) {
 
   Object.defineProperty(Math, 'random', {
     value: function() {
-      return Number(nextRandom64() >> 11n) / 9007199254740992;
+      return __runOriginalNumber(nextRandom64() >> 11n) / 9007199254740992;
     },
     writable: false,
     configurable: false,
@@ -256,15 +259,32 @@ const BRIDGE_TRACKING_SOURCE = `
   var records = [];
 
   function detachedError(message, record) {
-    var error = new Error(message);
-    error.name = 'RunDetachedBridgeRequestError';
-    error.code = 'RUN_DETACHED_BRIDGE_REQUEST';
-    error.details = {
-      id: record.id,
-      kind: record.kind,
-      name: record.name,
-      status: record.status
-    };
+    var error = new __runOriginalError(message);
+    __runOriginalObject.defineProperties(error, {
+      name: {
+        value: 'RunDetachedBridgeRequestError',
+        writable: true,
+        configurable: true,
+        enumerable: true
+      },
+      code: {
+        value: 'RUN_DETACHED_BRIDGE_REQUEST',
+        writable: true,
+        configurable: true,
+        enumerable: true
+      },
+      details: {
+        value: {
+          id: record.id,
+          kind: record.kind,
+          name: record.name,
+          status: record.status
+        },
+        writable: true,
+        configurable: true,
+        enumerable: true
+      }
+    });
     return error;
   }
 
@@ -272,8 +292,8 @@ const BRIDGE_TRACKING_SOURCE = `
     value: function(kind, name, start) {
       var record = {
         id: ++nextRecordId,
-        kind: String(kind),
-        name: String(name || ''),
+        kind: __runOriginalString(kind),
+        name: __runOriginalString(name || ''),
         observed: false,
         status: 'idle'
       };
@@ -284,7 +304,7 @@ const BRIDGE_TRACKING_SOURCE = `
         record.observed = true;
         if (!promise) {
           record.status = 'pending';
-          promise = Promise.resolve().then(start).then(
+          promise = __runOriginalPromise.resolve().then(start).then(
             function(value) {
               record.status = 'fulfilled';
               return value;
@@ -298,7 +318,7 @@ const BRIDGE_TRACKING_SOURCE = `
         return promise;
       }
 
-      return Object.freeze({
+      return __runOriginalObject.freeze({
         then: function(onFulfilled, onRejected) {
           return getPromise().then(onFulfilled, onRejected);
         },
@@ -308,7 +328,7 @@ const BRIDGE_TRACKING_SOURCE = `
         finally: function(onFinally) {
           return getPromise().finally(onFinally);
         },
-        get [Symbol.toStringTag]() {
+        get [__runOriginalSymbol.toStringTag]() {
           return 'Promise';
         }
       });
@@ -344,17 +364,17 @@ const BRIDGE_TRACKING_SOURCE = `
 const BINDINGS_PROXY_SOURCE = `
 (function(invokeBinding, bindingNamespaces) {
   function serializationError(label, error) {
-    var message = error && error.message ? String(error.message) : String(error);
-    var result = new TypeError(label + ': ' + message);
+    var message = error && error.message ? __runOriginalString(error.message) : __runOriginalString(error);
+    var result = new __runOriginalTypeError(label + ': ' + message);
     result.code = 'RUN_SERIALIZATION_ERROR';
     return result;
   }
 
   function makeProxy(path) {
-    return new Proxy(function(){}, {
+    return new __runOriginalProxy(function(){}, {
       get: function(_target, prop) {
         if (prop === 'then' || typeof prop === 'symbol') return undefined;
-        return makeProxy(path.concat([String(prop)]));
+        return makeProxy(path.concat([__runOriginalString(prop)]));
       },
       apply: function(_target, _thisArg, args) {
         var bindingPath = path.join('.');
@@ -406,14 +426,14 @@ const SERIALIZATION_GUARD_SOURCE = `
     try {
       encoded = __runSerdeBundle.serializeRunValue(value);
     } catch (error) {
-      var message = error && error.message ? String(error.message) : String(error);
-      var serializationError = new TypeError('JavaScript runtime result is not serializable: ' + message);
+      var message = error && error.message ? __runOriginalString(error.message) : __runOriginalString(error);
+      var serializationError = new __runOriginalTypeError('JavaScript runtime result is not serializable: ' + message);
       serializationError.code = 'RUN_SERIALIZATION_ERROR';
       throw serializationError;
     }
 
     if (encoded === undefined) {
-      var serializationError = new TypeError('JavaScript runtime result is not serializable.');
+      var serializationError = new __runOriginalTypeError('JavaScript runtime result is not serializable.');
       serializationError.code = 'RUN_SERIALIZATION_ERROR';
       throw serializationError;
     }
@@ -436,6 +456,16 @@ export const buildGuestRuntimeSetupSource = (
   return `
 (function(__runInvokeBinding, __runDeterminism) {
 const __runBindingNamespaces = ${namespacesJson};
+const __runOriginalError = Error;
+const __runOriginalMath = Math;
+const __runOriginalNumber = Number;
+const __runOriginalObject = Object;
+const __runOriginalPromise = Promise;
+const __runOriginalProxy = Proxy;
+const __runOriginalReflect = Reflect;
+const __runOriginalString = String;
+const __runOriginalSymbol = Symbol;
+const __runOriginalTypeError = TypeError;
 ${DETERMINISTIC_APIS_SOURCE}
 ${BASE64_SOURCE}
 ${GUEST_SERDE_SOURCE}

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -61,7 +61,10 @@ it('reports message failures and ignores late messages without crashing', async 
       ) {
         postToWorker({
           dateNowMs: 1_700_000_000_001,
-          invocationId: message.invocationId,
+          invocationId:
+            message.invocationId === 'run-failure'
+              ? 'wrong-invocation'
+              : message.invocationId,
           requestId: message.requestId,
           success: true,
           type: 'bridge-response',
@@ -100,11 +103,6 @@ it('reports message failures and ignores late messages without crashing', async 
       createRunMessage(
         'run-failure',
         `
-          globalThis.Math = {
-            trunc() {
-              throw new Error('reset failed');
-            },
-          };
           return await tools.echo();
         `,
       ),
@@ -113,7 +111,10 @@ it('reports message failures and ignores late messages without crashing', async 
 
     expect(results).toHaveLength(2);
     expect(results[0]).toMatchObject({
-      error: { message: 'reset failed' },
+      error: {
+        message:
+          'Bridge response invocationId mismatch for request run-failure:bridge-1: expected run-failure, received wrong-invocation.',
+      },
       invocationId: 'run-failure',
       success: false,
     });

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { RunDetachedBridgeRequestError } from './errors.js';
 import { getBindingContext, run } from './index.js';
 import type { Bindings } from './index.js';
 
@@ -16,6 +17,24 @@ async function value(source: string, bindings?: Bindings): Promise<unknown> {
 function expectValue(source: string, bindings?: Bindings) {
   return expect(value(source, bindings));
 }
+
+const LOCKED_GUEST_GLOBALS = [
+  'BigInt64Array',
+  'BigUint64Array',
+  'FinalizationRegistry',
+  'Float16Array',
+  'InternalError',
+  'Iterator',
+  'JSON',
+  'Math',
+  'Promise',
+  'Proxy',
+  'Reflect',
+  'Symbol',
+  'WeakRef',
+  'console',
+  'globalThis',
+] as const;
 
 describe('guest sandbox hardening', () => {
   it('exposes only the reviewed global surface', async () => {
@@ -196,6 +215,72 @@ describe('guest sandbox hardening', () => {
       setName: 'Set',
       toolsType: 'function',
     });
+  });
+
+  it('locks every privileged guest global binding', async () => {
+    const results = (await value(`
+      const realmGlobal = globalThis;
+      return ${JSON.stringify(LOCKED_GUEST_GLOBALS)}.map(name => {
+        const original = realmGlobal[name];
+        try { realmGlobal[name] = { replaced: true }; } catch {}
+        const descriptor = Object.getOwnPropertyDescriptor(realmGlobal, name);
+        return {
+          name,
+          configurable: descriptor.configurable,
+          writable: descriptor.writable,
+          unchanged: realmGlobal[name] === original,
+        };
+      });
+    `)) as {
+      configurable: boolean;
+      name: string;
+      unchanged: boolean;
+      writable: boolean;
+    }[];
+
+    expect(results).toEqual(
+      LOCKED_GUEST_GLOBALS.map(name => ({
+        configurable: false,
+        name,
+        unchanged: true,
+        writable: false,
+      })),
+    );
+  });
+
+  it('uses trusted intrinsics after attempted guest replacement', async () => {
+    await expectValue(
+      `
+        try { globalThis.Math = { trunc() { throw new Error('fake Math'); } }; } catch {}
+        try { globalThis.Promise = { resolve() { throw new Error('fake Promise'); } }; } catch {}
+        try { globalThis.Proxy = function FakeProxy() { throw new Error('fake Proxy'); }; } catch {}
+        try { globalThis.Reflect = { construct() { throw new Error('fake Reflect'); } }; } catch {}
+        try { globalThis.Symbol = { toStringTag: 'then' }; } catch {}
+
+        const explicitDate = new Date(123).getTime();
+        const echoed = await tools.echo('ok');
+        return { echoed, explicitDate };
+      `,
+      { tools: { echo: (input: unknown) => input } },
+    ).resolves.toEqual({ echoed: 'ok', explicitDate: 123 });
+  });
+
+  it('does not invoke guest Error prototype setters for runtime errors', async () => {
+    await expect(
+      run({
+        bindings: { tools: { echo: () => 'ok' } },
+        source: `
+          for (const name of ['name', 'code', 'details']) {
+            Object.defineProperty(Error.prototype, name, {
+              configurable: true,
+              set() { throw new Error('intercepted ' + name); },
+            });
+          }
+          tools.echo();
+          return true;
+        `,
+      }),
+    ).rejects.toBeInstanceOf(RunDetachedBridgeRequestError);
   });
 
   it('starts with a clean realm after mutation, failure, and interruption', async () => {


### PR DESCRIPTION
## Before

The runtime froze intrinsic objects such as Reflect, Promise, Math, Symbol, and Proxy, but their globalThis bindings remained writable. Guest code could replace the binding even though the original object was frozen

## After

- Captured trusted intrinsic references before guest code executes
- Updated delayed runtime callbacks to use those captured references
- Made all privileged global bindings non-writable and non-configurable