### PR TITLE
fix: prevent guests from forging runtime error codes

### DIFF
--- a/.changeset/small-goats-tell.md
+++ b/.changeset/small-goats-tell.md
@@ -1,0 +1,5 @@
+---
+"run": patch
+---
+
+fix forged serialization codes

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -483,6 +483,36 @@ const __runSerializeJsonPayloadHandle = (function() {
 })();
 `;
 
+const TRUSTED_ERROR_SOURCE = `
+const __runTrustedErrorHandles = (function() {
+  var trustedCodes = new __runOriginalWeakMap();
+  return __runOriginalObject.freeze({
+    register: function(error, name, code) {
+      if (typeof name === 'string') {
+        __runOriginalObject.defineProperty(error, 'name', {
+          value: __runOriginalString(name),
+          writable: true,
+          configurable: true
+        });
+      }
+      if (typeof code === 'string') {
+        var trustedCode = __runOriginalString(code);
+        __runOriginalObject.defineProperty(error, 'code', {
+          value: trustedCode,
+          writable: true,
+          configurable: true,
+          enumerable: true
+        });
+        trustedCodes.set(error, trustedCode);
+      }
+    },
+    getCode: function(error) {
+      return trustedCodes.get(error);
+    }
+  });
+})();
+`;
+
 export const buildGuestRuntimeSetupSource = (
   hostFunctionNamespaces: string[],
 ): string => {
@@ -500,6 +530,7 @@ const __runOriginalReflect = Reflect;
 const __runOriginalString = String;
 const __runOriginalSymbol = Symbol;
 const __runOriginalTypeError = TypeError;
+const __runOriginalWeakMap = WeakMap;
 ${DETERMINISTIC_APIS_SOURCE}
 ${BASE64_SOURCE}
 ${GUEST_SERDE_SOURCE}
@@ -507,7 +538,10 @@ ${HARDENING_SOURCE}
 ${BRIDGE_TRACKING_SOURCE}
 ${HOST_FUNCTIONS_PROXY_SOURCE}
 ${SERIALIZATION_GUARD_SOURCE}
+${TRUSTED_ERROR_SOURCE}
 return Object.freeze({
+  getTrustedErrorCode: __runTrustedErrorHandles.getCode,
+  registerTrustedError: __runTrustedErrorHandles.register,
   resetDateNow: __runResetDateNow,
   serializeJsonPayload: __runSerializeJsonPayloadHandle
 });

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -380,7 +380,12 @@ const HOST_FUNCTIONS_PROXY_SOURCE = `
   function serializationError(label, error) {
     var message = error && error.message ? __runOriginalString(error.message) : __runOriginalString(error);
     var result = new __runOriginalTypeError(label + ': ' + message);
-    result.code = 'RUN_SERIALIZATION_ERROR';
+    __runOriginalObject.defineProperty(result, 'code', {
+      value: 'RUN_SERIALIZATION_ERROR',
+      writable: true,
+      configurable: true,
+      enumerable: true
+    });
     return result;
   }
 
