### PR TITLE
fix: restrict host binding invocation to validated capabilities

### DIFF
--- a/packages/run/src/binding-invocation.test.ts
+++ b/packages/run/src/binding-invocation.test.ts
@@ -14,6 +14,8 @@ const createContext = (bindingName: string): BindingContext => ({
   requestIndex: 1,
 });
 
+const manifest = (...names: string[]) => new Map([['tools', new Set(names)]]);
+
 describe('invokeHostBinding', () => {
   it('rejects oversized arguments before parsing them', async () => {
     const binding = vi.fn();
@@ -32,6 +34,7 @@ describe('invokeHostBinding', () => {
 
     await expect(
       invokeHostBinding({
+        bindingManifest: manifest('test'),
         bindingName: 'tools.test',
         bindings: { tools: { test: binding } },
         context,
@@ -47,6 +50,7 @@ describe('invokeHostBinding', () => {
     const context = createContext('tools.missing');
     await expect(
       invokeHostBinding({
+        bindingManifest: manifest('present'),
         bindingName: 'tools.missing',
         bindings: { tools: { present: () => true } },
         context,
@@ -61,6 +65,7 @@ describe('invokeHostBinding', () => {
 
     await expect(
       invokeHostBinding({
+        bindingManifest: manifest('present'),
         bindingName: 'tools.present',
         bindings: {
           tools: { present: true as unknown as () => boolean },
@@ -73,10 +78,33 @@ describe('invokeHostBinding', () => {
     ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
   });
 
+  it('rejects non-enumerable bindings at the invocation boundary', async () => {
+    const hidden = vi.fn();
+    const group = { present: () => true };
+    Object.defineProperty(group, 'hidden', { value: hidden });
+
+    await expect(
+      invokeHostBinding({
+        bindingManifest: manifest('present'),
+        bindingName: 'tools.hidden',
+        bindings: { tools: group },
+        context: createContext('tools.hidden'),
+        inputJson: '[[]]',
+        maxBindingInputBytes: 1024,
+        maxBindingOutputBytes: 1024,
+      }),
+    ).rejects.toMatchObject({
+      code: 'RUN_BINDING_ERROR',
+      details: { availableBindings: ['tools.present'] },
+    });
+    expect(hidden).not.toHaveBeenCalled();
+  });
+
   it('serializes arguments and output at the host boundary', async () => {
     const binding = vi.fn((input: unknown) => ({ input, omitted: undefined }));
     await expect(
       invokeHostBinding({
+        bindingManifest: manifest('test'),
         bindingName: 'tools.test',
         bindings: { tools: { test: binding } },
         context: createContext('tools.test'),
@@ -94,6 +122,7 @@ describe('invokeHostBinding', () => {
   it('rejects oversized binding output', async () => {
     await expect(
       invokeHostBinding({
+        bindingManifest: manifest('test'),
         bindingName: 'tools.test',
         bindings: { tools: { test: () => 'too large' } },
         context: createContext('tools.test'),

--- a/packages/run/src/binding-invocation.ts
+++ b/packages/run/src/binding-invocation.ts
@@ -3,7 +3,7 @@ import { once } from 'node:events';
 import { RunBindingError } from './errors.js';
 import { runWithBindingContext } from './binding-context.js';
 import { isBindingInterruptSignal } from './interrupt.js';
-import type { BindingContext, Bindings } from './types.js';
+import type { BindingContext, BindingManifest, Bindings } from './types.js';
 import { parseJsonPayload, toJsonPayload } from './utils/serialization.js';
 
 export type BindingInvocationOutcome =
@@ -59,43 +59,59 @@ const assertPayloadSize = (
 };
 
 const unknownBindingError = (
-  bindings: Bindings,
+  bindingManifest: BindingManifest,
   bindingName: string,
 ): RunBindingError =>
   new RunBindingError(`Unknown binding: ${bindingName}`, {
-    availableBindings: Object.entries(bindings).flatMap(([group, entries]) =>
-      Object.keys(entries).map(name => `${group}.${name}`),
+    availableBindings: [...bindingManifest.entries()].flatMap(
+      ([group, names]) => [...names].map(name => `${group}.${name}`),
     ),
     bindingName,
   });
 
 const resolveBinding = (
   bindings: Bindings,
+  bindingManifest: BindingManifest,
   bindingName: string,
 ): InvokableBinding => {
   const separator = bindingName.indexOf('.');
   if (separator <= 0 || separator === bindingName.length - 1) {
-    throw unknownBindingError(bindings, bindingName);
+    throw unknownBindingError(bindingManifest, bindingName);
   }
 
   const groupName = bindingName.slice(0, separator);
   const functionName = bindingName.slice(separator + 1);
-  if (!Object.hasOwn(bindings, groupName)) {
-    throw unknownBindingError(bindings, bindingName);
+  if (bindingManifest.get(groupName)?.has(functionName) !== true) {
+    throw unknownBindingError(bindingManifest, bindingName);
   }
 
-  const group = bindings[groupName];
+  const groupDescriptor = Object.getOwnPropertyDescriptor(bindings, groupName);
   if (
-    typeof group !== 'object' ||
-    group === null ||
-    !Object.hasOwn(group, functionName)
+    groupDescriptor?.enumerable !== true ||
+    !Object.hasOwn(groupDescriptor, 'value')
   ) {
-    throw unknownBindingError(bindings, bindingName);
+    throw unknownBindingError(bindingManifest, bindingName);
   }
 
-  const binding = group[functionName];
+  const group = groupDescriptor.value as unknown;
+  if (typeof group !== 'object' || group === null) {
+    throw unknownBindingError(bindingManifest, bindingName);
+  }
+
+  const bindingDescriptor = Object.getOwnPropertyDescriptor(
+    group,
+    functionName,
+  );
+  if (
+    bindingDescriptor?.enumerable !== true ||
+    !Object.hasOwn(bindingDescriptor, 'value')
+  ) {
+    throw unknownBindingError(bindingManifest, bindingName);
+  }
+
+  const binding = bindingDescriptor.value;
   if (typeof binding !== 'function') {
-    throw unknownBindingError(bindings, bindingName);
+    throw unknownBindingError(bindingManifest, bindingName);
   }
 
   return binding as InvokableBinding;
@@ -104,6 +120,7 @@ const resolveBinding = (
 export const invokeHostBinding = async ({
   bindingName,
   inputJson,
+  bindingManifest,
   bindings,
   context,
   maxBindingInputBytes,
@@ -111,6 +128,7 @@ export const invokeHostBinding = async ({
 }: {
   bindingName: string;
   inputJson: string;
+  bindingManifest: BindingManifest;
   bindings: Bindings;
   context: BindingContext;
   maxBindingInputBytes: number;
@@ -118,7 +136,7 @@ export const invokeHostBinding = async ({
 }): Promise<BindingInvocationOutcome> => {
   throwIfAborted(context.abortSignal);
 
-  const binding = resolveBinding(bindings, bindingName);
+  const binding = resolveBinding(bindings, bindingManifest, bindingName);
   assertPayloadSize(inputJson, maxBindingInputBytes, 'Binding arguments');
   const args = parseJsonPayload(
     inputJson,

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'node:buffer';
 import { runManaged } from './runtime/manager.js';
 import { createSignedContinuationCodec } from './continuation-codec.js';
 import type {
+  BindingManifest,
   Bindings,
   ContinuationCodec,
   RunInput,
@@ -98,7 +99,8 @@ const RESERVED_BINDING_NAMES = new Set([
 
 const BINDING_IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/u;
 
-const validateBindings = (bindings: Bindings): void => {
+const validateBindings = (bindings: Bindings): BindingManifest => {
+  const bindingManifest = new Map<string, ReadonlySet<string>>();
   for (const [namespace, group] of Object.entries(bindings)) {
     if (!Object.hasOwn(bindings, namespace)) {
       continue;
@@ -121,6 +123,7 @@ const validateBindings = (bindings: Bindings): void => {
         `Binding namespace "${namespace}" must be an object.`,
       );
     }
+    const bindingNames = new Set<string>();
     for (const [name, binding] of Object.entries(group)) {
       if (!Object.hasOwn(group, name)) {
         continue;
@@ -138,8 +141,11 @@ const validateBindings = (bindings: Bindings): void => {
           `Binding "${namespace}.${name}" must be a function.`,
         );
       }
+      bindingNames.add(name);
     }
+    bindingManifest.set(namespace, bindingNames);
   }
+  return bindingManifest;
 };
 
 /** Creates a runner with shared defaults. */
@@ -177,9 +183,10 @@ export const createRunner = <TOKEN = string>(
       input: RunInput<TOKEN>,
     ): Promise<RunResult<OUTPUT, TOKEN>> {
       const bindings = input.bindings ?? {};
-      validateBindings(bindings);
+      const bindingManifest = validateBindings(bindings);
       const value = await runManaged({
         ...input,
+        bindingManifest,
         bindings,
         continuationAudience,
         continuationCodec,

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -375,6 +375,7 @@ function startWorkerRun({
   source,
   originalSource,
   bindings,
+  bindingManifest,
   abortSignal,
   resolutions,
   continuationCodec,
@@ -664,7 +665,7 @@ function startWorkerRun({
   }
 
   const runMessage: MainToWorkerMessage = {
-    bindingNamespaces: Object.keys(bindings),
+    bindingNamespaces: [...bindingManifest.keys()],
     determinism,
     invocationId,
     options: {
@@ -789,6 +790,7 @@ function startWorkerRun({
       }
 
       const outcome = await invokeHostBinding({
+        bindingManifest,
         bindingName: message.bindingName,
         bindings,
         context: {
@@ -1161,14 +1163,13 @@ function createContinuationScopeHash(
     options.maxContinuationBytes,
     'Continuation context',
   );
-  const bindingManifest = Object.keys(input.bindings)
+  const bindingManifest = [...input.bindingManifest.keys()]
     .toSorted()
-    .flatMap(namespace => {
-      const bindingGroup = input.bindings[namespace] ?? {};
-      return Object.keys(bindingGroup)
+    .flatMap(namespace =>
+      [...(input.bindingManifest.get(namespace) ?? [])]
         .toSorted()
-        .map(name => `${namespace}.${name}`);
-    });
+        .map(name => `${namespace}.${name}`),
+    );
   return createHash('sha256')
     .update(
       toJsonPayload(

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -374,6 +374,45 @@ describe('guest sandbox hardening', () => {
     },
   );
 
+  it.each(['hidden', 'admin.reset'])(
+    'does not expose the non-enumerable binding %s',
+    async name => {
+      let called = false;
+      const group = { visible: () => true };
+      Object.defineProperty(group, name, {
+        value: () => {
+          called = true;
+        },
+      });
+
+      await expect(
+        run({
+          bindings: { tools: group },
+          source: `return await tools[${JSON.stringify(name)}]();`,
+        }),
+      ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+      expect(called).toBe(false);
+    },
+  );
+
+  it('does not expose bindings added after validation', async () => {
+    let called = false;
+    const group: Record<string, () => unknown> = {};
+    group.install = () => {
+      group.hidden = () => {
+        called = true;
+      };
+    };
+
+    await expect(
+      run({
+        bindings: { tools: group },
+        source: 'await tools.install(); return await tools.hidden();',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+    expect(called).toBe(false);
+  });
+
   it.each([
     '',
     '1call',

--- a/packages/run/src/serialization-hardening.test.ts
+++ b/packages/run/src/serialization-hardening.test.ts
@@ -68,6 +68,7 @@ describe('serialization boundaries', () => {
 
       await expect(
         invokeHostBinding({
+          bindingManifest: new Map([['tools', new Set(['echo'])]]),
           bindingName: 'tools.echo',
           bindings: { tools: { echo: binding } },
           context: bindingContext(),
@@ -79,6 +80,7 @@ describe('serialization boundaries', () => {
 
       await expect(
         invokeHostBinding({
+          bindingManifest: new Map([['tools', new Set(['echo'])]]),
           bindingName: 'tools.echo',
           bindings: { tools: { echo: binding } },
           context: bindingContext(),

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -45,6 +45,9 @@ export type BindingGroup = Record<string, BindingFunction<never[], unknown>>;
  */
 export type Bindings = Record<string, BindingGroup>;
 
+/** @internal */
+export type BindingManifest = ReadonlyMap<string, ReadonlySet<string>>;
+
 /** Resource limits applied to one sandbox invocation. */
 export interface RunLimits {
   /** @default `30_000` */
@@ -218,6 +221,7 @@ export interface Runner<TOKEN = unknown> {
 /** @internal */
 export interface InternalRunInput extends RunInput<unknown> {
   bindings: Bindings;
+  bindingManifest: BindingManifest;
   limits: RunLimits;
   continuationCodec: ContinuationCodec;
   continuationAudience: string;


### PR DESCRIPTION
What was wrong:

- Validation used `Object.entries,` ignoring non-enumerable bindings
- Invocation used `Object.hasOwn,` allowing those same hidden bindings
- Bindings added after validation could also become callable


Fix:

- Build a validated binding manifest once per run
- Resolve only names present in that manifest
- Require current properties to remain enumerable own data properties and functions