### PR TITLE
feat: use quickjs-wasi for runtime

### DIFF
--- a/.changeset/short-bags-cross.md
+++ b/.changeset/short-bags-cross.md
@@ -1,0 +1,5 @@
+---
+"run": patch
+---
+
+feat: use quickjs-wasi for runtime

--- a/packages/run/THIRD_PARTY_NOTICES.md
+++ b/packages/run/THIRD_PARTY_NOTICES.md
@@ -1,16 +1,14 @@
 # Third-party notices
 
 `run` embeds the `devalue` serializer and a QuickJS WebAssembly runtime built by the
-[`quickjs-emscripten`](https://github.com/justjake/quickjs-emscripten) project.
+[`quickjs-wasi`](https://github.com/vercel-labs/quickjs-wasi) project.
 The following packages are used to build the published JavaScript and embedded
 WebAssembly artifact:
 
-| Package                                   | Version | License |
-| ----------------------------------------- | ------- | ------- |
-| `devalue`                                 | 5.8.2   | MIT     |
-| `quickjs-emscripten`                      | 0.32.0  | MIT     |
-| `quickjs-emscripten-core`                 | 0.32.0  | MIT     |
-| `@jitl/quickjs-wasmfile-release-asyncify` | 0.32.0  | MIT     |
+| Package        | Version | License |
+| -------------- | ------- | ------- |
+| `devalue`      | 5.8.2   | MIT     |
+| `quickjs-wasi` | 3.5.0   | MIT     |
 
 The release verification script rejects unreviewed changes to these embedded
 dependencies.
@@ -37,11 +35,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## quickjs-emscripten
+## quickjs-wasi
 
 The MIT License
 
-quickjs-emscripten copyright (c) 2019-2024 Jake Teton-Landis
+Copyright (c) quickjs-wasi contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -65,8 +63,10 @@ SOFTWARE.
 
 QuickJS Javascript Engine
 
-Copyright (c) 2017-2021 Fabrice Bellard
-Copyright (c) 2017-2021 Charlie Gordon
+Copyright (c) 2017-2026 Fabrice Bellard
+Copyright (c) 2017-2025 Charlie Gordon
+Copyright (c) 2023-2026 Ben Noordhuis
+Copyright (c) 2023-2026 Saúl Ibarra Corretgé
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/run/THIRD_PARTY_NOTICES.md
+++ b/packages/run/THIRD_PARTY_NOTICES.md
@@ -8,7 +8,7 @@ WebAssembly artifact:
 | Package        | Version | License |
 | -------------- | ------- | ------- |
 | `devalue`      | 5.8.2   | MIT     |
-| `quickjs-wasi` | 3.5.0   | MIT     |
+| `quickjs-wasi` | 3.6.0   | MIT     |
 
 The release verification script rejects unreviewed changes to these embedded
 dependencies.

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -55,7 +55,7 @@
     "esbuild": "^0.28.1",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",
-    "quickjs-wasi": "3.5.0",
+    "quickjs-wasi": "3.6.0",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
     "ultracite": "7.3.2",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -55,7 +55,7 @@
     "esbuild": "^0.28.1",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",
-    "quickjs-emscripten": "0.32.0",
+    "quickjs-wasi": "3.5.0",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
     "ultracite": "7.3.2",

--- a/packages/run/scripts/embed-inline-worker.mjs
+++ b/packages/run/scripts/embed-inline-worker.mjs
@@ -1,16 +1,10 @@
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
 
 const require = createRequire(import.meta.url);
-const quickjsPackageJsonPath =
-  require.resolve('quickjs-emscripten/package.json');
-const quickjsRequire = createRequire(quickjsPackageJsonPath);
-const quickjsWasmPath = quickjsRequire.resolve(
-  '@jitl/quickjs-wasmfile-release-asyncify/wasm',
-);
+const quickjsWasmPath = require.resolve('quickjs-wasi/quickjs.wasm');
 
 const outputPath = new URL('../dist/runtime/worker-source.js', import.meta.url);
 const guestSerdeOutputPath = new URL(
@@ -36,38 +30,6 @@ const workerPath = fileURLToPath(
   new URL('../dist/runtime/worker.js', import.meta.url),
 );
 
-const createInlineQuickJsRuntimePlugin = quickJsPackageRoot => ({
-  name: 'run-inline-quickjs-runtime',
-  setup(esbuild) {
-    esbuild.onResolve({ filter: /^quickjs-emscripten$/ }, () => ({
-      namespace: 'run-inline',
-      path: 'quickjs-emscripten-inline',
-    }));
-
-    esbuild.onLoad(
-      {
-        filter: /^quickjs-emscripten-inline$/,
-        namespace: 'run-inline',
-      },
-      () => ({
-        contents: [
-          'import { newQuickJSAsyncWASMModuleFromVariant, newVariant } from "quickjs-emscripten-core";',
-          'import { QuickJSAsyncFFI } from "@jitl/quickjs-wasmfile-release-asyncify/ffi";',
-          'import quickJSRawModule from "@jitl/quickjs-wasmfile-release-asyncify/emscripten-module";',
-          'const quickJSRaw = quickJSRawModule.default ?? quickJSRawModule;',
-          'export const RELEASE_ASYNC = { type: "async", importFFI: () => Promise.resolve(QuickJSAsyncFFI), importModuleLoader: () => Promise.resolve(quickJSRaw) };',
-          'export async function newQuickJSAsyncWASMModule(variantOrPromise = RELEASE_ASYNC) {',
-          '  return newQuickJSAsyncWASMModuleFromVariant(variantOrPromise);',
-          '}',
-          'export { newVariant };',
-        ].join('\n'),
-        loader: 'js',
-        resolveDir: quickJsPackageRoot,
-      }),
-    );
-  },
-});
-
 const buildInlineWorkerBundle = async () => {
   const result = await build({
     bundle: true,
@@ -78,9 +40,6 @@ const buildInlineWorkerBundle = async () => {
     legalComments: 'none',
     minify: true,
     platform: 'node',
-    plugins: [
-      createInlineQuickJsRuntimePlugin(dirname(quickjsPackageJsonPath)),
-    ],
     sourcemap: false,
     target: 'node22',
     write: false,
@@ -128,8 +87,10 @@ const assertBundledInlineWorkerSource = source => {
     [/\brequire\(/u, 'CommonJS require'],
     [/\bimport\(/u, 'dynamic import'],
     [/\bcreateRequire\b/u, 'createRequire'],
-    [/["']quickjs-emscripten["']/u, 'quickjs-emscripten package specifier'],
-    [/@jitl\//u, '@jitl package specifier'],
+    [
+      /["']quickjs-wasi\/quickjs\.wasm["']/u,
+      'quickjs-wasi WASM package specifier',
+    ],
     [/node_modules\/\.pnpm/u, 'absolute pnpm node_modules path'],
   ];
 

--- a/packages/run/scripts/verify-dependencies.mjs
+++ b/packages/run/scripts/verify-dependencies.mjs
@@ -13,7 +13,7 @@ const expected = [
   {
     license: 'MIT',
     name: 'quickjs-wasi',
-    version: '3.5.0',
+    version: '3.6.0',
   },
 ];
 

--- a/packages/run/scripts/verify-dependencies.mjs
+++ b/packages/run/scripts/verify-dependencies.mjs
@@ -12,33 +12,20 @@ const expected = [
   },
   {
     license: 'MIT',
-    name: 'quickjs-emscripten',
-    version: '0.32.0',
-  },
-  {
-    license: 'MIT',
-    name: 'quickjs-emscripten-core',
-    version: '0.32.0',
-  },
-  {
-    license: 'MIT',
-    name: '@jitl/quickjs-wasmfile-release-asyncify',
-    version: '0.32.0',
+    name: 'quickjs-wasi',
+    version: '3.5.0',
   },
 ];
 
-const quickJsManifestPath = require.resolve('quickjs-emscripten/package.json');
-const quickJsRequire = createRequire(quickJsManifestPath);
-
-async function findManifest(packageName, entryPath) {
-  let directory = dirname(entryPath);
+async function findManifest(packageName) {
+  let directory = dirname(require.resolve(packageName));
 
   while (true) {
     const manifestPath = join(directory, 'package.json');
     try {
       const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
       if (manifest.name === packageName) {
-        return { manifest, manifestPath };
+        return manifest;
       }
     } catch (error) {
       if (error?.code !== 'ENOENT') {
@@ -56,17 +43,7 @@ async function findManifest(packageName, entryPath) {
 
 const inventory = await Promise.all(
   expected.map(async expectedPackage => {
-    const { manifest } =
-      expectedPackage.name === 'quickjs-emscripten'
-        ? {
-            manifest: JSON.parse(await readFile(quickJsManifestPath, 'utf8')),
-          }
-        : await findManifest(
-            expectedPackage.name,
-            expectedPackage.name === 'devalue'
-              ? require.resolve('devalue')
-              : quickJsRequire.resolve(expectedPackage.name),
-          );
+    const manifest = await findManifest(expectedPackage.name);
     const actual = {
       license: manifest.license,
       name: manifest.name,

--- a/packages/run/src/resource-hardening.test.ts
+++ b/packages/run/src/resource-hardening.test.ts
@@ -95,6 +95,38 @@ describe('resource and lifecycle hardening', () => {
     }
   });
 
+  it('surfaces stack exhaustion as a catchable guest error at the configured limit', async () => {
+    await expect(
+      run({
+        limits: {
+          maxStackSizeBytes: 64 * 1024,
+          timeoutMs: 1000,
+        },
+        source: `
+            function recurse() {
+              return recurse();
+            }
+            try {
+              recurse();
+              return { caught: false };
+            } catch (error) {
+              return {
+                caught: true,
+                message: String(error && error.message),
+                name: String(error && error.name),
+              };
+            }
+          `,
+      }),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      value: {
+        caught: true,
+        message: expect.stringMatching(/stack/i),
+      },
+    });
+  });
+
   it('aborts a pending host function on timeout and releases runtime capacity', async () => {
     const started = deferred<null>();
     const aborted = deferred<null>();

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -70,6 +70,17 @@ const HARDENING_SOURCE = `
       configurable: false,
     });
   }
+  for (const name of [
+    'AsyncDisposableStack',
+    'DOMException',
+    'DisposableStack',
+    'SuppressedError',
+    'atob',
+    'btoa',
+    'queueMicrotask',
+  ]) {
+    try { delete globalThis[name]; } catch {}
+  }
 
   Object.defineProperty(globalThis, 'eval', {
     value: undefined,

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -1,16 +1,8 @@
 import { writeSync } from 'node:fs';
 import { formatWithOptions } from 'node:util';
 import { parentPort } from 'node:worker_threads';
-import {
-  newQuickJSAsyncWASMModule,
-  newVariant,
-  RELEASE_ASYNC,
-} from 'quickjs-emscripten';
-import type {
-  QuickJSAsyncContext,
-  QuickJSDeferredPromise,
-  QuickJSHandle,
-} from 'quickjs-emscripten';
+import { JSException, QuickJS } from 'quickjs-wasi';
+import type { Deferred, JSValueHandle } from 'quickjs-wasi';
 import {
   RunProtocolError,
   RunTimeoutError,
@@ -31,10 +23,10 @@ if (!parentPort) {
 const pendingBridgeRequests = new Map<
   string,
   {
-    context: QuickJSAsyncContext;
-    deferred: QuickJSDeferredPromise;
+    context: QuickJS;
+    deferred: Deferred;
     invocationId: string;
-    resetDateNow?: QuickJSHandle;
+    resetDateNow?: JSValueHandle;
   }
 >();
 let activeInvocationId: string | undefined;
@@ -173,28 +165,26 @@ async function run(message: WorkerRunMessage): Promise<void> {
 }
 
 async function execute(message: WorkerRunMessage): Promise<string> {
-  const context = await createQuickJSContext();
-  const { runtime } = context;
   const deadline = Date.now() + message.options.executionTimeoutMs;
   let interruptChecks = 0;
-  let bridgeFunctions: { invokeHostFunction: QuickJSHandle } | undefined;
-  let consoleFormatter: QuickJSHandle | undefined;
-  let determinismHandle: QuickJSHandle | undefined;
-  let resetDateNowHandle: QuickJSHandle | undefined;
   let cancelled = false;
   let executionTimedOut = false;
+  const context = await createQuickJSContext({
+    interruptHandler: () => {
+      interruptChecks += 1;
+      const timedOut = interruptChecks > 10_000 || Date.now() > deadline;
+      executionTimedOut ||= timedOut;
+      return cancelled || timedOut;
+    },
+    memoryLimitBytes: message.options.memoryLimitBytes,
+  });
+  let bridgeFunctions: { invokeHostFunction: JSValueHandle } | undefined;
+  let consoleFormatter: JSValueHandle | undefined;
+  let determinismHandle: JSValueHandle | undefined;
+  let resetDateNowHandle: JSValueHandle | undefined;
   let executionFailure: { error: unknown } | undefined;
   const getExecutionFailure = (): { error: unknown } | undefined =>
     executionFailure;
-
-  runtime.setMemoryLimit(message.options.memoryLimitBytes);
-  runtime.setMaxStackSize(message.options.maxStackSizeBytes);
-  runtime.setInterruptHandler(() => {
-    interruptChecks += 1;
-    const timedOut = interruptChecks > 10_000 || Date.now() > deadline;
-    executionTimedOut ||= timedOut;
-    return cancelled || timedOut;
-  });
   activeCancellation = {
     cancel: () => {
       cancelled = true;
@@ -234,7 +224,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       () => resetDateNowHandle,
     );
     determinismHandle = jsToHandle(context, message.determinism);
-    resetDateNowHandle = await initializeGuestRuntime(
+    resetDateNowHandle = initializeGuestRuntime(
       context,
       message,
       bridgeFunctions.invokeHostFunction,
@@ -275,104 +265,83 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     for (const [requestId] of pendingForInvocation) {
       pendingBridgeRequests.delete(requestId);
     }
-    if (bridgeFunctions?.invokeHostFunction.alive) {
-      bridgeFunctions.invokeHostFunction.dispose();
-    }
-    if (consoleFormatter?.alive) {
-      consoleFormatter.dispose();
-    }
-    if (resetDateNowHandle?.alive) {
-      resetDateNowHandle.dispose();
-    }
-    if (determinismHandle?.alive) {
-      determinismHandle.dispose();
-    }
+    disposeHandle(bridgeFunctions?.invokeHostFunction);
+    disposeHandle(consoleFormatter);
+    disposeHandle(resetDateNowHandle);
+    disposeHandle(determinismHandle);
     context.dispose();
   }
 }
 
-async function initializeGuestRuntime(
-  context: QuickJSAsyncContext,
+function initializeGuestRuntime(
+  context: QuickJS,
   message: WorkerRunMessage,
-  invokeHostFunction: QuickJSHandle,
-  determinismHandle: QuickJSHandle,
-): Promise<QuickJSHandle | undefined> {
+  invokeHostFunction: JSValueHandle,
+  determinismHandle: JSValueHandle,
+): JSValueHandle | undefined {
   const setupSource = buildGuestRuntimeSetupSource(
     message.hostFunctionNamespaces,
   );
-  const setupEvalResult = await context.evalCodeAsync(
-    setupSource,
-    'run-setup.js',
-  );
-  if (setupEvalResult.error) {
-    const error = context.dump(setupEvalResult.error);
-    if (setupEvalResult.error.alive) {
-      setupEvalResult.error.dispose();
-    }
-    throw toError(error);
+  let setupFunction: JSValueHandle;
+  try {
+    setupFunction = context.evalCode(setupSource, 'run-setup.js');
+  } catch (error) {
+    throw toError(dumpQuickJSError(context, error));
   }
   try {
-    const setupCallResult = context.callFunction(
-      setupEvalResult.value,
-      context.undefined,
-      invokeHostFunction,
-      determinismHandle,
-    );
-    if (setupCallResult.error) {
-      const error = context.dump(setupCallResult.error);
-      if (setupCallResult.error.alive) {
-        setupCallResult.error.dispose();
-      }
-      throw toError(error);
+    let setupResult: JSValueHandle;
+    try {
+      setupResult = context.callFunction(
+        setupFunction,
+        context.undefined,
+        invokeHostFunction,
+        determinismHandle,
+      );
+    } catch (error) {
+      throw toError(dumpQuickJSError(context, error));
     }
-    if (!setupCallResult.value.alive) {
-      return undefined;
+    try {
+      return setupResult.getProp('resetDateNow');
+    } finally {
+      setupResult.dispose();
     }
-    const resetDateNowHandle = context.getProp(
-      setupCallResult.value,
-      'resetDateNow',
-    );
-    setupCallResult.value.dispose();
-    return resetDateNowHandle;
   } finally {
-    if (setupEvalResult.value.alive) {
-      setupEvalResult.value.dispose();
-    }
+    setupFunction.dispose();
+  }
+}
+
+function disposeHandle(handle: JSValueHandle | undefined): void {
+  if (handle !== undefined && !handle.disposed) {
+    handle.dispose();
   }
 }
 
 async function evaluateUserSource(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
   message: WorkerRunMessage,
 ): Promise<string> {
   const wrapped = wrapUserCode(message.source);
-  const evalResult = await context.evalCodeAsync(wrapped, 'run.js');
-  if (evalResult.error) {
-    const error = context.dump(evalResult.error);
-    if (evalResult.error.alive) {
-      evalResult.error.dispose();
-    }
-    throw toUserSourceError(error, message.source);
-  }
-  if (evalResult.value.alive) {
-    evalResult.value.dispose();
+  try {
+    context.evalCode(wrapped, 'run.js').dispose();
+  } catch (error) {
+    throw toUserSourceError(dumpQuickJSError(context, error), message.source);
   }
 
-  const promiseHandle = context.getProp(context.global, '__runResult');
+  const promiseHandle = context.global.getProp('__runResult');
   const resolvedResult = await resolveQuickJSPromise(context, promiseHandle);
-  if (promiseHandle.alive) {
+  if (!promiseHandle.disposed) {
     promiseHandle.dispose();
   }
-  if (resolvedResult.error) {
-    const error = context.dump(resolvedResult.error);
-    if (resolvedResult.error.alive) {
+  if ('error' in resolvedResult) {
+    const error = dumpQuickJSErrorHandle(context, resolvedResult.error);
+    if (!resolvedResult.error.disposed) {
       resolvedResult.error.dispose();
     }
     throw toUserSourceError(error, message.source);
   }
 
   const valueJson = serializeQuickJSJsonPayload(context, resolvedResult.value);
-  if (resolvedResult.value.alive) {
+  if (!resolvedResult.value.disposed) {
     resolvedResult.value.dispose();
   }
   assertJsonPayloadSize(
@@ -384,10 +353,11 @@ async function evaluateUserSource(
 }
 
 function rejectPendingBridgeRequests(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
   invocationId: string,
   message: string,
 ): void {
+  let rejected = false;
   for (const pending of pendingBridgeRequests.values()) {
     if (pending.invocationId !== invocationId) {
       continue;
@@ -395,21 +365,26 @@ function rejectPendingBridgeRequests(
     const error = context.newError(message);
     pending.deferred.reject(error);
     error.dispose();
+    rejected = true;
+  }
+  if (rejected) {
+    context.executePendingJobs();
   }
 }
 
-async function createQuickJSContext(): Promise<QuickJSAsyncContext> {
+async function createQuickJSContext(options: {
+  interruptHandler: () => boolean;
+  memoryLimitBytes: number;
+}): Promise<QuickJS> {
   const embeddedWasmBase64 = getEmbeddedQuickJsWasmBase64();
-  if (embeddedWasmBase64 !== undefined) {
-    const variant = newVariant(RELEASE_ASYNC, {
-      wasmModule: () => getEmbeddedQuickJsWasmModule(embeddedWasmBase64),
-    });
-    const module = await newQuickJSAsyncWASMModule(variant);
-    return module.newContext();
+  if (embeddedWasmBase64 === undefined) {
+    throw new Error('Embedded QuickJS WASM bytes are unavailable.');
   }
-
-  const module = await newQuickJSAsyncWASMModule(RELEASE_ASYNC);
-  return module.newContext();
+  return QuickJS.create({
+    interruptHandler: options.interruptHandler,
+    memoryLimit: options.memoryLimitBytes,
+    wasm: await getEmbeddedQuickJsWasmModule(embeddedWasmBase64),
+  });
 }
 
 function getEmbeddedQuickJsWasmBase64(): string | undefined {
@@ -437,77 +412,95 @@ function decodeBase64ArrayBuffer(value: string): ArrayBuffer {
 }
 
 function serializeQuickJSJsonPayload(
-  context: QuickJSAsyncContext,
-  value: QuickJSHandle,
+  context: QuickJS,
+  value: JSValueHandle,
 ): string {
-  const serialize = context.getProp(
-    context.global,
-    '__runSerializeJsonPayload',
-  );
+  const serialize = context.global.getProp('__runSerializeJsonPayload');
   try {
-    const result = context.callFunction(serialize, context.undefined, value);
-    if (result.error) {
-      const error = context.dump(result.error);
-      if (result.error.alive) {
-        result.error.dispose();
-      }
-      throw toError(error);
+    let result: JSValueHandle;
+    try {
+      result = context.callFunction(serialize, context.undefined, value);
+    } catch (error) {
+      throw toError(dumpQuickJSError(context, error));
     }
-    const valueJson = context.getString(result.value);
-    if (result.value.alive) {
-      result.value.dispose();
+    try {
+      return result.toString();
+    } finally {
+      result.dispose();
     }
-    return valueJson;
   } finally {
-    if (serialize.alive) {
+    if (!serialize.disposed) {
       serialize.dispose();
     }
   }
 }
 
 function installConsole(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
   maxOutputBytes: number,
-): QuickJSHandle {
+): JSValueHandle {
   const outputBudget = { remainingBytes: maxOutputBytes };
-  const formatterResult = context.evalCode(`
-    (value, maxChars) => {
-      let rendered;
-      try {
-        rendered = typeof value === 'string' ? value : JSON.stringify(value);
-      } catch {}
-      return String(rendered === undefined ? value : rendered)
-      .slice(0, maxChars)
-      .replace(/[\\u0000-\\u001f\\u007f-\\u009f]/gu, character =>
-        character === '\\t'
-          ? '\\t'
-          : '\\\\u' + character.charCodeAt(0).toString(16).padStart(4, '0')
-      );
-    }
-  `);
-  if (formatterResult.error) {
-    const error = context.dump(formatterResult.error);
-    formatterResult.error.dispose();
-    throw toError(error);
+  let boundedFormatter: JSValueHandle;
+  try {
+    boundedFormatter = context.evalCode(`
+      (value, maxChars) => {
+        let rendered;
+        try {
+          rendered = typeof value === 'string' ? value : JSON.stringify(value);
+        } catch {}
+        return String(rendered === undefined ? value : rendered)
+        .slice(0, maxChars)
+        .replace(/[\\u0000-\\u001f\\u007f-\\u009f]/gu, character =>
+          character === '\\t'
+            ? '\\t'
+            : '\\\\u' + character.charCodeAt(0).toString(16).padStart(4, '0')
+        );
+      }
+    `);
+  } catch (error) {
+    throw toError(dumpQuickJSError(context, error));
   }
-  const boundedFormatter = formatterResult.value;
   const consoleHandle = context.newObject();
   const handles = [
     [
       'log',
-      createConsoleFunction(context, 'stdout', outputBudget, boundedFormatter),
+      createConsoleFunction(
+        context,
+        'console.log',
+        'stdout',
+        outputBudget,
+        boundedFormatter,
+      ),
     ],
     [
       'info',
-      createConsoleFunction(context, 'stdout', outputBudget, boundedFormatter),
+      createConsoleFunction(
+        context,
+        'console.info',
+        'stdout',
+        outputBudget,
+        boundedFormatter,
+      ),
     ],
     [
       'debug',
-      createConsoleFunction(context, 'stdout', outputBudget, boundedFormatter),
+      createConsoleFunction(
+        context,
+        'console.debug',
+        'stdout',
+        outputBudget,
+        boundedFormatter,
+      ),
     ],
     [
       'error',
-      createConsoleFunction(context, 'stderr', outputBudget, boundedFormatter),
+      createConsoleFunction(
+        context,
+        'console.error',
+        'stderr',
+        outputBudget,
+        boundedFormatter,
+      ),
     ],
   ] as const;
 
@@ -524,14 +517,15 @@ function installConsole(
 }
 
 function createConsoleFunction(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
+  name: string,
   stream: 'stdout' | 'stderr',
   outputBudget: { remainingBytes: number },
-  boundedFormatter: QuickJSHandle,
-): QuickJSHandle {
-  return context.newFunction('console', (...args: QuickJSHandle[]) => {
+  boundedFormatter: JSValueHandle,
+): JSValueHandle {
+  return context.newFunction(name, (...args: JSValueHandle[]) => {
     if (outputBudget.remainingBytes === 0) {
-      return;
+      return context.undefined;
     }
     const maxBytesPerArgument = Math.max(
       1,
@@ -545,17 +539,18 @@ function createConsoleFunction(
     const outputBytes = Buffer.byteLength(output);
     if (outputBytes > outputBudget.remainingBytes) {
       outputBudget.remainingBytes = 0;
-      return;
+      return context.undefined;
     }
     outputBudget.remainingBytes -= outputBytes;
     writeSync(stream === 'stderr' ? 2 : 1, output);
+    return context.undefined;
   });
 }
 
 function formatConsoleArg(
-  context: QuickJSAsyncContext,
-  boundedFormatter: QuickJSHandle,
-  arg: QuickJSHandle,
+  context: QuickJS,
+  boundedFormatter: JSValueHandle,
+  arg: JSValueHandle,
   remainingBytes: number,
 ): string {
   const maxCharsHandle = context.newNumber(remainingBytes);
@@ -566,12 +561,8 @@ function formatConsoleArg(
       arg,
       maxCharsHandle,
     );
-    if (result.error) {
-      result.error.dispose();
-      return '[Unprintable QuickJS value]';
-    }
-    const value = context.getString(result.value);
-    result.value.dispose();
+    const value = result.toString();
+    result.dispose();
     if (context.typeof(arg) === 'object') {
       try {
         return formatWithOptions({ colors: false, depth: 4 }, parseJson(value));
@@ -588,28 +579,24 @@ function formatConsoleArg(
 }
 
 function createBridgeFunctions(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
   message: WorkerRunMessage,
-  getResetDateNow: () => QuickJSHandle | undefined,
-): { invokeHostFunction: QuickJSHandle } {
+  getResetDateNow: () => JSValueHandle | undefined,
+): { invokeHostFunction: JSValueHandle } {
   const invokeHostFunction = context.newFunction(
     '__runInvokeHostFunction',
-    (hostFunctionNameHandle: QuickJSHandle, inputJsonHandle: QuickJSHandle) => {
-      const hostFunctionName = context.getString(hostFunctionNameHandle);
-      const inputJson = context.getString(inputJsonHandle);
+    (hostFunctionNameHandle: JSValueHandle, inputJsonHandle: JSValueHandle) => {
+      const hostFunctionName = hostFunctionNameHandle.toString();
+      const inputJson = inputJsonHandle.toString();
       if (Buffer.byteLength(hostFunctionName) > 1024) {
-        return {
-          error: context.newError('Host function name exceeds 1024 bytes.'),
-        };
+        throw new Error('Host function name exceeds 1024 bytes.');
       }
       if (
         Buffer.byteLength(inputJson) > message.options.maxHostFunctionInputBytes
       ) {
-        return {
-          error: context.newError(
-            `Host function arguments exceed the ${message.options.maxHostFunctionInputBytes} byte size limit.`,
-          ),
-        };
+        throw new Error(
+          `Host function arguments exceed the ${message.options.maxHostFunctionInputBytes} byte size limit.`,
+        );
       }
       return requestHost(
         context,
@@ -627,11 +614,11 @@ function createBridgeFunctions(
 }
 
 function requestHost(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
   invocationId: string,
   payload: Record<string, unknown>,
-  resetDateNow?: QuickJSHandle,
-): QuickJSHandle {
+  resetDateNow?: JSValueHandle,
+): JSValueHandle {
   bridgeRequestCounter += 1;
   const requestId = `${invocationId}:bridge-${bridgeRequestCounter}`;
   const deferred = context.newPromise();
@@ -663,35 +650,36 @@ function requestHost(
 }
 
 async function completeDeferredWhenSettled(
-  context: QuickJSAsyncContext,
-  deferred: QuickJSDeferredPromise,
+  context: QuickJS,
+  deferred: Deferred,
 ): Promise<void> {
   await deferred.settled;
-  context.runtime.executePendingJobs();
-  deferred.dispose();
+  context.executePendingJobs();
 }
 
 function resolveBridgeResponse(
-  context: QuickJSAsyncContext,
-  deferred: QuickJSDeferredPromise,
+  context: QuickJS,
+  deferred: Deferred,
   message: WorkerBridgeResponse,
-  resetDateNow?: QuickJSHandle,
+  resetDateNow?: JSValueHandle,
 ): void {
   resetGuestDateNow(context, resetDateNow, message.dateNowMs);
   if (message.success) {
     const value = context.newString(message.valueJson ?? '');
     deferred.resolve(value);
     value.dispose();
+    context.executePendingJobs();
     return;
   }
   const error = createBridgeErrorHandle(context, message.error);
   deferred.reject(error);
   error.dispose();
+  context.executePendingJobs();
 }
 
 function resetGuestDateNow(
-  context: QuickJSAsyncContext,
-  resetDateNow: QuickJSHandle | undefined,
+  context: QuickJS,
+  resetDateNow: JSValueHandle | undefined,
   dateNowMs: number,
 ): void {
   if (resetDateNow === undefined) {
@@ -699,26 +687,17 @@ function resetGuestDateNow(
   }
   const value = context.newNumber(dateNowMs);
   try {
-    const result = context.callFunction(resetDateNow, context.undefined, value);
-    if (result.error) {
-      const error = context.dump(result.error);
-      if (result.error.alive) {
-        result.error.dispose();
-      }
-      throw toError(error);
-    }
-    if (result.value.alive) {
-      result.value.dispose();
+    try {
+      context.callFunction(resetDateNow, context.undefined, value).dispose();
+    } catch (error) {
+      throw toError(dumpQuickJSError(context, error));
     }
   } finally {
     value.dispose();
   }
 }
 
-function jsToHandle(
-  context: QuickJSAsyncContext,
-  value: unknown,
-): QuickJSHandle {
+function jsToHandle(context: QuickJS, value: unknown): JSValueHandle {
   if (value === null) {
     return context.null;
   }
@@ -735,7 +714,7 @@ function jsToHandle(
     const result = context.newArray();
     for (const [index, item] of value.entries()) {
       const handle = jsToHandle(context, item);
-      context.setProp(result, index, handle);
+      context.setProp(result, String(index), handle);
       handle.dispose();
     }
     return result;
@@ -752,24 +731,13 @@ function jsToHandle(
   return context.undefined;
 }
 
-function drainPendingJobs(context: QuickJSAsyncContext): void {
-  while (context.runtime.hasPendingJob()) {
-    const pending = context.runtime.executePendingJobs();
-    if ('error' in pending && pending.error) {
-      const contextForError =
-        'context' in pending.error ? pending.error.context : context;
-      const error = contextForError.dump(pending.error);
-      if (pending.error.alive) {
-        pending.error.dispose();
-      }
-      throw toError(error);
-    }
-  }
+function drainPendingJobs(context: QuickJS): void {
+  context.executePendingJobs();
 }
 
 async function resolveQuickJSPromise(
-  context: QuickJSAsyncContext,
-  promiseHandle: QuickJSHandle,
+  context: QuickJS,
+  promiseHandle: JSValueHandle,
 ) {
   const resolved = context.resolvePromise(promiseHandle);
   const notSettled = Symbol('not-settled');
@@ -853,9 +821,9 @@ function toUserSourceError(value: unknown, source: string): Error {
 }
 
 function createBridgeErrorHandle(
-  context: QuickJSAsyncContext,
+  context: QuickJS,
   error: WorkerBridgeResponse['error'],
-): QuickJSHandle {
+): JSValueHandle {
   const handle = context.newError(
     error?.message ?? 'Host bridge request failed.',
   );
@@ -871,4 +839,43 @@ function createBridgeErrorHandle(
     code.dispose();
   }
   return handle;
+}
+
+function dumpQuickJSError(context: QuickJS, error: unknown): unknown {
+  if (!(error instanceof JSException)) {
+    return error;
+  }
+  try {
+    return dumpQuickJSErrorHandle(context, error.handle);
+  } finally {
+    error.dispose();
+  }
+}
+
+function dumpQuickJSErrorHandle(
+  context: QuickJS,
+  handle: JSValueHandle,
+): unknown {
+  const dumped = context.dump(handle);
+  if (!(dumped instanceof Error)) {
+    return dumped;
+  }
+
+  for (const property of ['code', 'details'] as const) {
+    const descriptor = handle.getOwnPropertyDescriptor(property);
+    if (descriptor?.value === undefined) {
+      descriptor?.get?.dispose();
+      descriptor?.set?.dispose();
+      continue;
+    }
+    try {
+      Object.defineProperty(dumped, property, {
+        enumerable: true,
+        value: context.dump(descriptor.value),
+      });
+    } finally {
+      descriptor.value.dispose();
+    }
+  }
+  return dumped;
 }

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -43,6 +43,7 @@ let activeCancellation:
 let pendingInvocationFailure:
   | { invocationId: string; error: unknown }
   | undefined;
+const MAX_SAFE_WASI_STACK_LIMIT_BYTES = 512 * 1024;
 
 parentPort.on('message', async (value: unknown) => {
   try {
@@ -176,6 +177,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       executionTimedOut ||= timedOut;
       return cancelled || timedOut;
     },
+    maxStackSizeBytes: message.options.maxStackSizeBytes,
     memoryLimitBytes: message.options.memoryLimitBytes,
   });
   let bridgeFunctions: { invokeHostFunction: JSValueHandle } | undefined;
@@ -374,6 +376,7 @@ function rejectPendingBridgeRequests(
 
 async function createQuickJSContext(options: {
   interruptHandler: () => boolean;
+  maxStackSizeBytes: number;
   memoryLimitBytes: number;
 }): Promise<QuickJS> {
   const embeddedWasmBase64 = getEmbeddedQuickJsWasmBase64();
@@ -382,6 +385,10 @@ async function createQuickJSContext(options: {
   }
   return QuickJS.create({
     interruptHandler: options.interruptHandler,
+    maxStackSize: Math.min(
+      options.maxStackSizeBytes,
+      MAX_SAFE_WASI_STACK_LIMIT_BYTES,
+    ),
     memoryLimit: options.memoryLimitBytes,
     wasm: await getEmbeddedQuickJsWasmModule(embeddedWasmBase64),
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,9 @@ importers:
       oxlint:
         specifier: ^1.56.0
         version: 1.56.0
-      quickjs-emscripten:
-        specifier: 0.32.0
-        version: 0.32.0
+      quickjs-wasi:
+        specifier: 3.5.0
+        version: 3.5.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.5)(typescript@5.8.3)(yaml@2.9.0)
@@ -800,21 +800,6 @@ packages:
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
-
-  '@jitl/quickjs-ffi-types@0.32.0':
-    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
-
-  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
-    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
-
-  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
-    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
-
-  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
-    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
-
-  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
-    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -4832,12 +4817,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quickjs-emscripten-core@0.32.0:
-    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
-
-  quickjs-emscripten@0.32.0:
-    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
-    engines: {node: '>=16.0.0'}
+  quickjs-wasi@3.5.0:
+    resolution: {integrity: sha512-/4LKs62eqqqQyr0uVEgSvB3QeOlIpM0Wc4XPgomOfucVurDWssH2eNfDS0Y4NjQoIzoD8jVO7qWvR5drkgnRVg==}
 
   radix-ui@1.6.4:
     resolution: {integrity: sha512-Kpgb9sx08toOydBK42//0N3MqIPlqjHcY39CYuGG8+7DrF6+NTfAnc3o+f1kvoKzG6cI56ri7Z45XEBQqG1QqQ==}
@@ -6152,24 +6133,6 @@ snapshots:
       '@types/node': 26.2.0
 
   '@isaacs/cliui@9.0.0': {}
-
-  '@jitl/quickjs-ffi-types@0.32.0': {}
-
-  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
-    dependencies:
-      '@jitl/quickjs-ffi-types': 0.32.0
-
-  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
-    dependencies:
-      '@jitl/quickjs-ffi-types': 0.32.0
-
-  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
-    dependencies:
-      '@jitl/quickjs-ffi-types': 0.32.0
-
-  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
-    dependencies:
-      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -10381,17 +10344,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quickjs-emscripten-core@0.32.0:
-    dependencies:
-      '@jitl/quickjs-ffi-types': 0.32.0
-
-  quickjs-emscripten@0.32.0:
-    dependencies:
-      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
-      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
-      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
-      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
-      quickjs-emscripten-core: 0.32.0
+  quickjs-wasi@3.5.0: {}
 
   radix-ui@1.6.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^1.56.0
         version: 1.56.0
       quickjs-wasi:
-        specifier: 3.5.0
-        version: 3.5.0
+        specifier: 3.6.0
+        version: 3.6.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.5)(typescript@5.8.3)(yaml@2.9.0)
@@ -244,6 +244,9 @@ packages:
   '@codemirror/commands@6.10.4':
     resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
 
+  '@codemirror/commands@6.11.0':
+    resolution: {integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==}
+
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
 
@@ -268,17 +271,8 @@ packages:
   '@codemirror/view@6.43.8':
     resolution: {integrity: sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==}
 
-  '@emnapi/core@2.0.0-alpha.3':
-    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
-
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
-
-  '@emnapi/runtime@2.0.0-alpha.3':
-    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
-
-  '@emnapi/wasi-threads@2.0.1':
-    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -879,13 +873,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/wasm-runtime@1.2.2':
-    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
   '@next/env@16.3.0':
     resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
 
@@ -965,8 +952,8 @@ packages:
     resolution: {integrity: sha512-Ra4dFddWZ7hCGPAehnd/6QZjlzQvczYSt1y1Fq4HteJqRu2yvfR6fXvxiUnKi+HIgJYPxKhebJEjvJdF8LYQWg==}
     engines: {node: '>= 20.0.0'}
 
-  '@oxc-project/types@0.142.0':
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+  '@oxc-project/types@0.146.0':
+    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
   '@oxfmt/binding-android-arm-eabi@0.41.0':
     resolution: {integrity: sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw==}
@@ -2258,96 +2245,98 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
-  '@rolldown/binding-android-arm64@1.2.1':
-    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.2.1':
-    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.1':
-    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
+  '@rolldown/binding-darwin-x64@1.2.5':
+    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.2.1':
-    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
-    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.1':
-    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.1':
-    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
-    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.1':
-    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.1':
-    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.2.1':
-    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.2.1':
-    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.2.1':
-    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-
-  '@rolldown/binding-win32-arm64-msvc@1.2.1':
-    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.1':
-    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2754,9 +2743,6 @@ packages:
     resolution: {integrity: sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q==}
     cpu: [arm64]
     os: [win32]
-
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4746,6 +4732,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -4817,8 +4807,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quickjs-wasi@3.5.0:
-    resolution: {integrity: sha512-/4LKs62eqqqQyr0uVEgSvB3QeOlIpM0Wc4XPgomOfucVurDWssH2eNfDS0Y4NjQoIzoD8jVO7qWvR5drkgnRVg==}
+  quickjs-wasi@3.6.0:
+    resolution: {integrity: sha512-/CNzMq42B8ThzUpzjLSF8K50ntVLV3RREyT8zr4wHaP2CZSHFhPkqg3E1GULmTerehf8Bo+UguQ+4LoOMCTC6A==}
 
   radix-ui@1.6.4:
     resolution: {integrity: sha512-Kpgb9sx08toOydBK42//0N3MqIPlqjHcY39CYuGG8+7DrF6+NTfAnc3o+f1kvoKzG6cI56ri7Z45XEBQqG1QqQ==}
@@ -4990,8 +4980,8 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
-  rolldown@1.2.1:
-    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
+  rolldown@1.2.5:
+    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5752,6 +5742,13 @@ snapshots:
       '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
 
+  '@codemirror/commands@6.11.0':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.8
+      '@lezer/common': 1.5.2
+
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -5806,23 +5803,7 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
-  '@emnapi/core@2.0.0-alpha.3':
-    dependencies:
-      '@emnapi/wasi-threads': 2.0.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@2.0.0-alpha.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@2.0.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6268,13 +6249,6 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 2.0.0-alpha.3
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@next/env@16.3.0': {}
 
   '@next/swc-darwin-arm64@16.3.0':
@@ -6321,7 +6295,7 @@ snapshots:
     dependencies:
       '@orama/orama': 3.1.18
 
-  '@oxc-project/types@0.142.0': {}
+  '@oxc-project/types@0.146.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.41.0':
     optional: true
@@ -7535,53 +7509,49 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
-  '@rolldown/binding-android-arm64@1.2.1':
+  '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.1':
+  '@rolldown/binding-android-arm64@1.2.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.1':
+  '@rolldown/binding-darwin-arm64@1.2.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.1':
+  '@rolldown/binding-darwin-x64@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+  '@rolldown/binding-freebsd-x64@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.1':
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.1':
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.1':
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.1':
+  '@rolldown/binding-linux-x64-musl@1.2.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.2.1':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 2.0.0-alpha.3
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+  '@rolldown/binding-openharmony-arm64@1.2.5':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.1':
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -7905,11 +7875,6 @@ snapshots:
     optional: true
 
   '@turbo/windows-arm64@2.10.8':
-    optional: true
-
-  '@tybys/wasm-util@0.10.3':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@types/chai@5.2.3':
@@ -8434,7 +8399,7 @@ snapshots:
   codemirror@6.0.2:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/commands': 6.10.4
+      '@codemirror/commands': 6.11.0
       '@codemirror/language': 6.12.4
       '@codemirror/lint': 6.9.7
       '@codemirror/search': 6.7.1
@@ -10279,6 +10244,8 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  picomatch@4.0.7: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
@@ -10344,7 +10311,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quickjs-wasi@3.5.0: {}
+  quickjs-wasi@3.6.0: {}
 
   radix-ui@1.6.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -10634,26 +10601,26 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown@1.2.1:
+  rolldown@1.2.5:
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.146.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.1
-      '@rolldown/binding-darwin-arm64': 1.2.1
-      '@rolldown/binding-darwin-x64': 1.2.1
-      '@rolldown/binding-freebsd-x64': 1.2.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
-      '@rolldown/binding-linux-arm64-gnu': 1.2.1
-      '@rolldown/binding-linux-arm64-musl': 1.2.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
-      '@rolldown/binding-linux-s390x-gnu': 1.2.1
-      '@rolldown/binding-linux-x64-gnu': 1.2.1
-      '@rolldown/binding-linux-x64-musl': 1.2.1
-      '@rolldown/binding-openharmony-arm64': 1.2.1
-      '@rolldown/binding-wasm32-wasi': 1.2.1
-      '@rolldown/binding-win32-arm64-msvc': 1.2.1
-      '@rolldown/binding-win32-x64-msvc': 1.2.1
+      '@rolldown/binding-android-arm-eabi': 1.2.5
+      '@rolldown/binding-android-arm64': 1.2.5
+      '@rolldown/binding-darwin-arm64': 1.2.5
+      '@rolldown/binding-darwin-x64': 1.2.5
+      '@rolldown/binding-freebsd-x64': 1.2.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
+      '@rolldown/binding-linux-arm64-gnu': 1.2.5
+      '@rolldown/binding-linux-arm64-musl': 1.2.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
+      '@rolldown/binding-linux-s390x-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-musl': 1.2.5
+      '@rolldown/binding-openharmony-arm64': 1.2.5
+      '@rolldown/binding-win32-arm64-msvc': 1.2.5
+      '@rolldown/binding-win32-x64-msvc': 1.2.5
 
   rollup@4.62.4:
     dependencies:
@@ -11137,9 +11104,9 @@ snapshots:
   vite@8.2.0(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       postcss: 8.5.26
-      rolldown: 1.2.1
+      rolldown: 1.2.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.19


### PR DESCRIPTION
quickjs-wasi can capture the complete VM state, including variables and pending promises, and restore it later. That could eventually replace parts of run’s replay-based continuation system.