### PR TITLE
fix: reject non-enumerable sandbox bindings

### DIFF
--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -99,8 +99,23 @@ const RESERVED_BINDING_NAMES = new Set([
 
 const BINDING_IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/u;
 
+const assertEnumerableProperties = (
+  value: object,
+  label: (name: string) => string,
+): void => {
+  for (const name of Object.getOwnPropertyNames(value)) {
+    if (Object.getOwnPropertyDescriptor(value, name)?.enumerable !== true) {
+      throw new TypeError(`${label(name)} must be enumerable.`);
+    }
+  }
+};
+
 const validateBindings = (bindings: Bindings): BindingManifest => {
   const bindingManifest = new Map<string, ReadonlySet<string>>();
+  assertEnumerableProperties(
+    bindings,
+    namespace => `Binding namespace "${namespace}"`,
+  );
   for (const [namespace, group] of Object.entries(bindings)) {
     if (!Object.hasOwn(bindings, namespace)) {
       continue;
@@ -124,6 +139,7 @@ const validateBindings = (bindings: Bindings): BindingManifest => {
       );
     }
     const bindingNames = new Set<string>();
+    assertEnumerableProperties(group, name => `Binding "${namespace}.${name}"`);
     for (const [name, binding] of Object.entries(group)) {
       if (!Object.hasOwn(group, name)) {
         continue;

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -375,7 +375,7 @@ describe('guest sandbox hardening', () => {
   );
 
   it.each(['hidden', 'admin.reset'])(
-    'does not expose the non-enumerable binding %s',
+    'rejects the non-enumerable binding %s',
     async name => {
       let called = false;
       const group = { visible: () => true };
@@ -390,10 +390,21 @@ describe('guest sandbox hardening', () => {
           bindings: { tools: group },
           source: `return await tools[${JSON.stringify(name)}]();`,
         }),
-      ).rejects.toMatchObject({ code: 'RUN_BINDING_ERROR' });
+      ).rejects.toThrow(`Binding "tools.${name}" must be enumerable.`);
       expect(called).toBe(false);
     },
   );
+
+  it('rejects a non-enumerable binding namespace', async () => {
+    const bindings = {};
+    Object.defineProperty(bindings, 'tools', {
+      value: { visible: () => true },
+    });
+
+    await expect(
+      run({ bindings, source: 'return await tools.visible();' }),
+    ).rejects.toThrow('Binding namespace "tools" must be enumerable.');
+  });
 
   it('does not expose bindings added after validation', async () => {
     let called = false;


### PR DESCRIPTION
Previously, `Object.entries` silently skipped hidden properties. Now all own string properties are inspected and hidden ones produce a clear `TypeError`