### PR TITLE
fix(run): honour the configured execution timeout

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"run": patch
+---
+
+fix(run): honour the configured execution timeout instead of a fixed interrupt-check budget

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -20,6 +20,13 @@ if (!parentPort) {
   throw new Error('JavaScript runtime worker must run inside a worker thread');
 }
 
+/*
+ * How many interrupt checks pass between reads of the clock. QuickJS calls the
+ * interrupt handler often enough that reading the clock every time is wasted
+ * work, and often enough that sampling still notices the deadline promptly.
+ */
+const INTERRUPT_CLOCK_SAMPLE_INTERVAL = 64;
+
 const pendingBridgeRequests = new Map<
   string,
   {
@@ -173,7 +180,16 @@ async function execute(message: WorkerRunMessage): Promise<string> {
   const context = await createQuickJSContext({
     interruptHandler: () => {
       interruptChecks += 1;
-      const timedOut = interruptChecks > 10_000 || Date.now() > deadline;
+      /*
+       * The check count decides only how often the clock is read, never
+       * whether the run ends. It measures how much bytecode has executed,
+       * which says nothing about elapsed time: ending a run on the count
+       * aborts long-but-terminating work inside its budget, and reports it
+       * as a timeout the run never reached.
+       */
+      const timedOut =
+        interruptChecks % INTERRUPT_CLOCK_SAMPLE_INTERVAL === 0 &&
+        Date.now() > deadline;
       executionTimedOut ||= timedOut;
       return cancelled || timedOut;
     },

--- a/packages/run/src/timeout-budget.test.ts
+++ b/packages/run/src/timeout-budget.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { run } from './run.js';
+
+/*
+ * The execution timeout must be a measure of elapsed time, not of how much
+ * bytecode the guest managed to execute. A long-but-terminating computation
+ * that finishes inside its budget has not timed out.
+ */
+describe('execution timeout', () => {
+  it('does not abort a computation that finishes within its budget', async () => {
+    const startedAt = Date.now();
+    const result = await run({
+      // Long enough to run well past any fixed interrupt-check budget, but
+      // still far inside the 10s timeout below.
+      limits: { timeoutMs: 10_000 },
+      source:
+        'let n = 0; for (let i = 0; i < 50_000_000; i++) n += i % 7; return n;',
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.status).toBe('completed');
+    expect(elapsedMs).toBeLessThan(10_000);
+  }, 30_000);
+
+  it('scales how long a runaway loop survives with the configured timeout', async () => {
+    const elapsedFor = async (timeoutMs: number): Promise<number> => {
+      const startedAt = Date.now();
+      await expect(
+        run({ limits: { timeoutMs }, source: 'while (true) {}' }),
+      ).rejects.toThrow(/timed out/i);
+      return Date.now() - startedAt;
+    };
+
+    // A budget of 1s must outlast a budget of 200ms. A fixed instruction
+    // budget would end both at the same point, whatever was configured.
+    const short = await elapsedFor(200);
+    const long = await elapsedFor(1000);
+
+    expect(long).toBeGreaterThan(short * 2);
+  }, 30_000);
+});


### PR DESCRIPTION
## The bug

The worker's interrupt handler ends a run on a fixed invocation count, not on the deadline:

```ts
const timedOut = interruptChecks > 10_000 || Date.now() > deadline;
```

`interruptChecks` measures how much bytecode the guest has executed, which says nothing about how long it has taken. Once it passes 10,000 the run is aborted with `RunTimeoutError(timeoutMs)` — naming a deadline the run never reached.

The effect is that `limits.timeoutMs` does not control how long a run may take. Measured on `main`:

| `timeoutMs` | actual abort |
| --- | --- |
| 200 | 314ms |
| 1000 | 221ms |

A longer budget bought less time than a shorter one — the abort point tracks the shape of the guest's loop body, not the clock.

It also cuts off legitimate work. With a 10s budget, a 10,000,000-iteration loop completes in ~1.5s, while a 50,000,000-iteration one is killed at ~1.5s and reported as `timed out after 10000ms`.

## The fix

The counter is kept, but only as the stride for sampling the clock — so the handler still avoids a `Date.now()` on every check — and the deadline alone decides when a run ends.

After, across two orders of magnitude:

| `timeoutMs` | actual | overshoot |
| --- | --- | --- |
| 100 | 116ms | +16ms |
| 250 | 248ms | −2ms |
| 500 | 457ms | −43ms |
| 1000 | 956ms | −44ms |
| 2000 | 1958ms | −42ms |

The 50,000,000-iteration loop now completes in ~1.7s rather than being aborted.

## Tests

`src/timeout-budget.test.ts` covers both halves — that a computation finishing inside its budget is not aborted, and that a runaway loop's survival scales with the configured timeout. Both fail on `main`: the first with `timed out after 10000ms`, the second with `expected 221 to be greater than 314`.

Full suite passes (258 tests, 23 files), plus `type-check` and `ultracite check`.

## How this came up

Evaluating `run` as the sandbox for AI SDK code mode, where tool calls are host functions and a program may legitimately run for seconds. Worth noting `run` handled that workload cleanly — the same async-host-call pattern aborts the process outright under `quickjs-emscripten`'s asyncify build.
