### PR TITLE
docs: remove AI-written phrasing from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,20 @@ and its credentials stay in your application.
 
 ## Features
 
-- **Hardened execution** - every invocation uses a fresh QuickJS context in a
-  worker thread, with no ambient Node.js, filesystem, module or network access.
-- **Human-in-the-loop** - interrupt for approval or authentication, then resume
-  without repeating completed host calls.
-- **Resource controls** - set time, memory, result size and concurrency limits.
+- Every invocation gets a fresh QuickJS context in a worker thread, with no
+  ambient Node.js, filesystem, module or network access.
+- A host function can interrupt a run for approval or authentication. The run
+  resumes without repeating host calls that already completed.
+- Time, memory, result size and concurrency are capped, per run or per runner.
 
-`run` is designed for sandboxed JavaScript computation inside an application.
-Workloads that need an operating system, package installation, or process-level
-isolation should use Vercel Sandbox.
+`run` is for sandboxed JavaScript computation inside an application. Workloads
+that need an operating system, package installation, or process-level isolation
+should use Vercel Sandbox.
 
 ## Documentation
 
-Read the [introduction](content/docs/introduction/index.mdx), explore the
-[foundations](content/docs/foundations/overview.mdx), or browse the
+Start with the [introduction](content/docs/introduction/index.mdx), then the
+[foundations](content/docs/foundations/overview.mdx) and the
 [API reference](content/docs/reference/index.mdx).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ and its credentials stay in your application.
 ## Features
 
 - Every invocation gets a fresh QuickJS context in a worker thread, with no
-  ambient Node.js, filesystem, module or network access.
+  ambient Node.js, filesystem, module, or network access.
 - A host function can interrupt a run for approval or authentication. The run
   resumes without repeating host calls that already completed.
-- Time, memory, result size and concurrency are capped, per run or per runner.
+- Time, memory, result size, and concurrency are capped, per run or per runner.
 
 `run` is for sandboxed JavaScript computation inside an application. Workloads
 that need an operating system, package installation, or process-level isolation

--- a/content/docs/advanced/cancellation.mdx
+++ b/content/docs/advanced/cancellation.mdx
@@ -5,9 +5,9 @@ description: Stop an active run and propagate cancellation to host functions.
 
 # Cancellation
 
-Cancellation lets the host stop work that is no longer needed. This is useful
-when a client disconnects, a user cancels an operation, or a parent request
-ends before the sandbox has returned a result.
+Cancellation stops work the host no longer needs: a client disconnected, a user
+cancelled the operation, or the parent request ended before the sandbox
+returned a result.
 
 ## Concept
 

--- a/content/docs/advanced/concurrency.mdx
+++ b/content/docs/advanced/concurrency.mdx
@@ -5,9 +5,9 @@ description: Control parallel host function calls and simultaneous sandbox invoc
 
 # Concurrency
 
-Concurrency appears at two different levels in `run`. Guest source can call
-several host functions at once, and the host process can execute several
-sandbox invocations at once.
+Concurrency appears at two levels in `run`. Guest source can call several host
+functions at once, and the host process can execute several sandbox invocations
+at once.
 
 These levels use different limits and should be configured independently.
 
@@ -82,13 +82,13 @@ setMaxWorkers();
 ```
 
 Choose the cap with both QuickJS memory and worker overhead in mind. A worker
-can consume more memory than the configured guest `memoryLimitBytes`, so the
-guest memory limit should not be treated as the total cost of an invocation.
+can consume more memory than the configured guest `memoryLimitBytes`, so
+`memoryLimitBytes` is not the total cost of an invocation.
 
 ## Admission
 
-Applications should decide what happens when all workers are busy. An HTTP
-service can reject the request with backpressure:
+Decide what happens when all workers are busy. An HTTP service can reject the
+request with backpressure:
 
 ```ts
 import { RunError } from 'run';
@@ -126,11 +126,11 @@ active workers with an in-flight host function limit of eight can produce up to
 
 Set both values from the capacity of downstream services, then measure:
 
-- Track active invocations and concurrency-limit failures.
-- Track active host function calls and their latency.
-- Track process memory under representative source and result sizes.
-- Reduce concurrency before increasing memory limits when the process is under
-  memory pressure.
+- Active invocations and concurrency-limit failures.
+- Active host function calls and their latency.
+- Process memory under representative source and result sizes.
 
