### PR TITLE
fix(run): keep an error listener on pooled idle workers

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"run": patch
+---
+
+fix(run): keep an error listener on pooled idle workers

--- a/packages/run/src/runtime/manager-protocol.test.ts
+++ b/packages/run/src/runtime/manager-protocol.test.ts
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getHostFunctionContext } from '../host-function-context.js';
 import { createRunner, run } from '../run.js';
 import { createPromiseWithResolvers } from '../utils/promise-with-resolvers.js';
-import { setRuntimeWorkerFactoryForTest } from './manager.js';
+import {
+  getRuntimeDiagnostics,
+  setRuntimeWorkerFactoryForTest,
+} from './manager.js';
 
 type WorkerListener = (value: unknown) => void;
 type WorkerEmit = (event: string, value: unknown) => void;
@@ -279,5 +282,42 @@ describe('manager protocol state machine', () => {
       continuation: 'encoded-interruption',
       status: 'interrupted',
     });
+  });
+
+  it('discards a pooled worker that reports an error while idle', async () => {
+    let emitWorker: WorkerEmit | undefined;
+    setRuntimeWorkerFactoryForTest(() =>
+      createWorkerDouble({
+        postMessage: (value, emit) => {
+          emitWorker = emit;
+          const message = value as { invocationId?: string; type?: string };
+          const { invocationId } = message;
+          if (message.type !== 'run' || invocationId === undefined) {
+            return;
+          }
+          queueMicrotask(() => {
+            emit('message', {
+              invocationId,
+              success: true,
+              type: 'result',
+              valueJson: '[1]',
+            });
+            emit('message', { invocationId, type: 'ready' });
+          });
+        },
+        terminate: emit => emit('exit', 0),
+      }),
+    );
+
+    await expect(run({ source: 'return 1;' })).resolves.toEqual({
+      status: 'completed',
+      value: 1,
+    });
+    const pooledWorkers = getRuntimeDiagnostics().idleWorkers;
+    expect(pooledWorkers).toBeGreaterThan(0);
+
+    emitWorker?.('error', new Error('idle worker crashed'));
+
+    expect(getRuntimeDiagnostics().idleWorkers).toBe(pooledWorkers - 1);
   });
 });

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -1209,6 +1209,7 @@ function acquireWorker(maxPoolSize: number): PooledWorker {
   }
   pooledWorker ??= createWorker();
   pooledWorker.worker.removeAllListeners('exit');
+  pooledWorker.worker.removeAllListeners('error');
   pooledWorker.worker.ref();
   trimIdleWorkers(Math.max(0, maxPoolSize - activeInvocations));
   return pooledWorker;
@@ -1239,13 +1240,17 @@ function releaseWorker(pooledWorker: PooledWorker): void {
   if (pooledWorker.destroyed) {
     return;
   }
-  pooledWorker.worker.once('exit', () => {
+  const discardPooledWorker = () => {
     pooledWorker.destroyed = true;
     const index = idleWorkers.indexOf(pooledWorker);
     if (index !== -1) {
       idleWorkers.splice(index, 1);
     }
-  });
+  };
+  pooledWorker.worker.once('exit', discardPooledWorker);
+  // An idle worker has no invocation-scoped listeners, so an 'error' at rest
+  // would reach a bare EventEmitter and throw in the host process.
+  pooledWorker.worker.once('error', discardPooledWorker);
   pooledWorker.worker.unref();
   idleWorkers.push(pooledWorker);
 }


### PR DESCRIPTION
Fixes #50.

`cleanupWorker` detaches the invocation-scoped `message`, `error`, and `exit` listeners, then hands the worker to `releaseWorker`, which reattaches only `once('exit', ...)`. A worker sitting in `idleWorkers` therefore has no `error` listener, and an error emitted while it is parked reaches a bare `EventEmitter` and throws as an uncaught exception the embedder cannot catch.

The fix attaches the same discard handler to `error` as the one already used for `exit`, so a worker that fails at rest is marked destroyed and dropped from the pool instead of being handed to the next invocation. `acquireWorker` clears it on reacquisition, alongside the existing `removeAllListeners('exit')`, before `startWorkerRun` attaches the invocation-scoped handlers. There is no `await` between those two points, so no window opens where a reacquired worker is unguarded.

## Verification

Each changed line was removed one at a time, rebuilt, and re-probed against real `node:worker_threads` workers:

| changed line | present | removed |
| --- | --- | --- |
| `once('error', discardPooledWorker)` | `error:1`, emit survives, pool 1 -> 0 | `error:0`, the probe dies at the emit |
| `removeAllListeners('error')` | counts stay `1,1,1,1,1,1` over six reuse cycles | counts stack `1,2,3,4,5,6` |
| `once('exit', discardPooledWorker)` | pool 1 -> 0 on exit | pool 1 -> 1 |

The third row is the control: the exit assertion can go red, so its passing state means something. One worker is reused across all six cycles, and a run issued after a poisoned worker is discarded still returns normally.

The regression test in `manager-protocol.test.ts` fails before the change (`expected 1 to be +0`) and passes after. It asserts the pool-accounting side effect rather than the crash itself, because `createWorkerDouble` is a plain listener map that drops an unhandled `error` instead of throwing the way `EventEmitter` does; the crash property is covered by the probe above.

`pnpm test` 263/263 and `pnpm --filter run test:bun` 263/263, both on Node 22.22.2 and Bun 1.3.14. Lint, format, and type-check clean.

## On reachability

Worth stating plainly: I could not produce a genuine at-rest `error` from a parked worker. Malformed messages return `run-worker-message-error` rather than crashing the thread, which is #28 doing its job, and an unawaited host-function call is rejected outright. No `resourceLimits` are set on the `Worker`, so there is no `ERR_WORKER_OUT_OF_MEMORY` path. What remains is abnormal thread death. So this is hardening, not a live crash report, and every `error` emit in the verification above is synthetic.

## Not included

`destroyWorker` has the same shape and I left it alone rather than widen the diff. It calls `removeAllListeners()` for every event before awaiting termination, and on Bun `terminatePooledWorker` races `terminate()` against the 100ms grace timer and returns when the grace wins, per the existing comment about oven-sh/bun#12616, which can leave a still-executing worker unguarded. I read that path but did not run it on Bun, so it is noted rather than claimed.
