### PR TITLE
feat: support bun runtime

### DIFF
--- a/.changeset/fluffy-breads-peel.md
+++ b/.changeset/fluffy-breads-peel.md
@@ -1,0 +1,5 @@
+---
+"run": patch
+---
+
+feat: support bun runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -44,3 +47,6 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Test Bun compatibility
+        run: pnpm --filter run test:bun

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ QuickJS sandbox. Guest code can access only the host functions you provide.
 pnpm add run
 ```
 
-Requires Node.js 22.13 or newer.
+Supports Node.js 22.13 or newer and Bun.
 
 ```ts
 import { run } from 'run';

--- a/content/docs/introduction/index.mdx
+++ b/content/docs/introduction/index.mdx
@@ -34,7 +34,7 @@ without repeating host functions that already completed.
 pnpm add run
 ```
 
-`run` requires Node.js 22.13 or newer.
+`run` supports Node.js 22.13 or newer and Bun.
 
 ## Run your first program
 

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -18,7 +18,7 @@ repeating already invoked host functions.
 pnpm add run
 ```
 
-`run` requires Node.js 22.13 or newer.
+`run` supports Node.js 22.13 or newer and Bun.
 
 ## Run JavaScript
 

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -36,6 +36,7 @@
     "fix": "ultracite fix",
     "type-check": "tsc -p tsconfig.build.json --noEmit && tsc -p src/tsconfig.json",
     "test": "pnpm build && pnpm test:node",
+    "test:bun": "pnpm build && bun scripts/bun-smoke.mjs && bun --bun vitest --config vitest.node.config.js --run",
     "test:hardening": "pnpm build && vitest --config vitest.node.config.js --run",
     "test:watch": "vitest --config vitest.node.config.js",
     "test:node": "vitest --config vitest.node.config.js --run",

--- a/packages/run/scripts/bun-smoke.mjs
+++ b/packages/run/scripts/bun-smoke.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { run } from '../dist/index.js';
+
+const javascriptResult = await run({
+  source: 'return 40 + 2;',
+});
+assert.deepEqual(javascriptResult, {
+  status: 'completed',
+  value: 42,
+});
+
+const typescriptAndHostFunctionResult = await run({
+  hostFunctions: {
+    math: {
+      values: () => [20, 22],
+    },
+  },
+  source: `
+    const values: number[] = await math.values();
+    return values.reduce((total: number, value: number) => total + value, 0);
+  `,
+});
+assert.deepEqual(typescriptAndHostFunctionResult, {
+  status: 'completed',
+  value: 42,
+});

--- a/packages/run/scripts/bun-smoke.mjs
+++ b/packages/run/scripts/bun-smoke.mjs
@@ -24,3 +24,15 @@ assert.deepEqual(typescriptAndHostFunctionResult, {
   status: 'completed',
   value: 42,
 });
+
+await assert.rejects(
+  run({
+    limits: { timeoutMs: 250 },
+    source: 'while (true) {}',
+  }),
+  { code: 'RUN_TIMEOUT' },
+);
+assert.deepEqual(await run({ source: 'return 1;' }), {
+  status: 'completed',
+  value: 1,
+});