-Concurrency improves throughput only while the host and its dependencies have
-capacity. Higher values can otherwise increase latency and failure rates.
+Under memory pressure, reduce concurrency before raising memory limits.
+
+Concurrency only improves throughput while the host and its dependencies have
+capacity. Past that, it adds latency and failures.

--- a/content/docs/advanced/continuations.mdx
+++ b/content/docs/advanced/continuations.mdx
@@ -134,8 +134,8 @@ compatible behavior for interrupted host functions while old continuations
 remain valid.
 
 Several host functions can interrupt during the same invocation. The result
-contains the complete batch, and the host must resolve every interruption in
-that batch together. Replay may later reach another batch of interruptions.
+contains the full batch, and the host must resolve every interruption in that
+batch together. Replay may later reach another batch of interruptions.
 
 ## Signing
 

--- a/content/docs/advanced/continuations.mdx
+++ b/content/docs/advanced/continuations.mdx
@@ -6,8 +6,8 @@ description: Implement interrupt-and-resume flows and protect their replay state
 # Continuations
 
 A continuation lets the host stop an invocation at an interruption and resume
-the same logical run later. It is useful for approvals, authentication, and
-other decisions that happen outside the sandbox.
+the same logical run later. Use it for approvals, authentication, and other
+decisions made outside the sandbox.
 
 ## Concept
 
@@ -21,7 +21,7 @@ scheduling resumed work, authorizing callers, and handling retries.
 
 ## Configuration
 
-The simplest production configuration uses a shared signing secret:
+The simplest configuration uses a shared signing secret:
 
 ```ts
 import { createRunner } from 'run';

--- a/content/docs/advanced/index.mdx
+++ b/content/docs/advanced/index.mdx
@@ -1,24 +1,21 @@
 ---
 title: Advanced
-description: Build production-ready execution flows with cancellation, limits, concurrency, continuations, and replay.
+description: Cancellation, limits, concurrency, and continuations.
 ---
 
 # Advanced
 
-This section explains the controls needed when `run` becomes part of a
-long-running service, approval flow, or multi-user application.
+These guides cover the controls you need once `run` is part of a long-running
+service, an approval flow, or a multi-user application.
 
-Each guide begins with the concept being introduced and then shows how to
-implement it:
+- [Cancellation](./cancellation): stop a run, and pass the cancellation signal
+  through to active host functions.
+- [Limits](./limits): set resource budgets for source, execution, host function
+  traffic, and results.
+- [Concurrency](./concurrency): parallel host function calls, the process-wide
+  worker pool, and admission control.
+- [Continuations](./continuations): build an interrupt-and-resume flow and
+  protect its replay state.
 
-1. [Cancellation](./cancellation) explains how the host can stop a run and how
-   active host functions receive the same cancellation signal.
-2. [Limits](./limits) explains how to set resource budgets for source,
-   execution, host function traffic, and results.
-3. [Concurrency](./concurrency) explains parallel host function calls, the
-   process-wide worker pool, and admission control.
-4. [Continuations](./continuations) explains how to implement an
-   interrupt-and-resume flow and choose how continuation state is protected.
-
-These guides focus on implementation patterns. For exact function signatures,
-options, return types, and errors, use the [API Reference](../reference/).
+For exact signatures, options, return types, and errors, see the
+[API Reference](../reference/).

--- a/content/docs/advanced/limits.mdx
+++ b/content/docs/advanced/limits.mdx
@@ -15,31 +15,24 @@ Every invocation has a `RunLimits` budget. The budget applies to the complete
 invocation, including guest execution, host function calls, result
 serialization, and continuation operations.
 
-The package provides defaults, but production applications should choose
-budgets that match their workloads. A short data transformation and a coding
-agent should not necessarily receive the same limits.
+The defaults are a starting point, not a policy. A short data transformation
+and a coding agent rarely want the same budget.
 
 ## Defaults
 
-The available limits are:
-
-- `timeoutMs` allows 30 seconds for the complete invocation by default.
-- `memoryLimitBytes` allows 64 MiB of QuickJS memory by default.
-- `maxStackSizeBytes` allows a 2 MiB QuickJS stack by default.
-- `maxSourceBytes` accepts up to 256 KiB of UTF-8 source by default.
-- `maxResultBytes` accepts up to 1 MiB of serialized result data by default.
-- `maxConsoleOutputBytes` accepts up to 64 KiB of guest console output by
-  default.
-- `maxHostFunctionArgumentsBytes` accepts up to 1 MiB of serialized arguments
-  for one host function call by default.
-- `maxHostFunctionOutputBytes` accepts up to 4 MiB of serialized host function
-  output or interruption payload by default.
-- `maxBridgeRequests` allows 256 total host function calls in one invocation by
-  default.
-- `maxInFlightBridgeRequests` allows 32 host function calls to be active at once
-  by default.
-- `maxContinuationBytes` accepts up to 32 MiB of serialized continuation state
-  by default.
+| Limit                           |    Default | Bounds                                    |
+| ------------------------------- | ---------: | ----------------------------------------- |
+| `timeoutMs`                     | 30 seconds | The complete invocation                   |
+| `memoryLimitBytes`              |     64 MiB | QuickJS memory                            |
+| `maxStackSizeBytes`             |      2 MiB | QuickJS stack                             |
+| `maxSourceBytes`                |    256 KiB | UTF-8 source                              |
+| `maxResultBytes`                |      1 MiB | Serialized result data                    |
+| `maxConsoleOutputBytes`         |     64 KiB | Guest console output                      |
+| `maxHostFunctionArgumentsBytes` |      1 MiB | Serialized arguments for one call         |
+| `maxHostFunctionOutputBytes`    |      4 MiB | Serialized output or interruption payload |
+| `maxBridgeRequests`             |        256 | Host function calls in one invocation     |
+| `maxInFlightBridgeRequests`     |         32 | Host function calls active at once        |
+| `maxContinuationBytes`          |     32 MiB | Serialized continuation state             |
 
 Every configured value must be a positive integer.
 

--- a/content/docs/foundations/host-functions.mdx
+++ b/content/docs/foundations/host-functions.mdx
@@ -36,8 +36,8 @@ const result = await run({
 });
 ```
 