@@ -446,13 +451,23 @@ const __runSerializeJsonPayloadHandle = (function() {
     } catch (error) {
       var message = error && error.message ? __runOriginalString(error.message) : __runOriginalString(error);
       var serializationError = new __runOriginalTypeError('JavaScript runtime result is not serializable: ' + message);
-      serializationError.code = 'RUN_SERIALIZATION_ERROR';
+      __runOriginalObject.defineProperty(serializationError, 'code', {
+        value: 'RUN_SERIALIZATION_ERROR',
+        writable: true,
+        configurable: true,
+        enumerable: true
+      });
       throw serializationError;
     }
 
     if (encoded === undefined) {
       var serializationError = new __runOriginalTypeError('JavaScript runtime result is not serializable.');
-      serializationError.code = 'RUN_SERIALIZATION_ERROR';
+      __runOriginalObject.defineProperty(serializationError, 'code', {
+        value: 'RUN_SERIALIZATION_ERROR',
+        writable: true,
+        configurable: true,
+        enumerable: true
+      });
       throw serializationError;
     }
 

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -378,7 +378,7 @@ const __runCreateBridgePromiseHandle = (function() {
 const HOST_FUNCTIONS_PROXY_SOURCE = `
 (function(invokeHostFunction, hostFunctionNamespaces, createBridgePromise) {
   function serializationError(label, error) {
-    var message = error && error.message ? __runOriginalString(error.message) : __runOriginalString(error);
+    var message = __runSafeErrorMessage(error);
     var result = new __runOriginalTypeError(label + ': ' + message);
     __runOriginalObject.defineProperty(result, 'code', {
       value: 'RUN_SERIALIZATION_ERROR',
@@ -449,7 +449,7 @@ const __runSerializeJsonPayloadHandle = (function() {
     try {
       encoded = __runSerdeBundle.serializeRunValue(value);
     } catch (error) {
-      var message = error && error.message ? __runOriginalString(error.message) : __runOriginalString(error);
+      var message = __runSafeErrorMessage(error);
       var serializationError = new __runOriginalTypeError('JavaScript runtime result is not serializable: ' + message);
       __runOriginalObject.defineProperty(serializationError, 'code', {
         value: 'RUN_SERIALIZATION_ERROR',
@@ -531,6 +531,21 @@ const __runOriginalString = String;
 const __runOriginalSymbol = Symbol;
 const __runOriginalTypeError = TypeError;
 const __runOriginalWeakMap = WeakMap;
+function __runSafeErrorMessage(error) {
+  if (typeof error === 'string') return error;
+  if (
+    (typeof error === 'object' && error !== null) ||
+    typeof error === 'function'
+  ) {
+    try {
+      var descriptor = __runOriginalObject.getOwnPropertyDescriptor(error, 'message');
+      if (descriptor && typeof descriptor.value === 'string') {
+        return descriptor.value;
+      }
+    } catch {}
+  }
+  return 'Serialization failed.';
+}
 ${DETERMINISTIC_APIS_SOURCE}
 ${BASE64_SOURCE}
 ${GUEST_SERDE_SOURCE}

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -26,6 +26,7 @@ const pendingBridgeRequests = new Map<
     context: QuickJS;
     deferred: Deferred;
     invocationId: string;
+    registerTrustedError?: JSValueHandle;
     resetDateNow?: JSValueHandle;
   }
 >();
@@ -88,6 +89,7 @@ async function handleMainMessage(value: unknown): Promise<void> {
       pending.deferred,
       message,
       pending.resetDateNow,
+      pending.registerTrustedError,
     );
     pendingBridgeRequests.delete(message.requestId);
     return;
@@ -183,6 +185,8 @@ async function execute(message: WorkerRunMessage): Promise<string> {
   let bridgeFunctions: { invokeHostFunction: JSValueHandle } | undefined;
   let consoleFormatter: JSValueHandle | undefined;
   let determinismHandle: JSValueHandle | undefined;
+  let getTrustedErrorCodeHandle: JSValueHandle | undefined;
+  let registerTrustedErrorHandle: JSValueHandle | undefined;
   let resetDateNowHandle: JSValueHandle | undefined;
   let serializeJsonPayloadHandle: JSValueHandle | undefined;
   let executionFailure: { error: unknown } | undefined;
@@ -225,6 +229,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       context,
       message,
       () => resetDateNowHandle,
+      () => registerTrustedErrorHandle,
     );
     determinismHandle = jsToHandle(context, message.determinism);
     const guestRuntimeHandles = initializeGuestRuntime(
@@ -233,12 +238,15 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       bridgeFunctions.invokeHostFunction,
       determinismHandle,
     );
+    getTrustedErrorCodeHandle = guestRuntimeHandles.getTrustedErrorCode;
+    registerTrustedErrorHandle = guestRuntimeHandles.registerTrustedError;
     resetDateNowHandle = guestRuntimeHandles.resetDateNow;
     serializeJsonPayloadHandle = guestRuntimeHandles.serializeJsonPayload;
     const valueJson = await evaluateUserSource(
       context,
       message,
       serializeJsonPayloadHandle,
+      getTrustedErrorCodeHandle,
     );
     const completedFailure = getExecutionFailure();
     if (completedFailure !== undefined) {
@@ -276,6 +284,8 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     }
     disposeHandle(bridgeFunctions?.invokeHostFunction);
     disposeHandle(consoleFormatter);
+    disposeHandle(getTrustedErrorCodeHandle);
+    disposeHandle(registerTrustedErrorHandle);
     disposeHandle(resetDateNowHandle);
     disposeHandle(serializeJsonPayloadHandle);
     disposeHandle(determinismHandle);
@@ -289,6 +299,8 @@ function initializeGuestRuntime(
   invokeHostFunction: JSValueHandle,
   determinismHandle: JSValueHandle,
 ): {
+  getTrustedErrorCode: JSValueHandle;
+  registerTrustedError: JSValueHandle;
   resetDateNow: JSValueHandle;
   serializeJsonPayload: JSValueHandle;
 } {
@@ -315,6 +327,8 @@ function initializeGuestRuntime(
     }
     try {
       return {
+        getTrustedErrorCode: setupResult.getProp('getTrustedErrorCode'),
+        registerTrustedError: setupResult.getProp('registerTrustedError'),
         resetDateNow: setupResult.getProp('resetDateNow'),
         serializeJsonPayload: setupResult.getProp('serializeJsonPayload'),
       };
@@ -336,6 +350,7 @@ async function evaluateUserSource(
   context: QuickJS,
   message: WorkerRunMessage,
   serializeJsonPayload: JSValueHandle,
+  getTrustedErrorCode: JSValueHandle,
 ): Promise<string> {
   const wrapped = wrapUserCode(message.source);
   try {
@@ -350,11 +365,16 @@ async function evaluateUserSource(
     promiseHandle.dispose();
   }
   if ('error' in resolvedResult) {
+    const trustedCode = readTrustedErrorCode(
+      context,
+      getTrustedErrorCode,
+      resolvedResult.error,
+    );
     const error = dumpQuickJSErrorHandle(context, resolvedResult.error);
     if (!resolvedResult.error.disposed) {
       resolvedResult.error.dispose();
     }
-    throw toUserSourceError(error, message.source);
+    throw toUserSourceError(error, message.source, trustedCode);
   }
 
   const valueJson = serializeQuickJSJsonPayload(
@@ -602,6 +622,7 @@ function createBridgeFunctions(
   context: QuickJS,
   message: WorkerRunMessage,
   getResetDateNow: () => JSValueHandle | undefined,
+  getRegisterTrustedError: () => JSValueHandle | undefined,
 ): { invokeHostFunction: JSValueHandle } {
   const invokeHostFunction = context.newFunction(
     '__runInvokeHostFunction',
@@ -626,6 +647,7 @@ function createBridgeFunctions(
           inputJson,
         },
         getResetDateNow(),
+        getRegisterTrustedError(),
       );
     },
   );
@@ -638,6 +660,7 @@ function requestHost(
   invocationId: string,
   payload: Record<string, unknown>,
   resetDateNow?: JSValueHandle,
+  registerTrustedError?: JSValueHandle,
 ): JSValueHandle {
   bridgeRequestCounter += 1;
   const requestId = `${invocationId}:bridge-${bridgeRequestCounter}`;
@@ -646,6 +669,7 @@ function requestHost(
     context,
     deferred,
     invocationId,
+    ...(registerTrustedError === undefined ? {} : { registerTrustedError }),
     ...(resetDateNow === undefined ? {} : { resetDateNow }),
   });
   completeDeferredWhenSettled(context, deferred);
@@ -682,6 +706,7 @@ function resolveBridgeResponse(
   deferred: Deferred,
   message: WorkerBridgeResponse,
   resetDateNow?: JSValueHandle,
+  registerTrustedError?: JSValueHandle,
 ): void {
   resetGuestDateNow(context, resetDateNow, message.dateNowMs);
   if (message.success) {
@@ -692,9 +717,33 @@ function resolveBridgeResponse(
     return;
   }
   const error = createBridgeErrorHandle(context, message.error);
+  registerBridgeError(context, registerTrustedError, error, message.error);
   deferred.reject(error);
   error.dispose();
   context.executePendingJobs();
+}
+
+function registerBridgeError(
+  context: QuickJS,
+  registerTrustedError: JSValueHandle | undefined,
+  error: JSValueHandle,
+  serializedError: WorkerBridgeResponse['error'],
+): void {
+  if (registerTrustedError === undefined) {
+    return;
+  }
+  const name = jsToHandle(context, serializedError?.name);
+  const code = jsToHandle(context, serializedError?.code);
+  try {
+    context
+      .callFunction(registerTrustedError, context.undefined, error, name, code)
+      .dispose();
+  } catch (registrationError) {
+    throw toError(dumpQuickJSError(context, registrationError));
+  } finally {
+    name.dispose();
+    code.dispose();
+  }
 }
 
 function resetGuestDateNow(
@@ -773,16 +822,13 @@ async function resolveQuickJSPromise(
   }
 }
 
-const GUEST_FORBIDDEN_ERROR_CODES = new Set([
-  'RUN_ABORTED',
-  'RUN_CONCURRENCY_LIMIT',
-  'RUN_DETACHED_BRIDGE_REQUEST',
-  'RUN_PROTOCOL_ERROR',
-  'RUN_SOURCE_TOO_LARGE',
-  'RUN_TIMEOUT',
-]);
+const GUEST_ALLOWED_RUN_ERROR_CODES = new Set(['RUN_ERROR']);
 
-function toError(value: unknown, filterGuestCode = false): Error {
+function toError(
+  value: unknown,
+  filterGuestCode = false,
+  trustedCode?: string,
+): Error {
   if (
     typeof value === 'object' &&
     value !== null &&
@@ -797,6 +843,7 @@ function toError(value: unknown, filterGuestCode = false): Error {
       details?: unknown;
     };
     const error = new Error(errorValue.message);
+    const errorCode = trustedCode ?? errorValue.code;
     const { name } = errorValue;
     if (typeof name === 'string') {
       error.name = name;
@@ -808,17 +855,19 @@ function toError(value: unknown, filterGuestCode = false): Error {
       error.stack = (value as { stack: string }).stack;
     }
     if (
-      errorValue.code !== undefined &&
+      errorCode !== undefined &&
       (!filterGuestCode ||
-        typeof errorValue.code !== 'string' ||
-        !GUEST_FORBIDDEN_ERROR_CODES.has(errorValue.code))
+        trustedCode !== undefined ||
+        typeof errorCode !== 'string' ||
+        !errorCode.startsWith('RUN_') ||
+        GUEST_ALLOWED_RUN_ERROR_CODES.has(errorCode))
     ) {
       Object.defineProperty(error, 'code', {
         enumerable: true,
-        value: errorValue.code,
+        value: errorCode,
       });
     }
-    if (errorValue.details !== undefined) {
+    if (trustedCode === undefined && errorValue.details !== undefined) {
       Object.defineProperty(error, 'details', {
         enumerable: true,
         value: errorValue.details,
@@ -829,8 +878,12 @@ function toError(value: unknown, filterGuestCode = false): Error {
   return new Error(String(value));
 }
 
-function toUserSourceError(value: unknown, source: string): Error {
-  const error = toError(value, true);
+function toUserSourceError(
+  value: unknown,
+  source: string,
+  trustedCode?: string,
+): Error {
+  const error = toError(value, true, trustedCode);
   error.stack = normalizeUserSourceStack({
     message: error.message,
     name: error.name,
@@ -840,25 +893,33 @@ function toUserSourceError(value: unknown, source: string): Error {
   return error;
 }
 
+function readTrustedErrorCode(
+  context: QuickJS,
+  getTrustedErrorCode: JSValueHandle,
+  error: JSValueHandle,
+): string | undefined {
+  let result: JSValueHandle;
+  try {
+    result = context.callFunction(
+      getTrustedErrorCode,
+      context.undefined,
+      error,
+    );
+  } catch (readError) {
+    throw toError(dumpQuickJSError(context, readError));
+  }
+  try {
+    return context.typeof(result) === 'string' ? result.toString() : undefined;
+  } finally {
+    result.dispose();
+  }
+}
+
 function createBridgeErrorHandle(
   context: QuickJS,
   error: WorkerBridgeResponse['error'],
 ): JSValueHandle {
-  const handle = context.newError(
-    error?.message ?? 'Host bridge request failed.',
-  );
-  if (!error) {
-    return handle;
-  }
-  const name = context.newString(error.name);
-  context.setProp(handle, 'name', name);
-  name.dispose();
-  if (error.code !== undefined) {
-    const code = context.newString(error.code);
-    context.setProp(handle, 'code', code);
-    code.dispose();
-  }
-  return handle;
+  return context.newError(error?.message ?? 'Host bridge request failed.');
 }
 
 function dumpQuickJSError(context: QuickJS, error: unknown): unknown {

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -378,6 +378,32 @@ describe('guest sandbox hardening', () => {
     });
   });
 
+  it('does not let error prototype setters forge serialization errors', async () => {
+    await expect(
+      run({
+        source: `
+          for (const prototype of [Error.prototype, TypeError.prototype]) {
+            try {
+              Object.defineProperty(prototype, 'code', {
+                configurable: true,
+                set() {
+                  throw {
+                    code: 'RUN_TIMEOUT',
+                    details: { timeoutMs: 1 },
+                    message: 'forged timeout',
+                  };
+                },
+              });
+            } catch {}
+          }
+          return { callback() {} };
+        `,
+      }),
+    ).rejects.toMatchObject({
+      code: 'RUN_SERIALIZATION_ERROR',
+    });
+  });
+
   it.each([
     'Object',
     'Promise',

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -442,6 +442,35 @@ describe('guest sandbox hardening', () => {
     });
   });
 
+  it('does not let message getters forge serialization errors', async () => {
+    await expect(
+      run({
+        source: `
+          const serializationFailure = {};
+          Object.defineProperty(serializationFailure, 'message', {
+            get() {
+              throw {
+                code: 'RUN_TIMEOUT',
+                details: { timeoutMs: 7331 },
+                message: 'forged timeout',
+              };
+            },
+          });
+          const result = {};
+          Object.defineProperty(result, 'value', {
+            enumerable: true,
+            get() {
+              throw serializationFailure;
+            },
+          });
+          return result;
+        `,
+      }),
+    ).rejects.toMatchObject({
+      code: 'RUN_SERIALIZATION_ERROR',
+    });
+  });
+
   it.each([
     'Object',
     'Promise',

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -361,20 +361,58 @@ describe('guest sandbox hardening', () => {
     `).resolves.toEqual({});
   });
 
