### PR TITLE
fix(run): capture guest result serializer before execution

### DIFF
--- a/.changeset/sweet-results-try.md
+++ b/.changeset/sweet-results-try.md
@@ -1,0 +1,5 @@
+---
+"run": patch
+---
+
+fix(run): capture guest result serializer before execution

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -416,7 +416,7 @@ const HOST_FUNCTIONS_PROXY_SOURCE = `
 `;
 
 const SERIALIZATION_GUARD_SOURCE = `
-(function() {
+const __runSerializeJsonPayloadHandle = (function() {
   function serializeValuePayload(value) {
     if (typeof globalThis.__runAssertNoDetachedBridgeCalls === 'function') {
       globalThis.__runAssertNoDetachedBridgeCalls();
@@ -446,6 +446,7 @@ const SERIALIZATION_GUARD_SOURCE = `
     writable: false,
     configurable: false,
   });
+  return serializeValuePayload;
 })();
 `;
 
@@ -473,7 +474,10 @@ ${HARDENING_SOURCE}
 ${BRIDGE_TRACKING_SOURCE}
 ${HOST_FUNCTIONS_PROXY_SOURCE}
 ${SERIALIZATION_GUARD_SOURCE}
-return Object.freeze({ resetDateNow: __runResetDateNow });
+return Object.freeze({
+  resetDateNow: __runResetDateNow,
+  serializeJsonPayload: __runSerializeJsonPayloadHandle
+});
 })
 `;
 };

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -282,22 +282,22 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     for (const [requestId] of pendingForInvocation) {
       pendingBridgeRequests.delete(requestId);
     }
-    if (bridgeFunctions?.invokeHostFunction.alive) {
-      bridgeFunctions.invokeHostFunction.dispose();
-    }
-    if (consoleFormatter?.alive) {
-      consoleFormatter.dispose();
-    }
-    if (resetDateNowHandle?.alive) {
-      resetDateNowHandle.dispose();
-    }
-    if (serializeJsonPayloadHandle?.alive) {
-      serializeJsonPayloadHandle.dispose();
-    }
-    if (determinismHandle?.alive) {
-      determinismHandle.dispose();
-    }
+    disposeHandles(
+      bridgeFunctions?.invokeHostFunction,
+      consoleFormatter,
+      resetDateNowHandle,
+      serializeJsonPayloadHandle,
+      determinismHandle,
+    );
     context.dispose();
+  }
+}
+
+function disposeHandles(...handles: (QuickJSHandle | undefined)[]): void {
+  for (const handle of handles) {
+    if (handle?.alive) {
+      handle.dispose();
+    }
   }
 }
 

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -181,6 +181,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
   let consoleFormatter: QuickJSHandle | undefined;
   let determinismHandle: QuickJSHandle | undefined;
   let resetDateNowHandle: QuickJSHandle | undefined;
+  let serializeJsonPayloadHandle: QuickJSHandle | undefined;
   let cancelled = false;
   let executionTimedOut = false;
   let executionFailure: { error: unknown } | undefined;
@@ -234,13 +235,19 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       () => resetDateNowHandle,
     );
     determinismHandle = jsToHandle(context, message.determinism);