-The complete name of the host function in this example is `users.find`. The
-`users` namespace is available only for this invocation.
+The fully qualified name of the host function in this example is `users.find`.
+The `users` namespace is available only for this invocation.
 
 A namespace must be a valid JavaScript identifier, must not conflict with a
 reserved global, and must not begin with `__run`.
@@ -120,7 +120,7 @@ const hostFunctions = {
 - `requestId` identifies the current host function call within the
   invocation.
 - `requestIndex` contains the one-based order of the host function call.
-- `hostFunctionName` contains the complete host function name, such as
+- `hostFunctionName` contains the fully qualified host function name, such as
   `users.find`.
 - `interrupt(payload)` pauses the run and returns an application-defined
   payload to the host.

--- a/content/docs/foundations/host-functions.mdx
+++ b/content/docs/foundations/host-functions.mdx
@@ -9,10 +9,9 @@ Host functions are functions that guest code is allowed to call. They are the
 only supported way for source running in the sandbox to interact with your
 application or the systems connected to it.
 
-A host function should represent a focused capability. Instead of exposing a
-database client, for example, the host can expose a function that loads one
-kind of record after applying the application's validation and authorization
-rules.
+A host function should expose one narrow capability. Rather than handing the
+guest a database client, expose a function that loads one kind of record, after
+the application's validation and authorization rules have run.
 
 ## Defining host functions
 
@@ -89,8 +88,8 @@ number that may be in flight at once.
 
 ## Context
 
-A host function has the option to call `getHostFunctionContext()` to access
-information about its active request:
+A host function can call `getHostFunctionContext()` to read information about
+its active request:
 
 ```ts
 import { getHostFunctionContext } from 'run';
@@ -128,9 +127,8 @@ const hostFunctions = {
 - `resume` is available when an interrupted host function is invoked again. It
   contains the interruption ID, original payload, and supplied resolution.
 
-These identifiers are useful for tracing, auditing, and deduplicating external
-side effects. They are not authentication credentials. We will dive deep into these
-later.
+Use these identifiers to trace, audit, and deduplicate external side effects.
+They are not authentication credentials.
 
 ## Cancellation
 

--- a/content/docs/foundations/interruptions.mdx
+++ b/content/docs/foundations/interruptions.mdx
@@ -44,9 +44,8 @@ A **continuation** is the token returned with an interrupted result. It
 represents the state required to replay the source and continue the logical
 run.
 
-The package does not choose where continuations are stored. The host can save
-the token as an opaque string in a database, durable key-value store, or job
-record:
+You choose where continuations are stored. The token is an opaque string, so it
+can live in a database, a durable key-value store, or a job record:
 
 ```ts
 if (result.status === 'interrupted') {
@@ -61,15 +60,13 @@ When the external decision is available, the host reads the same token and
 passes it back to the runner as `continuation`. The token must not be modified
 between these invocations.
 
-A continuation should be treated as a bearer capability because a party
-holding a valid token may be able to resume the workflow. Its storage should
-therefore be access-controlled, and the raw token should not be written to
-logs.
+Treat a continuation as a bearer capability: anyone holding a valid token can
+resume the workflow. Store it behind access controls and keep the raw token out
+of logs.
 
 The default signed continuation protects integrity but does not encrypt its
-contents. Sensitive information should not be placed in source, host function
-arguments, interruption payloads, or continuation context merely because the
-token is encoded.
+contents. Base64 is not encryption, so keep sensitive data out of source, host
+function arguments, interruption payloads, and continuation context.
 
 A **continuation codec** is responsible for encoding replay state into a token
 and decoding that token later. The package provides a signed codec, a stored
@@ -126,7 +123,7 @@ validation fails instead of applying recorded outcomes to different work.
 ## Determinism
 
 Guest time and pseudorandom behavior are deterministic across replay. The
-logical run records an initial clock value and random seed so that source
+logical run records an initial clock value and random seed, so the source
 observes the same sequence in later attempts.
 
 Determinism helps the source reach the same host function calls during replay.
@@ -143,5 +140,5 @@ The **logical run ID** remains stable across the original invocation and all
 replay attempts. Each host function call also receives a **request ID** and a
 one-based **request index**.
 
-These identifiers let the host correlate logs, audit a workflow, and
-deduplicate host function side effects across attempts.
+Together they let the host correlate logs across a workflow that spans several
+attempts.

--- a/content/docs/foundations/interruptions.mdx
+++ b/content/docs/foundations/interruptions.mdx
@@ -32,9 +32,9 @@ if (context.resume === undefined) {
 ```
 
 The invocation resolves with an interrupted result after pending host function
-work has settled. Each interruption contains an ID, the complete host function
-name (`hostFunctionName`), the guest arguments, and the payload created by the
-host function.
+work has settled. Each interruption contains an ID, the fully qualified host
+function name (`hostFunctionName`), the guest arguments, and the payload created
+by the host function.
 
 An interruption is an expected result rather than an error.
 

--- a/content/docs/foundations/overview.mdx
+++ b/content/docs/foundations/overview.mdx
@@ -48,9 +48,8 @@ hardened QuickJS context with a restricted set of JavaScript capabilities. The
 guest cannot access host resources unless the host exposes them through a
 host function.
 
-The environment containing the guest is referred to as the **sandbox**. The
-sandbox creates a boundary between untrusted code and the rest of your
-application.
+The environment containing the guest is called the **sandbox**. The sandbox
+creates a boundary between untrusted code and the rest of your application.
 
 ## Runs and invocations
 
@@ -101,7 +100,7 @@ The host and guest do not share JavaScript objects. Arguments, host function
 outputs, and final results are serialized and copied across the sandbox
 boundary.
 
-A call such as `users.find("user_123")` is known internally as a **bridge
-request**. The guest sends the serialized arguments to the host, the host calls
-the host function, and the serialized outcome is returned to the guest. The
-host function may be synchronous or asynchronous.
+A call such as `users.find("user_123")` is called a **bridge request**. The
+guest sends the serialized arguments to the host, the host calls the host
+function, and the serialized outcome is returned to the guest. The host
+function may be synchronous or asynchronous.

--- a/content/docs/foundations/overview.mdx
+++ b/content/docs/foundations/overview.mdx
@@ -3,18 +3,13 @@ title: Overview
 description: Learn the core concepts behind executing code with run.
 ---
 
-# Introduction
+# Overview
 
 `run` executes JavaScript and TypeScript without giving that code direct access
-to your application or system. It is designed for applications that need to
-execute generated or otherwise untrusted code, including coding agents and code
-interpreters.
+to your application or system. Your application decides which functions the
+code can call, how much work it may perform, and what happens to its result.
 
-The package separates the code being executed from the application executing
-it. Your application decides which functions are available, how much work the
-code may perform, and how its result should be handled.
-
-Here is a complete example:
+A complete example:
 
 ```ts
 import { run } from 'run';
@@ -62,11 +57,10 @@ application.
 A **run** is one logical execution of a source program. Most runs consist of a
 single invocation that either returns a value or throws an error.
 
-Some runs need to pause while the host waits for approval, authentication, or
-another external decision. Continuing one of these runs starts another
-**invocation** of the same logical run. The source executes again, while
-previous host function outcomes are replayed so that completed work does not
-need to be repeated.
+Some runs need to pause while the host waits for an approval or an
+authentication step. Continuing one of these runs starts another **invocation**
+of the same logical run. The source executes again, while previous host
+function outcomes are replayed so that completed work is not repeated.
 
 The term **logical run** refers to the complete workflow across the original
 invocation and any later replay attempts.
@@ -97,9 +91,9 @@ const result = await run({
 });
 ```
 
-Each invocation receives a new QuickJS context. Guest globals, values, and
-mutations therefore do not carry into another invocation. The worker thread
-that hosts QuickJS may be reused after the context has been disposed.
+Each invocation receives a new QuickJS context, so guest globals, values, and
+mutations do not carry into another invocation. The worker thread that hosts
+QuickJS may be reused after the context has been disposed.
 
 ## Communication
 

--- a/content/docs/foundations/sandbox.mdx
+++ b/content/docs/foundations/sandbox.mdx
@@ -9,10 +9,9 @@ The sandbox is the restricted JavaScript environment in which guest source
 executes. It is implemented with QuickJS inside a Node.js worker thread and is
 created fresh for every invocation.
 
-The sandbox provides the JavaScript features needed to perform useful
-computation while removing ambient access to the host application. Any access
-to application data or external services must be provided explicitly through a
-host function.
+The sandbox provides the JavaScript needed to compute over data, but no ambient
+access to the host application. Reaching application data or an external
+service requires a host function.
 
 ## Source
 
@@ -37,9 +36,9 @@ const result = await run({
   with `atob()` and `btoa()`.
 - The guest implementation of `Date` and `Math.random()` is deterministic. This
   allows an interrupted run to execute consistently when it is replayed.
-- TypeScript annotations are removed before execution. This makes common
-  TypeScript syntax convenient to use, but it does not provide type checking or
-  the complete behavior of a TypeScript compiler.
+- TypeScript annotations are stripped before execution. Common TypeScript
+  syntax works, but nothing is type-checked and this is not a full TypeScript
+  compiler.
 - The source cannot use static imports or dynamic `import()`. Dependencies must
   either be included directly in the source or represented by a host function.
 - The sandbox does not provide Node.js globals such as `process`, `require`,
@@ -71,8 +70,8 @@ A host function namespace must be a valid JavaScript identifier and must not
 conflict with a reserved global. Names beginning with `__run` are reserved for
 the runtime.
 
-The sandbox also contains internal runtime helpers. These helpers are
-implementation details and are not part of the supported guest API.
+The sandbox also contains internal runtime helpers. They are implementation
+details, not part of the guest API.
 
 ## Isolation
 
@@ -83,21 +82,20 @@ guest state does not persist between invocations.
 Worker threads may be pooled and reused. Reusing a worker does not reuse the
 guest context that previously ran inside it.
 
-The sandbox combines a separate JavaScript engine, a worker thread, hardened
+The sandbox is a separate JavaScript engine on a worker thread, with hardened
 globals, explicit host functions, serialization, and resource limits. It is not
-a container, virtual machine, or separate operating-system process.
+a container, a virtual machine, or a separate operating-system process.
 
 ## Trust
 
 The sandbox controls what guest code can access directly, but host functions
-remain trusted application code. A broad host function can expose a broad
-capability, even when the sandbox itself is correctly configured.
+remain trusted application code. A broad host function grants broad authority,
+however well the sandbox itself is configured.
 
-For example, a host function that accepts an arbitrary URL and forwards any
-request would effectively provide general network access. A safer host function
-would accept a specific business-level operation, validate its arguments,
-enforce authorization in the host, and return only the required data.
+A host function that accepts an arbitrary URL and forwards the request, for
+example, hands the guest general network access. Accept a specific
+business-level operation instead, validate its arguments, enforce authorization
+in the host, and return only the data the guest needs.
 
-The sandbox should therefore be treated as one part of the security model.
-Host function design and resource limits determine the practical authority
-available to guest code.
+The sandbox is one part of the security model. Host function design and
+resource limits determine what guest code can actually do.

--- a/content/docs/foundations/serialization.mdx
+++ b/content/docs/foundations/serialization.mdx
@@ -170,18 +170,18 @@ Console output has a shared 64 KiB limit for each invocation. Continuation state
 has a separate 32 MiB limit, and source code has a 256 KiB limit before
 execution begins.
 
-A value that appears small as a JavaScript object can have a larger serialized
-representation. Host functions should return references, summaries, or
-paginated data instead of transferring large record sets when possible.
+A value that appears small as a JavaScript object can have a much larger
+serialized representation. Return references, summaries, or paginated data
+rather than whole record sets.
 
 ## Contracts
 
-The serialization boundary should be treated like an API boundary. Each host
-function should have a deliberate input and output shape, and both sides should
-avoid relying on host-specific implementation details.
+Treat the serialization boundary like an API boundary. Give each host function
+an explicit input and output shape, and do not rely on host implementation
+details on either side.
 
-The following host function accepts a small input object and returns a small,
-explicit result:
+This host function validates a small input object and returns only the fields
+the guest needs:
 
 ```ts
 const hostFunctions = {
@@ -206,6 +206,3 @@ const hostFunctions = {
   },
 };
 ```
-
-This approach keeps the boundary predictable, limits the authority of guest
-code, and makes the host function easier to test.

--- a/content/docs/introduction/index.mdx
+++ b/content/docs/introduction/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: run
-description: Securely execute JavaScript and TypeScript with explicit host functions and resumable interruptions.
+description: Execute JavaScript and TypeScript with explicit host functions and resumable interruptions.
 ---
 
 # run
@@ -8,10 +8,10 @@ description: Securely execute JavaScript and TypeScript with explicit host funct
 `run` is a TypeScript package for executing untrusted JavaScript and TypeScript
 without giving it direct access to your application or system.
 
-It is designed for coding agents, code interpreters, and other applications
-that need to execute generated code. Each invocation runs in a hardened QuickJS
-sandbox with no ambient access to Node.js, the filesystem, environment
-variables, modules, or the network.
+Use it for coding agents, code interpreters, and anything else that executes
+generated code. Each invocation runs in a hardened QuickJS sandbox with no
+ambient access to Node.js, the filesystem, environment variables, modules, or
+the network.
 
 ## How it works
 
@@ -24,9 +24,9 @@ you provide. Arguments and return values are serialized across the sandbox
 boundary, and every invocation uses a fresh QuickJS context inside a worker
 thread.
 
-Host functions can also interrupt execution for workflows that require approval,
-authentication, or another external decision. The run can then resume from a
-signed continuation without repeating host functions that already completed.
+A host function can also interrupt execution when the workflow needs an
+approval or an authentication step. The run resumes from a signed continuation
+without repeating host functions that already completed.
 
 ## Install
 
@@ -59,8 +59,8 @@ if (result.status === 'completed') {
 ```
 
 The `tools` host function group becomes a global named `tools` inside the
-sandbox. Calling `tools.double(21)` invokes the host function with the same
-arguments and returns its result to the sandbox.
+sandbox, so `tools.double(21)` calls the host function with those arguments and
+returns its result to the guest.
 
 ## Core APIs
 

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -310,7 +310,7 @@ const result = await run({
 });
 
 if (result.status === 'interrupted') {
-  // Present the complete batch to the user, then resolve every item together.
+  // Present the full batch to the user, then resolve every item together.
   await run({
     source,
     hostFunctions,

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -1,10 +1,8 @@
 # run
 
-`run` is a secure and efficient alternative to `eval` for coding agents with
-support for TypeScript.
-
-It is suitable for code-mode, code interpreter, or other patterns that require
-execution of untrusted JS or TS.
+`run` is an alternative to `eval` for coding agents, with support for
+TypeScript. Use it for code-mode, code interpreters, and other patterns that
+execute untrusted JS or TS.
 
 `run` executes JavaScript in a hardened QuickJS sandbox. Guest code starts with
 no access to Node.js, the filesystem, environment variables, modules, or the


### PR DESCRIPTION
This is an editorial pass over the two READMEs and `content/docs`. No API or behavior changes.