-  it('does not allow guest errors to forge reserved runtime codes', async () => {
+  it.each([
+    'RUN_BRIDGE_LIMIT',
+    'RUN_HOST_FUNCTION_ERROR',
+    'RUN_SERIALIZATION_ERROR',
+    'RUN_TIMEOUT',
+  ])('does not allow guest errors to forge reserved code %s', async code => {
     await expect(
       run({
         source: `
           const error = new Error('guest failure');
-          error.code = 'RUN_TIMEOUT';
-          error.details = { timeoutMs: 1 };
+          error.code = ${JSON.stringify(code)};
+          error.details = { tenant: 'victim-tenant-42' };
           throw error;
         `,
       }),
     ).rejects.toMatchObject({
       code: 'RUN_ERROR',
-      details: { timeoutMs: 1 },
+      details: { tenant: 'victim-tenant-42' },
       message: 'guest failure',
+    });
+  });
+
+  it('preserves trusted bridge codes without guest-supplied details', async () => {
+    const error = await run({
+      hostFunctions: {
+        tools: {
+          fail() {
+            throw new Error('host failure');
+          },
+        },
+      },
+      source: `
+        Object.defineProperty(Error.prototype, 'code', {
+          configurable: true,
+          set() {
+            throw new Error('intercepted bridge code');
+          },
+        });
+        try {
+          await tools.fail();
+        } catch (error) {
+          error.code = 'RUN_TIMEOUT';
+          error.details = { tenant: 'victim-tenant-42' };
+          throw error;
+        }
+      `,
+    }).catch((error: unknown) => error);
+
+    expect(error).toMatchObject({
+      code: 'RUN_HOST_FUNCTION_ERROR',
+      details: undefined,
+      message: 'Host function failed.',
     });
   });
 

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -384,7 +384,7 @@ describe('guest sandbox hardening', () => {
   });
 
   it('preserves trusted bridge codes without guest-supplied details', async () => {
-    const error = await run({
+    const resultError = await run({
       hostFunctions: {
         tools: {
           fail() {
@@ -409,7 +409,7 @@ describe('guest sandbox hardening', () => {
       `,
     }).catch((error: unknown) => error);
 
-    expect(error).toMatchObject({
+    expect(resultError).toMatchObject({
       code: 'RUN_HOST_FUNCTION_ERROR',
       details: undefined,
       message: 'Host function failed.',


### PR DESCRIPTION
## Before:

Guest code could forge trusted RUN_* errors, including timeout and bridge-limit errors.
Prototype setters or message getters could hijack serialization failures.
Forged details could appear host-generated.

## After:

Guest-provided reserved codes are rejected.
Genuine host errors are privately tracked and preserved.
Serialization errors no longer execute guest setters or getters.