--- a/packages/run/src/runtime/bundled-runtime.test.ts
+++ b/packages/run/src/runtime/bundled-runtime.test.ts
@@ -53,12 +53,12 @@ describe('bundled runtime', () => {
       script,
       `
         for (const specifier of ['run/worker', 'run/quickjs-wasm', 'run/runtime/worker-source']) {
+          let resolved = false;
           try {
             import.meta.resolve(specifier);
-            throw new Error('Expected resolution to fail: ' + specifier);
-          } catch (error) {
-            if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error;
-          }
+            resolved = true;
+          } catch {}
+          if (resolved) throw new Error('Expected resolution to fail: ' + specifier);
         }
       `,
     );

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -80,6 +80,8 @@ let terminatingWorkers = 0;
 let inlineWorkerUrl: URL | undefined;
 const idleWorkers: PooledWorker[] = [];
 let workerFactory: () => Worker = createRuntimeWorker;
+const isBunRuntime = (globalThis as { Bun?: unknown }).Bun !== undefined;
+const BUN_WORKER_TERMINATE_GRACE_MS = 100;
 
 const runInBackground = async (operation: Promise<unknown>): Promise<void> => {
   await operation;
@@ -1220,7 +1222,7 @@ function createWorker(): PooledWorker {
 }
 
 function createRuntimeWorker(): Worker {
-  if ((globalThis as { Bun?: unknown }).Bun !== undefined) {
+  if (isBunRuntime) {
     return new Worker(INLINE_RUN_WORKER_SOURCE, { eval: true, execArgv: [] });
   }
   return new Worker(getInlineWorkerUrl(), { execArgv: [] });
@@ -1248,6 +1250,30 @@ function releaseWorker(pooledWorker: PooledWorker): void {
   idleWorkers.push(pooledWorker);
 }
 
+async function terminatePooledWorker(worker: Worker): Promise<void> {
+  const termination = Promise.resolve(worker.terminate());
+  if (!isBunRuntime) {
+    await termination;
+    return;
+  }
+
+  // Bun's worker_threads.terminate() can hang (oven-sh/bun#12616 and
+  // follow-ups), including when the thread is busy in QuickJS WASM. Bound the
+  // wait so caller settlement and pool accounting can proceed. The interval
+  // keeps the event loop alive while we wait (oven-sh/bun#12614).
+  const keepalive = setInterval(() => undefined, 1_000);
+  try {
+    await Promise.race([
+      termination,
+      new Promise<void>(resolve => {
+        setTimeout(resolve, BUN_WORKER_TERMINATE_GRACE_MS);
+      }),
+    ]);
+  } finally {
+    clearInterval(keepalive);
+  }
+}
+
 async function destroyWorker(pooledWorker: PooledWorker): Promise<void> {
   if (pooledWorker.destroyed) {
     return;
@@ -1256,7 +1282,7 @@ async function destroyWorker(pooledWorker: PooledWorker): Promise<void> {
   pooledWorker.worker.removeAllListeners();
   terminatingWorkers += 1;
   try {
-    await pooledWorker.worker.terminate();
+    await terminatePooledWorker(pooledWorker.worker);
   } catch {
     // The worker may already have exited between the state check and terminate.
   } finally {

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -1224,6 +1224,16 @@ function createRuntimeWorker(): Worker {
 }
 
 function getInlineWorkerUrl(): URL {
+  if (
+    inlineWorkerUrl === undefined &&
+    (globalThis as { Bun?: unknown }).Bun !== undefined
+  ) {
+    inlineWorkerUrl = new URL(
+      URL.createObjectURL(
+        new Blob([INLINE_RUN_WORKER_SOURCE], { type: 'text/javascript' }),
+      ),
+    );
+  }
   inlineWorkerUrl ??= new URL(
     `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
   );

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -1259,18 +1259,17 @@ async function terminatePooledWorker(worker: Worker): Promise<void> {
 
   // Bun's worker_threads.terminate() can hang (oven-sh/bun#12616 and
   // follow-ups), including when the thread is busy in QuickJS WASM. Bound the
-  // wait so caller settlement and pool accounting can proceed. The interval
-  // keeps the event loop alive while we wait (oven-sh/bun#12614).
-  const keepalive = setInterval(() => undefined, 1_000);
+  // wait so caller settlement and pool accounting can proceed. The grace
+  // timer also keeps the event loop alive while we wait (oven-sh/bun#12614).
+  const grace = createPromiseWithResolvers<null>();
+  const graceHandle = setTimeout(
+    () => grace.resolve(null),
+    BUN_WORKER_TERMINATE_GRACE_MS,
+  );
   try {
-    await Promise.race([
-      termination,
-      new Promise<void>(resolve => {
-        setTimeout(resolve, BUN_WORKER_TERMINATE_GRACE_MS);
-      }),
-    ]);
+    await Promise.race([termination, grace.promise]);
   } finally {
-    clearInterval(keepalive);
+    clearTimeout(graceHandle);
   }
 }
 

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -1220,20 +1220,13 @@ function createWorker(): PooledWorker {
 }
 
 function createRuntimeWorker(): Worker {
+  if ((globalThis as { Bun?: unknown }).Bun !== undefined) {
+    return new Worker(INLINE_RUN_WORKER_SOURCE, { eval: true, execArgv: [] });
+  }
   return new Worker(getInlineWorkerUrl(), { execArgv: [] });
 }
 
 function getInlineWorkerUrl(): URL {
-  if (
-    inlineWorkerUrl === undefined &&
-    (globalThis as { Bun?: unknown }).Bun !== undefined
-  ) {
-    inlineWorkerUrl = new URL(
-      URL.createObjectURL(
-        new Blob([INLINE_RUN_WORKER_SOURCE], { type: 'text/javascript' }),
-      ),
-    );
-  }
   inlineWorkerUrl ??= new URL(
     `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
   );

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -29,17 +29,15 @@ const createRunMessage = (
 });
 
 it('reports message failures and ignores late messages without crashing', async () => {
-  const workerUrl =
+  const worker =
     (globalThis as { Bun?: unknown }).Bun === undefined
-      ? new URL(
-          `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
-        )
-      : new URL(
-          URL.createObjectURL(
-            new Blob([INLINE_RUN_WORKER_SOURCE], { type: 'text/javascript' }),
+      ? new Worker(
+          new URL(
+            `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
           ),
-        );
-  const worker = new Worker(workerUrl, { execArgv: [] });
+          { execArgv: [] },
+        )
+      : new Worker(INLINE_RUN_WORKER_SOURCE, { eval: true, execArgv: [] });
   const postToWorker = (message: MainToWorkerMessage): void => {
     // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
     worker.postMessage(message);

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -29,9 +29,16 @@ const createRunMessage = (
 });
 
 it('reports message failures and ignores late messages without crashing', async () => {
-  const workerUrl = new URL(
-    `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
-  );
+  const workerUrl =
+    (globalThis as { Bun?: unknown }).Bun === undefined
+      ? new URL(
+          `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
+        )
+      : new URL(
+          URL.createObjectURL(
+            new Blob([INLINE_RUN_WORKER_SOURCE], { type: 'text/javascript' }),
+          ),
+        );
   const worker = new Worker(workerUrl, { execArgv: [] });
   const postToWorker = (message: MainToWorkerMessage): void => {
     // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.

--- a/packages/run/src/utils/source-cache.test.ts
+++ b/packages/run/src/utils/source-cache.test.ts
@@ -31,6 +31,16 @@ describe('source limits and transform cache', () => {
     expect(transformed.split('\n')).toHaveLength(source.split('\n').length);
   });
 
+  it('does not extract Bun transforms that inject external helpers', () => {
+    if ((globalThis as { Bun?: unknown }).Bun === undefined) {
+      return;
+    }
+
+    const source =
+      'using resource: Disposable = getResource();\nreturn resource;';
+    expect(transformSource(source)).toBe(source);
+  });
+
   it('does not cache transformed sources above the per-entry byte limit', () => {
     const largeSource = `const value = ${JSON.stringify('x'.repeat(70_000))}; return value.length;`;
     transformSource(largeSource);

--- a/packages/run/src/utils/source-cache.ts
+++ b/packages/run/src/utils/source-cache.ts
@@ -71,12 +71,27 @@ const stripSnippetTypes = (source: string): string => {
     return source;
   }
   try {
+    const wrapperDeclaration = 'async function __runUser__()';
     const transformed = bunTypeScriptTranspiler.transformSync(
-      `async function __runUser__(){\n${source}\n}`,
+      `${wrapperDeclaration}{\n${source}\n}`,
     );
-    const bodyStart = transformed.indexOf('{');
+    const declarationStart = transformed.indexOf(wrapperDeclaration);
+    if (
+      declarationStart === -1 ||
+      transformed.slice(0, declarationStart).trim() !== ''
+    ) {
+      return source;
+    }
+    const bodyStart = transformed.indexOf(
+      '{',
+      declarationStart + wrapperDeclaration.length,
+    );
     const bodyEnd = transformed.lastIndexOf('}');
-    if (bodyStart === -1 || bodyEnd <= bodyStart) {
+    if (
+      bodyStart === -1 ||
+      bodyEnd <= bodyStart ||
+      transformed.slice(bodyEnd + 1).trim() !== ''
+    ) {
       return source;
     }
     return transformed

--- a/packages/run/src/utils/source-cache.ts
+++ b/packages/run/src/utils/source-cache.ts
@@ -1,11 +1,24 @@
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
-import { stripTypeScriptTypes } from 'node:module';
+import * as nodeModule from 'node:module';
 import { RunSourceTooLargeError } from '../errors.js';
 
 const MAX_CACHE_ENTRIES = 256;
 const MAX_CACHE_BYTES = 4 * 1024 * 1024;
 const MAX_CACHE_ENTRY_BYTES = 64 * 1024;
+const bunRuntime = (
+  globalThis as typeof globalThis & {
+    Bun?: {
+      Transpiler: new (options: { loader: 'ts' }) => {
+        transformSync: (source: string) => string;
+      };
+    };
+  }
+).Bun;
+const bunTypeScriptTranspiler =
+  bunRuntime === undefined
+    ? undefined
+    : new bunRuntime.Transpiler({ loader: 'ts' });
 const transformedSourceCache = new Map<
   string,
   {
@@ -33,21 +46,46 @@ const evictTransformedSourceCache = (): void => {
 };
 
 const stripSnippetTypes = (source: string): string => {
-  const prefix = 'async function __runUser__(){\n';
-  const suffix = '\n}';
-  let stripped: string;
+  const { stripTypeScriptTypes } = nodeModule as typeof nodeModule & {
+    stripTypeScriptTypes?: (source: string) => string;
+  };
+  if (stripTypeScriptTypes !== undefined) {
+    const prefix = 'async function __runUser__(){\n';
+    const suffix = '\n}';
+    let stripped: string;
+    try {
+      stripped = stripTypeScriptTypes(`${prefix}${source}${suffix}`);
+    } catch {
+      // Let QuickJS report syntax failures. Its diagnostics use the same source
+      // filename and coordinates as runtime failures and do not expose the host
+      // TypeScript transform or its wrapper.
+      return source;
+    }
+    if (!stripped.startsWith(prefix) || !stripped.endsWith(suffix)) {
+      return source;
+    }
+    return stripped.slice(prefix.length, -suffix.length);
+  }
+
+  if (bunTypeScriptTranspiler === undefined) {
+    return source;
+  }
   try {
-    stripped = stripTypeScriptTypes(`${prefix}${source}${suffix}`);
+    const transformed = bunTypeScriptTranspiler.transformSync(
+      `async function __runUser__(){\n${source}\n}`,
+    );
+    const bodyStart = transformed.indexOf('{');
+    const bodyEnd = transformed.lastIndexOf('}');
+    if (bodyStart === -1 || bodyEnd <= bodyStart) {
+      return source;
+    }
+    return transformed
+      .slice(bodyStart + 1, bodyEnd)
+      .replace(/^\n/u, '')
+      .replace(/\n$/u, '');
   } catch {
-    // Let QuickJS report syntax failures. Its diagnostics use the same source
-    // filename and coordinates as runtime failures and do not expose the host
-    // TypeScript transform or its wrapper.
     return source;
   }
-  if (!stripped.startsWith(prefix) || !stripped.endsWith(suffix)) {
-    return source;
-  }
-  return stripped.slice(prefix.length, -suffix.length);
 };
 
 export const assertSourceSize = (


### PR DESCRIPTION
we had 2 incompatibilities before: 

- Bun 1.2.21 didn't export Node’s `stripTypeScriptTypes` API.
  - Fixed by detecting the runtime and using `Bun.Transpiler` for TypeScript stripping.

- Bun workers don’t accept the large inline worker as a data: URL
  - Fixed by using a `blob: URL` under Bun while retaining `data: URL` under Node.