-    resetDateNowHandle = await initializeGuestRuntime(
+    const guestRuntimeHandles = await initializeGuestRuntime(
       context,
       message,
       bridgeFunctions.invokeHostFunction,
       determinismHandle,
     );
-    const valueJson = await evaluateUserSource(context, message);
+    resetDateNowHandle = guestRuntimeHandles.resetDateNow;
+    serializeJsonPayloadHandle = guestRuntimeHandles.serializeJsonPayload;
+    const valueJson = await evaluateUserSource(
+      context,
+      message,
+      serializeJsonPayloadHandle,
+    );
     const completedFailure = getExecutionFailure();
     if (completedFailure !== undefined) {
       throw completedFailure.error;
@@ -284,6 +291,9 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     if (resetDateNowHandle?.alive) {
       resetDateNowHandle.dispose();
     }
+    if (serializeJsonPayloadHandle?.alive) {
+      serializeJsonPayloadHandle.dispose();
+    }
     if (determinismHandle?.alive) {
       determinismHandle.dispose();
     }
@@ -296,7 +306,10 @@ async function initializeGuestRuntime(
   message: WorkerRunMessage,
   invokeHostFunction: QuickJSHandle,
   determinismHandle: QuickJSHandle,
-): Promise<QuickJSHandle | undefined> {
+): Promise<{
+  resetDateNow: QuickJSHandle;
+  serializeJsonPayload: QuickJSHandle;
+}> {
   const setupSource = buildGuestRuntimeSetupSource(
     message.hostFunctionNamespaces,
   );
@@ -326,14 +339,21 @@ async function initializeGuestRuntime(
       throw toError(error);
     }
     if (!setupCallResult.value.alive) {
-      return undefined;
+      throw new Error('Guest runtime setup did not return its handles.');
     }
     const resetDateNowHandle = context.getProp(
       setupCallResult.value,
       'resetDateNow',
     );
+    const serializeJsonPayloadHandle = context.getProp(
+      setupCallResult.value,
+      'serializeJsonPayload',
+    );
     setupCallResult.value.dispose();
-    return resetDateNowHandle;
+    return {
+      resetDateNow: resetDateNowHandle,
+      serializeJsonPayload: serializeJsonPayloadHandle,
+    };
   } finally {
     if (setupEvalResult.value.alive) {
       setupEvalResult.value.dispose();
@@ -344,6 +364,7 @@ async function initializeGuestRuntime(
 async function evaluateUserSource(
   context: QuickJSAsyncContext,
   message: WorkerRunMessage,
+  serializeJsonPayload: QuickJSHandle,
 ): Promise<string> {
   const wrapped = wrapUserCode(message.source);
   const evalResult = await context.evalCodeAsync(wrapped, 'run.js');
@@ -371,7 +392,11 @@ async function evaluateUserSource(
     throw toUserSourceError(error, message.source);
   }
 
-  const valueJson = serializeQuickJSJsonPayload(context, resolvedResult.value);
+  const valueJson = serializeQuickJSJsonPayload(
+    context,
+    serializeJsonPayload,
+    resolvedResult.value,
+  );
   if (resolvedResult.value.alive) {
     resolvedResult.value.dispose();
   }
@@ -438,31 +463,22 @@ function decodeBase64ArrayBuffer(value: string): ArrayBuffer {
 
 function serializeQuickJSJsonPayload(
   context: QuickJSAsyncContext,
+  serialize: QuickJSHandle,
   value: QuickJSHandle,
 ): string {
-  const serialize = context.getProp(
-    context.global,
-    '__runSerializeJsonPayload',
-  );
-  try {
-    const result = context.callFunction(serialize, context.undefined, value);
-    if (result.error) {
-      const error = context.dump(result.error);
-      if (result.error.alive) {
-        result.error.dispose();
-      }
-      throw toError(error);
+  const result = context.callFunction(serialize, context.undefined, value);
+  if (result.error) {
+    const error = context.dump(result.error);
+    if (result.error.alive) {
+      result.error.dispose();
     }
-    const valueJson = context.getString(result.value);
-    if (result.value.alive) {
-      result.value.dispose();
-    }
-    return valueJson;
-  } finally {
-    if (serialize.alive) {
-      serialize.dispose();
-    }
+    throw toError(error);
   }
+  const valueJson = context.getString(result.value);
+  if (result.value.alive) {
+    result.value.dispose();
+  }
+  return valueJson;
 }
 
 function installConsole(

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { RunDetachedBridgeRequestError } from './errors.js';
 import { getHostFunctionContext, run } from './index.js';
 import type { HostFunctions } from './index.js';
+import { serializeRunValue } from './utils/serde.js';
 
 async function value(
   source: string,
@@ -218,6 +219,23 @@ describe('guest sandbox hardening', () => {
       setName: 'Set',
       toolsType: 'function',
     });
+  });
+
+  it('uses the captured result serializer after guest global redefinition', async () => {
+    const forgedPayload = serializeRunValue(
+      new Map([['injectedKey', 'injectedValue']]),
+    );
+
+    await expectValue(`
+      try {
+        Object.defineProperty(globalThis, '__runSerializeJsonPayload', {
+          value: () => ${JSON.stringify(forgedPayload)},
+          writable: false,
+          configurable: false,
+        });
+      } catch {}
+      return 'legitimate result';
+    `).resolves.toBe('legitimate result');
   });
 
   it('locks every privileged guest global binding', async () => {


### PR DESCRIPTION
## Before

The host looked up `__runSerializeJsonPayload` from `globalThis` after guest code ran. A guest could replace it and forge the returned result.

## After

The host now captures the real serializer before guest code runs and uses that saved function afterward. Changes to the global no longer affect results