### PR TITLE
feat: add synchronous host functions and native modules

### DIFF
--- a/.changeset/calm-geckos-run.md
+++ b/.changeset/calm-geckos-run.md
@@ -1,0 +1,5 @@
+---
+'run': minor
+---
+
+Add synchronous host-function bindings and native static/dynamic ES module loading, with bounded per-invocation bridge transport, cancellation propagation, continuation safeguards, and Node.js 20 support.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,13 @@ permissions:
 
 jobs:
   quality:
-    name: Quality
+    name: Quality (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.19, 22]
 
     steps:
       - name: Checkout
@@ -29,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -49,4 +53,5 @@ jobs:
         run: pnpm test
 
       - name: Test Bun compatibility
+        if: matrix.node-version == 22
         run: pnpm --filter run test:bun

--- a/content/docs/advanced/cancellation.mdx
+++ b/content/docs/advanced/cancellation.mdx
@@ -71,6 +71,11 @@ The `fetch()` call runs in the host, not in the sandbox. When the run is
 cancelled, the host function receives the abort event and the request can stop
 without waiting for the remote server.
 
+The same rule applies to promise-returning `syncHostFunctions` and to
+`moduleLoader.normalize()` and `moduleLoader.load()`. Those APIs block the guest
+worker while their host implementation settles, so forwarding the signal is
+required to stop underlying filesystem, network, or command work promptly.
+
 Handle cancellation by checking the stable package error code:
 
 ```ts
@@ -125,8 +130,9 @@ Cancellation and timeouts both stop an invocation, but they report different
 errors. An explicit abort produces `RUN_ABORTED`, while exceeding `timeoutMs`
 produces `RUN_TIMEOUT`.
 
-The timeout covers guest execution, host function work, and continuation
-operations. Both outcomes abort the signal exposed to active host functions.
+The timeout covers guest execution, asynchronous and synchronous host function
+work, module loading, and continuation operations. Both outcomes abort the
+signal exposed to active host callbacks.
 
 Use `timeoutMs` as the runtime budget and an abort signal for lifecycle events
 such as client disconnects and application shutdown:

--- a/content/docs/advanced/continuations.mdx
+++ b/content/docs/advanced/continuations.mdx
@@ -125,9 +125,9 @@ if (resumed.status === 'completed') {
 }
 ```
 
-The original source, host function names, audience, and continuation context
-must match when the run resumes. A mismatch rejects the continuation before the
-interrupted host function is invoked.
+The original source, asynchronous and synchronous host function names, audience,
+and continuation context must match when the run resumes. A mismatch rejects
+the continuation before the interrupted host function is invoked.
 
 Host function implementations are not compared. Deployments must preserve
 compatible behavior for interrupted host functions while old continuations
@@ -136,6 +136,11 @@ remain valid.
 Several host functions can interrupt during the same invocation. The result
 contains the full batch, and the host must resolve every interruption in that
 batch together. Replay may later reach another batch of interruptions.
+
+Continuations are limited to asynchronous host functions. A run cannot mint a
+continuation after it has used a synchronous binding, and replay rejects a
+synchronous bridge request before dispatching it. Module-backed runs cannot
+create or resume continuations.
 
 ## Signing
 

--- a/content/docs/advanced/limits.mdx
+++ b/content/docs/advanced/limits.mdx
@@ -20,19 +20,19 @@ and a coding agent rarely want the same budget.
 
 ## Defaults
 
-| Limit                           |    Default | Bounds                                    |
-| ------------------------------- | ---------: | ----------------------------------------- |
-| `timeoutMs`                     | 30 seconds | The complete invocation                   |
-| `memoryLimitBytes`              |     64 MiB | QuickJS memory                            |
-| `maxStackSizeBytes`             |      2 MiB | QuickJS stack                             |
-| `maxSourceBytes`                |    256 KiB | UTF-8 source                              |
-| `maxResultBytes`                |      1 MiB | Serialized result data                    |
-| `maxConsoleOutputBytes`         |     64 KiB | Guest console output                      |
-| `maxHostFunctionArgumentsBytes` |      1 MiB | Serialized arguments for one call         |
-| `maxHostFunctionOutputBytes`    |      4 MiB | Serialized output or interruption payload |
-| `maxBridgeRequests`             |        256 | Host function calls in one invocation     |
-| `maxInFlightBridgeRequests`     |         32 | Host function calls active at once        |
-| `maxContinuationBytes`          |     32 MiB | Serialized continuation state             |
+| Limit                           |    Default | Bounds                              |
+| ------------------------------- | ---------: | ----------------------------------- |
+| `timeoutMs`                     | 30 seconds | The complete invocation             |
+| `memoryLimitBytes`              |     64 MiB | QuickJS and sync-bridge admission   |
+| `maxStackSizeBytes`             |      2 MiB | QuickJS stack                       |
+| `maxSourceBytes`                |    256 KiB | Entry and loaded module source      |
+| `maxResultBytes`                |      1 MiB | Serialized result data              |
+| `maxConsoleOutputBytes`         |     64 KiB | Guest console output                |
+| `maxHostFunctionArgumentsBytes` |      1 MiB | Serialized arguments for one call   |
+| `maxHostFunctionOutputBytes`    |      4 MiB | Serialized binding or loader output |
+| `maxBridgeRequests`             |        256 | Binding and module requests         |
+| `maxInFlightBridgeRequests`     |         32 | Host function calls active at once  |
+| `maxContinuationBytes`          |     32 MiB | Serialized continuation state       |
 
 Every configured value must be a positive integer.
 
@@ -112,15 +112,27 @@ Source, argument, output, result, and continuation limits are measured after
 their relevant UTF-8 encoding or serialization step. A JavaScript object that
 appears small can have a much larger serialized representation.
 
+For modules, `maxSourceBytes` applies both before and after type stripping, and
+`maxHostFunctionOutputBytes` applies to the JSON-encoded loader response written
+to the bridge. Escapes such as quotes and backslashes can make that encoded
+response larger than the source text.
+
 Memory and worker concurrency should be planned together. Raising
 `memoryLimitBytes` increases the maximum memory available to every active
 worker, which may reduce the number of invocations a process can safely run at
 once.
 
-`maxBridgeRequests` controls total host interaction, while
+Runs without synchronous bindings or a module loader do not allocate a
+synchronous bridge. When needed, the bridge is included in process memory
+admission, must fit within `memoryLimitBytes`, and has a hard 64 MiB capacity.
+
+`maxBridgeRequests` controls total asynchronous bindings, synchronous bindings,
+and module-loader interaction, while
 `maxInFlightBridgeRequests` controls parallel host interaction. Lowering the
 in-flight limit can protect a database or external service even when the total
-number of host function calls remains unchanged.
+number of asynchronous host function calls remains unchanged. Synchronous and
+module requests are serialized separately and do not count toward the in-flight
+limit.
 
 ## Failures
 

--- a/content/docs/foundations/host-functions.mdx
+++ b/content/docs/foundations/host-functions.mdx
@@ -86,6 +86,56 @@ const [profile, orders] = await Promise.all([
 The invocation limits both the total number of host function calls and the
 number that may be in flight at once.
 
+## Synchronous host functions
+
+Use `syncHostFunctions` when a guest API must return before the next guest
+statement executes. Synchronous bindings are configured on a runner and exposed
+as ordinary, non-promise-returning guest methods:
+
+```ts
+import { createRunner } from 'run';
+
+const files = new Map<string, string>();
+
+const runner = createRunner({
+  syncHostFunctions: {
+    fs: {
+      readFile(path: string) {
+        return files.get(path);
+      },
+      writeFile(path: string, value: string) {
+        files.set(path, value);
+      },
+    },
+  },
+});
+
+const result = await runner.run({
+  source: `
+    fs.writeFile('/state', 'ready');
+    return fs.readFile('/state');
+  `,
+});
+```
+
+The host implementation may itself be asynchronous. The worker remains blocked
+until it settles, while guest code receives either the serializable return value
+or an immediate throw. A synchronous binding cannot interrupt a run.
+
+Synchronous and asynchronous namespaces must not overlap. Both kinds of calls
+share `maxBridgeRequests`; synchronous requests execute one at a time and do not
+count toward `maxInFlightBridgeRequests`.
+
+The synchronous bridge is created only for runners that expose synchronous
+bindings or runs that use a module loader. Its allocation is included in memory
+admission and capped at 64 MiB. `SharedArrayBuffer` and `Atomics` remain
+unavailable to guest code.
+
+A run cannot create a continuation after using a synchronous binding, and
+synchronous calls are forbidden during continuation replay. The synchronous
+binding-name manifest is part of continuation scope, so changing it invalidates
+an existing continuation before replay.
+
 ## Context
 
 A host function can call `getHostFunctionContext()` to read information about
@@ -150,6 +200,10 @@ const hostFunctions = {
   },
 };
 ```
+
+This requirement also applies to synchronous bindings whose host implementation
+returns a promise. Although the guest worker is blocked, the host operation can
+still observe cancellation and stop its work.
 
 Aborting the signal cannot automatically undo work that has already completed.
 Host functions that perform writes should use application-level idempotency and

--- a/content/docs/foundations/meta.json
+++ b/content/docs/foundations/meta.json
@@ -5,6 +5,7 @@
     "overview",
     "sandbox",
     "host-functions",
+    "modules",
     "serialization",
     "interruptions"
   ]

--- a/content/docs/foundations/modules.mdx
+++ b/content/docs/foundations/modules.mdx
@@ -1,0 +1,104 @@
+---
+title: Native modules
+description: Load static, cyclic, and dynamic ES modules inside the sandbox.
+---
+
+# Native modules
+
+Pass a `moduleLoader` to evaluate the entry source as an ES module and resolve
+its imports through host-controlled callbacks. QuickJS performs native module
+linking, so static imports, aliases, cycles, and dynamic `import()` use normal
+ES module semantics without rewriting source text.
+
+```ts
+import { createRunner } from 'run';
+
+const modules = new Map([['/values.js', 'export const value = 42;']]);
+
+const runner = createRunner({
+  syncHostFunctions: {
+    report: {
+      value: (value: number) => console.log(value),
+    },
+  },
+});
+
+const result = await runner.run({
+  source: `
+    import { value } from './values.js';
+    report.value(value);
+  `,
+  moduleLoader: {
+    identity: 'workspace-v1',
+    normalize(specifier) {
+      return specifier === './values.js' ? '/values.js' : specifier;
+    },
+    load(specifier) {
+      const source = modules.get(specifier);
+      if (source === undefined) throw new Error('Module not found');
+      return source;
+    },
+  },
+});
+```
+
+## Resolution
+
+`normalize(specifier, importer)` returns the canonical name used for module
+identity and caching. It receives the raw import specifier and the importing
+module name. If `normalize` is omitted, the raw specifier is used.
+
+`load(specifier)` receives a normalized name and returns its source text. Both
+callbacks may return strings directly or promises. They execute in the host and
+can call `getHostFunctionContext()` to obtain cancellation and request metadata.
+
+Treat guest-controlled specifiers as untrusted input. Restrict resolution to an
+allowed module graph, normalize paths before authorization, and prevent escapes
+from the intended root. Raw loader failures are redacted before they enter the
+sandbox, but the loader should still avoid placing secrets in returned source.
+
+## Results
+
+Entry modules execute for their side effects. A successfully evaluated
+module-backed run returns:
+
+```ts
+{ status: 'completed', value: undefined }
+```
+
+The module namespace is deliberately not serialized as the result. Modules may
+therefore export functions and cyclic namespaces without causing result
+serialization failures. Use a host function when the entry module needs to send
+a value to the host.
+
+## TypeScript
+
+Node uses its native type stripper when available, and Bun uses its native
+TypeScript transpiler. On Node 20, install the optional `typescript` peer
+dependency when the runtime must strip TypeScript syntax:
+
+```sh
+pnpm add typescript
+```
+
+Without the optional peer, Node 20 continues to support JavaScript and source
+that has already been type-stripped. Unsupported TypeScript syntax is reported
+as a guest syntax error.
+
+Type stripping is not type checking. Compile and validate authored modules
+before execution when type correctness matters.
+
+## Limits and cancellation
+
+Raw and transformed module source are bounded by `maxSourceBytes`. The
+JSON-encoded loader response is bounded by `maxHostFunctionOutputBytes`, and
+module resolution shares `maxBridgeRequests` with host-function calls.
+
+Module loading uses the synchronous bridge internally, even when a loader
+callback returns a promise. The worker waits while the host callback runs. Pass
+`getHostFunctionContext().abortSignal` to filesystem, network, or other
+cancellable work so timeouts and caller cancellation can stop it.
+
+Module-backed runs cannot create or resume continuations. Do not combine
+`moduleLoader` with `continuation`; an interruption reached during module
+evaluation fails instead of minting a continuation.

--- a/content/docs/foundations/overview.mdx
+++ b/content/docs/foundations/overview.mdx
@@ -102,5 +102,7 @@ boundary.
 
 A call such as `users.find("user_123")` is called a **bridge request**. The
 guest sends the serialized arguments to the host, the host calls the host
-function, and the serialized outcome is returned to the guest. The host
-function may be synchronous or asynchronous.
+function, and the serialized outcome is returned to the guest. Ordinary host
+functions always appear asynchronous to guest code. A runner can separately
+configure synchronous host functions for APIs that must return before the next
+guest statement executes.

--- a/content/docs/foundations/sandbox.mdx
+++ b/content/docs/foundations/sandbox.mdx
@@ -15,9 +15,9 @@ service requires a host function.
 
 ## Source
 
-The `source` property accepts JavaScript or type-stripped TypeScript. The source
-is evaluated as the body of an asynchronous function rather than as a module,
-so it can use top-level `await` and `return`.
+The `source` property accepts JavaScript or type-stripped TypeScript. By default,
+source is evaluated as the body of an asynchronous function, so it can use
+top-level `await` and `return`.
 
 ```ts
 const result = await run({
@@ -36,11 +36,12 @@ const result = await run({
   with `atob()` and `btoa()`.
 - The guest implementation of `Date` and `Math.random()` is deterministic. This
   allows an interrupted run to execute consistently when it is replayed.
-- TypeScript annotations are stripped before execution. Common TypeScript
-  syntax works, but nothing is type-checked and this is not a full TypeScript
-  compiler.
-- The source cannot use static imports or dynamic `import()`. Dependencies must
-  either be included directly in the source or represented by a host function.
+- TypeScript annotations are stripped before execution when the runtime has a
+  native stripper. Node 20 uses the optional `typescript` peer dependency as a
+  fallback. Nothing is type-checked.
+- Default function-body source cannot import modules. Passing a `moduleLoader`
+  evaluates source as an ES module and enables static and dynamic imports
+  through host-controlled resolution.
 - The sandbox does not provide Node.js globals such as `process`, `require`,
   `module`, or `Buffer`. It also does not provide browser networking APIs such
   as `fetch`, `WebSocket`, or `XMLHttpRequest`.

--- a/content/docs/reference/create-runner.mdx
+++ b/content/docs/reference/create-runner.mdx
@@ -13,6 +13,11 @@ import { createRunner } from 'run';
 
 const runner = createRunner({
   limits: { timeoutMs: 10_000 },
+  syncHostFunctions: {
+    values: {
+      read: () => 42,
+    },
+  },
 });
 
 const result = await runner.run<number>({
@@ -119,6 +124,24 @@ import { createRunner } from 'run';
             "type": "number",
             "isOptional": true,
             "description": "Maximum serialized continuation state in bytes. Default: 33554432."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "syncHostFunctions",
+    "type": "SyncHostFunctions",
+    "isOptional": true,
+    "description": "Host function groups exposed with synchronous guest call semantics. Calls must settle to serializable values, cannot interrupt, and share maxBridgeRequests with asynchronous host functions. Default: {}.",
+    "properties": [
+      {
+        "type": "SyncHostFunctions",
+        "parameters": [
+          {
+            "name": "[groupName]",
+            "type": "HostFunctionGroup",
+            "description": "A synchronous binding namespace. It cannot overlap an asynchronous host-function namespace."
           }
         ]
       }

--- a/content/docs/reference/get-host-function-context.mdx
+++ b/content/docs/reference/get-host-function-context.mdx
@@ -5,7 +5,8 @@ description: API Reference for getHostFunctionContext.
 
 # `getHostFunctionContext()`
 
-Get the context for the currently executing host function.
+Get the context for the currently executing asynchronous or synchronous host
+function, or module-loader callback.
 
 ```ts
 import { getHostFunctionContext, run } from 'run';
@@ -44,7 +45,7 @@ import { getHostFunctionContext } from 'run';
   {
     "name": "context",
     "type": "HostFunctionContext",
-    "description": "The context for the active host function call.",
+    "description": "The context for the active host binding or module-loader call.",
     "properties": [
       {
         "type": "HostFunctionContext",
@@ -77,12 +78,12 @@ import { getHostFunctionContext } from 'run';
           {
             "name": "hostFunctionName",
             "type": "string",
-            "description": "The fully qualified host function path, for example tools.search."
+            "description": "The fully qualified callback path, for example tools.search or moduleLoader.load."
           },
           {
             "name": "interrupt",
             "type": "(payload: unknown) => never",
-            "description": "Interrupts the host function and suspends the run."
+            "description": "Interrupts an asynchronous host function and suspends the run. Synchronous bindings and module loaders cannot interrupt."
           },
           {
             "name": "resume",

--- a/content/docs/reference/run.mdx
+++ b/content/docs/reference/run.mdx
@@ -53,7 +53,7 @@ import { run } from 'run';
   {
     "name": "source",
     "type": "string",
-    "description": "JavaScript or type-stripped TypeScript function-body source. Top-level await and return are supported."
+    "description": "JavaScript or type-stripped TypeScript source. Without moduleLoader it is an async function body with top-level await and return; with moduleLoader it is an ES module."
   },
   {
     "name": "hostFunctions",
@@ -80,6 +80,36 @@ import { run } from 'run';
                 ]
               }
             ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "moduleLoader",
+    "type": "RunModuleLoader",
+    "isOptional": true,
+    "description": "A host-controlled native ES module loader. Its presence evaluates source as a module; completed module-backed runs have value undefined and cannot create or resume continuations.",
+    "properties": [
+      {
+        "type": "RunModuleLoader",
+        "parameters": [
+          {
+            "name": "identity",
+            "type": "string",
+            "isOptional": true,
+            "description": "A stable loader identity, limited to 512 bytes."
+          },
+          {
+            "name": "normalize",
+            "type": "(specifier: string, importer: string) => string | Promise<string>",
+            "isOptional": true,
+            "description": "Returns the canonical module name for a raw specifier and importer. The raw specifier is used when omitted."
+          },
+          {
+            "name": "load",
+            "type": "(specifier: string) => string | Promise<string>",
+            "description": "Returns source text for a normalized module name."
           }
         ]
       }

--- a/content/docs/reference/types.mdx
+++ b/content/docs/reference/types.mdx
@@ -38,12 +38,14 @@ import type {
   RunInterruption,
   RunLedgerEntry,
   RunLimits,
+  RunModuleLoader,
   RunResolution,
   Runner,
   RunnerOptions,
   RunResult,
   SignedContinuationCodecOptions,
   StoredContinuation,
+  SyncHostFunctions,
 } from 'run';
 ```
 
@@ -64,13 +66,19 @@ import type {
           {
             "name": "source",
             "type": "string",
-            "description": "JavaScript or type-stripped TypeScript function-body source."
+            "description": "JavaScript or type-stripped TypeScript source, evaluated as a function body by default or as ESM when moduleLoader is present."
           },
           {
             "name": "hostFunctions",
             "type": "HostFunctions",
             "isOptional": true,
             "description": "Host function groups installed as guest globals."
+          },
+          {
+            "name": "moduleLoader",
+            "type": "RunModuleLoader",
+            "isOptional": true,
+            "description": "A host-controlled native ES module loader. Its presence evaluates source as ESM."
           },
           {
             "name": "abortSignal",
@@ -314,6 +322,12 @@ import type {
             "description": "Shared resource limits."
           },
           {
+            "name": "syncHostFunctions",
+            "type": "SyncHostFunctions",
+            "isOptional": true,
+            "description": "Host functions exposed with synchronous guest call semantics."
+          },
+          {
             "name": "continuationSecret",
             "type": "string | Uint8Array",
             "isOptional": true,
@@ -373,6 +387,40 @@ import type {
     "name": "HostFunctions",
     "type": "Record<string, HostFunctionGroup>",
     "description": "Host function groups installed as guest globals."
+  },
+  {
+    "name": "SyncHostFunctions",
+    "type": "HostFunctions",
+    "description": "Host function groups exposed with synchronous guest call semantics."
+  },
+  {
+    "name": "RunModuleLoader",
+    "type": "interface",
+    "description": "A host-controlled native ES module resolver.",
+    "properties": [
+      {
+        "type": "RunModuleLoader",
+        "parameters": [
+          {
+            "name": "identity",
+            "type": "string",
+            "isOptional": true,
+            "description": "A stable loader identity, limited to 512 bytes."
+          },
+          {
+            "name": "normalize",
+            "type": "(specifier: string, importer: string) => string | Promise<string>",
+            "isOptional": true,
+            "description": "Returns a canonical module name."
+          },
+          {
+            "name": "load",
+            "type": "(specifier: string) => string | Promise<string>",
+            "description": "Returns source for a normalized module name."
+          }
+        ]
+      }
+    ]
   },
   {
     "name": "HostFunctionContext",

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -18,7 +18,7 @@ repeating already invoked host functions.
 pnpm add run
 ```
 
-`run` supports Node.js 22.13 or newer and Bun.
+`run` supports Node.js 20.19 or newer and Bun.
 
 ## Run JavaScript
 
@@ -96,6 +96,62 @@ Functions, symbols, promises, weak collections, and arbitrary class instances
 cannot cross the boundary. Returning one fails with a serialization error that
 includes its path when available. Keep capabilities in host functions and send
 data through their arguments and results.
+
+### Synchronous host functions
+
+Use `syncHostFunctions` when guest APIs must return before the next guest
+statement runs, such as filesystem compatibility methods. The host handler may
+still be asynchronous; `run` blocks only the invocation's worker while it
+settles and returns the serialized value directly to guest code.
+
+```ts
+const runner = createRunner({
+  syncHostFunctions: {
+    fs: {
+      readFile: async (path: string) => storage.read(path),
+      writeFile: async (path: string, value: string) =>
+        storage.write(path, value),
+    },
+  },
+});
+
+await runner.run({
+  source: `
+    fs.writeFile('/state', 'ready');
+    return fs.readFile('/state');
+  `,
+});
+```
+
+Synchronous host functions must settle to a serializable value and cannot
+interrupt a run. Their calls share `maxBridgeRequests` with ordinary host
+functions. Forward `getHostFunctionContext().abortSignal` to cancellable work;
+the signal is aborted on timeout or caller cancellation.
+
+### Native ES modules
+
+Passing `moduleLoader` evaluates `source` as an ES module and enables static,
+cyclic, and dynamic imports through QuickJS's native module loader:
+
+```ts
+await runner.run({
+  source: `import { value } from './value.js'; export { value };`,
+  moduleLoader: {
+    identity: 'workspace-v1',
+    normalize(specifier, importer) {
+      return resolveModuleSpecifier(specifier, importer);
+    },
+    load(specifier) {
+      return readModuleSource(specifier);
+    },
+  },
+});
+```
+
+`normalize` and `load` may be synchronous or asynchronous. Their results are
+bounded by the host-function bridge limits, and `SharedArrayBuffer` and
+`Atomics` remain unavailable to guest JavaScript. Module-backed runs cannot
+create or resume continuations.
 
 ### Host function context
 

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -126,7 +126,9 @@ await runner.run({
 Synchronous host functions must settle to a serializable value and cannot
 interrupt a run. Their calls share `maxBridgeRequests` with ordinary host
 functions. Forward `getHostFunctionContext().abortSignal` to cancellable work;
-the signal is aborted on timeout or caller cancellation.
+the signal is aborted on timeout or caller cancellation. The synchronous bridge
+is allocated only for runs that configure synchronous bindings or a module
+loader, is included in invocation memory admission, and is capped at 64 MiB.
 
 ### Native ES modules
 
@@ -135,7 +137,7 @@ cyclic, and dynamic imports through QuickJS's native module loader:
 
 ```ts
 await runner.run({
-  source: `import { value } from './value.js'; export { value };`,
+  source: `import { value } from './value.js'; console.log(value);`,
   moduleLoader: {
     identity: 'workspace-v1',
     normalize(specifier, importer) {
@@ -151,7 +153,19 @@ await runner.run({
 `normalize` and `load` may be synchronous or asynchronous. Their results are
 bounded by the host-function bridge limits, and `SharedArrayBuffer` and
 `Atomics` remain unavailable to guest JavaScript. Module-backed runs cannot
-create or resume continuations.
+create or resume continuations. Loader failures are redacted before entering the
+sandbox.
+
+Entry modules execute for their side effects and a completed module-backed run
+has `value: undefined`; the module namespace is not serialized as the run
+result. This allows modules to export functions and cyclic namespaces without
+turning those exports into result-serialization failures.
+
+Native Node type stripping is used when the runtime provides it, and Bun uses
+its native TypeScript transpiler. On Node 20, install the optional `typescript`
+peer dependency to enable runtime type stripping. Without that peer, JavaScript
+and already type-stripped input remain supported and QuickJS reports unsupported
+TypeScript syntax without exposing a host module-resolution error.
 
 ### Host function context
 

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -57,12 +57,14 @@
     "oxlint": "^1.56.0",
     "quickjs-wasi": "3.6.0",
     "tsup": "^8.5.1",
-    "typescript": "5.8.3",
     "ultracite": "7.3.2",
     "vitest": "^4.1.6"
   },
+  "dependencies": {
+    "typescript": "5.8.3"
+  },
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -57,11 +57,17 @@
     "oxlint": "^1.56.0",
     "quickjs-wasi": "3.6.0",
     "tsup": "^8.5.1",
+    "typescript": "5.8.3",
     "ultracite": "7.3.2",
     "vitest": "^4.1.6"
   },
-  "dependencies": {
-    "typescript": "5.8.3"
+  "peerDependencies": {
+    "typescript": ">=5.1.6 <7"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.19.0"

--- a/packages/run/scripts/package-files.json
+++ b/packages/run/scripts/package-files.json
@@ -52,6 +52,8 @@
   "dist/runtime/protocol.js.map",
   "dist/runtime/source-stack.js",
   "dist/runtime/source-stack.js.map",
+  "dist/runtime/sync-bridge-protocol.js",
+  "dist/runtime/sync-bridge-protocol.js.map",
   "dist/runtime/worker-source.d.ts",
   "dist/runtime/worker-source.js",
   "dist/types.js",

--- a/packages/run/scripts/verify-package.mjs
+++ b/packages/run/scripts/verify-package.mjs
@@ -35,7 +35,11 @@ try {
     ],
     { env: commandEnvironment, maxBuffer: 10 * 1024 * 1024 },
   );
-  const [packed] = JSON.parse(stdout);
+  const jsonStart = stdout.indexOf('[\n');
+  if (jsonStart === -1) {
+    throw new Error(`npm pack did not return a JSON manifest:\n${stdout}`);
+  }
+  const [packed] = JSON.parse(stdout.slice(jsonStart));
   if (packed.size > 650_000 || packed.unpackedSize > 2_100_000) {
     throw new Error(
       `Package size budget exceeded: ${packed.size} packed, ${packed.unpackedSize} unpacked.`,

--- a/packages/run/src/errors.ts
+++ b/packages/run/src/errors.ts
@@ -205,6 +205,9 @@ export const serializeBridgeErrorForGuest = (
   if (RunError.isInstance(error)) {
     return compactError({
       code: boundedString(error.code, MAX_ERROR_CODE_BYTES, 'RUN_ERROR'),
+      ...(error instanceof RunSourceTooLargeError
+        ? { details: error.details }
+        : {}),
       message: boundedString(
         error.message,
         MAX_ERROR_MESSAGE_BYTES,

--- a/packages/run/src/host-function-invocation.ts
+++ b/packages/run/src/host-function-invocation.ts
@@ -26,7 +26,7 @@ const throwIfAborted = (abortSignal: AbortSignal): void => {
   }
 };
 
-const raceAgainstAbort = async <T>(
+export const raceAgainstAbort = async <T>(
   operation: Promise<T>,
   abortSignal: AbortSignal,
 ): Promise<T> => {

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -26,6 +26,8 @@ export type {
   HostFunctionGroup,
   HostFunctionResumeContext,
   HostFunctions,
+  SyncHostFunctions,
+  RunModuleLoader,
   ContinuationCodec,
   ContinuationDecodeTransaction,
   ContinuationOperationContext,

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -4,6 +4,7 @@ import { createSignedContinuationCodec } from './continuation-codec.js';
 import type {
   HostFunctionManifest,
   HostFunctions,
+  SyncHostFunctions,
   ContinuationCodec,
   RunInput,
   Runner,
@@ -191,6 +192,8 @@ export const createRunner = <TOKEN = string>(
           secret: configuredSecret,
         }) as ContinuationCodec<TOKEN>));
   const continuationAudience = options.continuationAudience ?? 'run';
+  const syncHostFunctions: SyncHostFunctions = options.syncHostFunctions ?? {};
+  const syncHostFunctionManifest = validateHostFunctions(syncHostFunctions);
   if (
     continuationAudience.length === 0 ||
     Buffer.byteLength(continuationAudience) > 512
@@ -205,6 +208,34 @@ export const createRunner = <TOKEN = string>(
     ): Promise<RunResult<OUTPUT, TOKEN>> {
       const hostFunctions = input.hostFunctions ?? {};
       const hostFunctionManifest = validateHostFunctions(hostFunctions);
+      for (const namespace of syncHostFunctionManifest.keys()) {
+        if (hostFunctionManifest.has(namespace)) {
+          throw new TypeError(
+            `Host function namespace "${namespace}" cannot be both asynchronous and synchronous.`,
+          );
+        }
+      }
+      if (
+        input.moduleLoader !== undefined &&
+        (typeof input.moduleLoader !== 'object' ||
+          input.moduleLoader === null ||
+          typeof input.moduleLoader.load !== 'function' ||
+          (input.moduleLoader.normalize !== undefined &&
+            typeof input.moduleLoader.normalize !== 'function') ||
+          (input.moduleLoader.identity !== undefined &&
+            (typeof input.moduleLoader.identity !== 'string' ||
+              Buffer.byteLength(input.moduleLoader.identity) > 512)))
+      ) {
+        throw new TypeError('Invalid moduleLoader configuration.');
+      }
+      if (
+        input.moduleLoader !== undefined &&
+        input.continuation !== undefined
+      ) {
+        throw new TypeError(
+          'Continuations cannot be resumed with a module loader configured.',
+        );
+      }
       const value = await runManaged({
         ...input,
         continuationAudience,
@@ -215,6 +246,8 @@ export const createRunner = <TOKEN = string>(
           ...options.limits,
           ...input.limits,
         },
+        syncHostFunctionManifest,
+        syncHostFunctions,
       });
       return value as RunResult<OUTPUT, TOKEN>;
     },

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -481,6 +481,7 @@ const SYNC_HOST_FUNCTIONS_PROXY_SOURCE = `
           if (typeof serialized.name === 'string') error.name = serialized.name;
           if (typeof serialized.code === 'string') error.code = serialized.code;
           if (serialized.details !== undefined) error.details = serialized.details;
+          __runTrustedErrorHandles.register(error, serialized.name, serialized.code);
           throw error;
         }
         try {

--- a/packages/run/src/runtime/guest-sources.ts
+++ b/packages/run/src/runtime/guest-sources.ts
@@ -70,6 +70,14 @@ const HARDENING_SOURCE = `
       configurable: false,
     });
   }
+  try { delete globalThis.Atomics; } catch {}
+  if ('Atomics' in globalThis) {
+    Object.defineProperty(globalThis, 'Atomics', {
+      value: undefined,
+      writable: false,
+      configurable: false,
+    });
+  }
   for (const name of [
     'AsyncDisposableStack',
     'DOMException',
@@ -438,6 +446,63 @@ const HOST_FUNCTIONS_PROXY_SOURCE = `
 );
 `;
 
+const SYNC_HOST_FUNCTIONS_PROXY_SOURCE = `
+(function(invokeSyncHostFunction, syncHostFunctionNamespaces) {
+  function serializationError(label, error) {
+    var message = __runSafeErrorMessage(error);
+    var result = new __runOriginalTypeError(label + ': ' + message);
+    __runOriginalObject.defineProperty(result, 'code', {
+      value: 'RUN_SERIALIZATION_ERROR',
+      writable: true,
+      configurable: true,
+      enumerable: true
+    });
+    return result;
+  }
+
+  function makeProxy(path) {
+    return new __runOriginalProxy(function(){}, {
+      get: function(_target, prop) {
+        if (prop === 'then' || typeof prop === 'symbol') return undefined;
+        return makeProxy(path.concat([__runOriginalString(prop)]));
+      },
+      apply: function(_target, _thisArg, args) {
+        var hostFunctionPath = path.join('.');
+        var inputJson;
+        try {
+          inputJson = __runSerdeBundle.serializeRunValue(args);
+        } catch (error) {
+          throw serializationError('Synchronous host function arguments are not serializable', error);
+        }
+        var encoded = invokeSyncHostFunction(hostFunctionPath, inputJson);
+        if (encoded.charCodeAt(0) === 0) {
+          var serialized = JSON.parse(encoded.slice(1));
+          var error = new __runOriginalError(serialized.message || 'Synchronous host function failed');
+          if (typeof serialized.name === 'string') error.name = serialized.name;
+          if (typeof serialized.code === 'string') error.code = serialized.code;
+          if (serialized.details !== undefined) error.details = serialized.details;
+          throw error;
+        }
+        try {
+          return __runSerdeBundle.deserializeRunValue(encoded.slice(1));
+        } catch (error) {
+          throw serializationError('Synchronous host function result is invalid run-js-v1 data', error);
+        }
+      }
+    });
+  }
+
+  for (var i = 0; i < syncHostFunctionNamespaces.length; i++) {
+    var namespace = syncHostFunctionNamespaces[i];
+    Object.defineProperty(globalThis, namespace, {
+      value: makeProxy([namespace]),
+      writable: false,
+      configurable: false
+    });
+  }
+})(__runInvokeSyncHostFunction, __runSyncHostFunctionNamespaces);
+`;
+
 const SERIALIZATION_GUARD_SOURCE = `
 const __runSerializeJsonPayloadHandle = (function() {
   function serializeValuePayload(value) {
@@ -515,11 +580,14 @@ const __runTrustedErrorHandles = (function() {
 
 export const buildGuestRuntimeSetupSource = (
   hostFunctionNamespaces: string[],
+  syncHostFunctionNamespaces: string[] = [],
 ): string => {
   const namespacesJson = JSON.stringify(hostFunctionNamespaces);
+  const syncNamespacesJson = JSON.stringify(syncHostFunctionNamespaces);
   return `
-(function(__runInvokeHostFunction, __runDeterminism) {
+(function(__runInvokeHostFunction, __runInvokeSyncHostFunction, __runDeterminism) {
 const __runHostFunctionNamespaces = ${namespacesJson};
+const __runSyncHostFunctionNamespaces = ${syncNamespacesJson};
 const __runOriginalError = Error;
 const __runOriginalMath = Math;
 const __runOriginalNumber = Number;
@@ -552,6 +620,7 @@ ${GUEST_SERDE_SOURCE}
 ${HARDENING_SOURCE}
 ${BRIDGE_TRACKING_SOURCE}
 ${HOST_FUNCTIONS_PROXY_SOURCE}
+${SYNC_HOST_FUNCTIONS_PROXY_SOURCE}
 ${SERIALIZATION_GUARD_SOURCE}
 ${TRUSTED_ERROR_SOURCE}
 return Object.freeze({

--- a/packages/run/src/runtime/manager-admission.test.ts
+++ b/packages/run/src/runtime/manager-admission.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getHostFunctionContext, run, setMaxWorkers } from '../index.js';
+import {
+  RunSourceTooLargeError,
+  getHostFunctionContext,
+  run,
+  setMaxWorkers,
+} from '../index.js';
 import { createPromiseWithResolvers } from '../utils/promise-with-resolvers.js';
 import * as sourceCache from '../utils/source-cache.js';
 
@@ -105,6 +110,18 @@ describe('run admission and source transformation', () => {
       status: 'completed',
       value: 2,
     });
+  });
+
+  it('rejects transformed entry source above the configured limit', async () => {
+    transformSourceSpy.mockImplementationOnce(() => 'x'.repeat(65));
+
+    await expect(
+      run({
+        limits: { maxSourceBytes: 64 },
+        moduleLoader: { load: () => 'export {};' },
+        source: 'export {};',
+      }),
+    ).rejects.toBeInstanceOf(RunSourceTooLargeError);
   });
 
   it('resumes when TypeScript transform output changes between hosts', async () => {

--- a/packages/run/src/runtime/manager-protocol.test.ts
+++ b/packages/run/src/runtime/manager-protocol.test.ts
@@ -8,6 +8,10 @@ import { setRuntimeWorkerFactoryForTest } from './manager.js';
 type WorkerListener = (value: unknown) => void;
 type WorkerEmit = (event: string, value: unknown) => void;
 
+function ThrowingSharedArrayBuffer(): never {
+  throw new RangeError('allocation failed');
+}
+
 const createWorkerDouble = ({
   postMessage,
   terminate,
@@ -107,7 +111,65 @@ const expectCleanRun = async (): Promise<void> => {
 };
 
 describe('manager protocol state machine', () => {
-  afterEach(() => setRuntimeWorkerFactoryForTest(undefined));
+  afterEach(() => {
+    setRuntimeWorkerFactoryForTest(undefined);
+    vi.unstubAllGlobals();
+  });
+
+  it('omits the synchronous bridge for ordinary runs', async () => {
+    let receivedSyncBridge: unknown = 'not-received';
+    setRuntimeWorkerFactoryForTest(() =>
+      createWorkerDouble({
+        postMessage: (value, emit) => {
+          const message = value as {
+            invocationId?: string;
+            syncBridge?: unknown;
+            type?: string;
+          };
+          if (message.type !== 'run' || message.invocationId === undefined) {
+            return;
+          }
+          receivedSyncBridge = message.syncBridge;
+          queueMicrotask(() => {
+            emit('message', {
+              invocationId: message.invocationId,
+              success: true,
+              type: 'result',
+              valueJson: '[1]',
+            });
+            emit('message', {
+              invocationId: message.invocationId,
+              type: 'ready',
+            });
+          });
+        },
+      }),
+    );
+
+    await expect(run({ source: 'return 1;' })).resolves.toEqual({
+      status: 'completed',
+      value: 1,
+    });
+    expect(receivedSyncBridge).toBeUndefined();
+  });
+
+  it('allocates the synchronous bridge before acquiring a worker', async () => {
+    const workerFactory = vi.fn(() =>
+      createProtocolWorker(invocationId => [
+        { invocationId, success: true, type: 'result', valueJson: '[1]' },
+        { invocationId, type: 'ready' },
+      ]),
+    );
+    setRuntimeWorkerFactoryForTest(workerFactory);
+    vi.stubGlobal('SharedArrayBuffer', ThrowingSharedArrayBuffer);
+
+    await expect(
+      createRunner({
+        syncHostFunctions: { values: { read: () => 1 } },
+      }).run({ source: 'return values.read();' }),
+    ).rejects.toThrow('allocation failed');
+    expect(workerFactory).not.toHaveBeenCalled();
+  });
 
   it.each([
     {
@@ -161,6 +223,7 @@ describe('manager protocol state machine', () => {
           inputJson: '[[]]',
           invocationId,
           requestId: `${invocationId}:bridge-1`,
+          requestIndex: 1,
           type: 'host-function-request',
         },
       ]),
@@ -223,6 +286,7 @@ describe('manager protocol state machine', () => {
               inputJson: '[[]]',
               invocationId: message.invocationId,
               requestId: `${message.invocationId}:bridge-1`,
+              requestIndex: 1,
               type: 'host-function-request',
             });
             emit('message', {

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -12,9 +12,14 @@ import {
   RunTimeoutError,
   MAX_SERIALIZED_ERROR_BYTES,
   deserializeError,
+  serializeError,
   serializeBridgeErrorForGuest,
 } from '../errors.js';
-import { invokeHostFunction } from '../host-function-invocation.js';
+import {
+  invokeHostFunction,
+  raceAgainstAbort,
+} from '../host-function-invocation.js';
+import { runWithHostFunctionContext } from '../host-function-context.js';
 import {
   assertContinuationState,
   assertContinuationTokenSize,
@@ -59,11 +64,34 @@ import type {
 } from './protocol.js';
 import { assertWorkerToMainMessage } from './protocol-validation.js';
 import { INLINE_RUN_WORKER_SOURCE } from './worker-source.js';
+import {
+  SyncBridgeHeader,
+  SyncBridgeRequestKind,
+  SyncBridgeState,
+  createSyncBridgeBuffer,
+  getSyncBridgeViews,
+  readSyncBridgeRequest,
+  waitAsyncForSyncBridgeChange,
+  writeSyncBridgeResponse,
+} from './sync-bridge-protocol.js';
 
 interface PooledWorker {
   worker: Worker;
   destroyed: boolean;
 }
+
+const getSyncBridgeHostFunctionName = (
+  kind: SyncBridgeRequestKind,
+  name: string,
+): string => {
+  if (kind === SyncBridgeRequestKind.HostFunction) {
+    return name;
+  }
+  if (kind === SyncBridgeRequestKind.ModuleNormalize) {
+    return 'moduleLoader.normalize';
+  }
+  return 'moduleLoader.load';
+};
 
 interface ManagedWorkerRun {
   result: Promise<RunResult>;
@@ -329,7 +357,10 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
   activeInvocations += 1;
   try {
     assertSourceSize(input.source, normalizedOptions.maxSourceBytes);
-    const transformedSource = transformSource(input.source);
+    const transformedSource = transformSource(
+      input.source,
+      input.moduleLoader !== undefined,
+    );
     const scopeHash = createContinuationScopeHash(input, normalizedOptions);
     const continuationState = await readContinuation(
       input,
@@ -378,6 +409,9 @@ function startWorkerRun({
   originalSource,
   hostFunctions,
   hostFunctionManifest,
+  syncHostFunctions,
+  syncHostFunctionManifest,
+  moduleLoader,
   abortSignal,
   resolutions,
   continuationCodec,
@@ -418,6 +452,8 @@ function startWorkerRun({
   let workerCleanedUp = false;
   let workerCleanup: Promise<void> | undefined;
   let totalBridgeRequests = 0;
+  let asyncBridgeRequests = 0;
+  let syncBridgeRequests = 0;
   let inFlightBridgeRequests = 0;
   let suspensionSettling = false;
   let interruptedResultPending: RunInterruptedResult | undefined;
@@ -447,6 +483,11 @@ function startWorkerRun({
   };
   const logicalRunId =
     continuationState?.logicalRunId ?? randomBytes(16).toString('hex');
+  const syncBridge = createSyncBridgeBuffer(
+    normalizedOptions.maxHostFunctionInputBytes,
+    normalizedOptions.maxHostFunctionOutputBytes,
+  );
+  const { header: syncBridgeHeader } = getSyncBridgeViews(syncBridge);
 
   const {
     promise: result,
@@ -468,6 +509,12 @@ function startWorkerRun({
       return Promise.resolve();
     }
     workerCleanedUp = true;
+    Atomics.store(
+      syncBridgeHeader,
+      SyncBridgeHeader.State,
+      SyncBridgeState.Closed,
+    );
+    Atomics.notify(syncBridgeHeader, SyncBridgeHeader.State);
     clearTimeout(timeoutHandle);
     outerAbortSignal?.removeEventListener('abort', onAbort);
     worker.off('message', onMessage);
@@ -609,12 +656,12 @@ function startWorkerRun({
     }
 
     if (message.type === 'bridge-idle') {
-      if (message.requestCount !== totalBridgeRequests) {
+      if (message.requestCount !== asyncBridgeRequests) {
         failTerminal(
           new RunProtocolError(
-            `Worker bridge-idle count mismatch: expected ${totalBridgeRequests}, received ${message.requestCount}.`,
+            `Worker bridge-idle count mismatch: expected ${asyncBridgeRequests}, received ${message.requestCount}.`,
             {
-              expectedRequestCount: totalBridgeRequests,
+              expectedRequestCount: asyncBridgeRequests,
               receivedRequestCount: message.requestCount,
             },
           ),
@@ -670,6 +717,7 @@ function startWorkerRun({
     determinism,
     hostFunctionNamespaces: [...hostFunctionManifest.keys()],
     invocationId,
+    moduleLoader: moduleLoader !== undefined,
     options: {
       executionTimeoutMs: getWorkerExecutionTimeoutMs(
         normalizedOptions.timeoutMs,
@@ -682,8 +730,12 @@ function startWorkerRun({
       timeoutMs: timeoutErrorMs,
     },
     source,
+    syncBridge,
+    syncHostFunctionNamespaces: [...syncHostFunctionManifest.keys()],
     type: 'run',
   };
+
+  runInBackground(runSyncBridgeLoop());
 
   if (!terminalReached) {
     try {
@@ -698,11 +750,11 @@ function startWorkerRun({
 
   function markWorkerRequest(
     message: WorkerHostFunctionRequest,
-  ): number | undefined {
+  ): { bridgeIndex: number; requestIndex: number } | undefined {
     if (terminalReached) {
       return undefined;
     }
-    const expectedRequestId = `${invocationId}:bridge-${totalBridgeRequests + 1}`;
+    const expectedRequestId = `${invocationId}:bridge-${asyncBridgeRequests + 1}`;
     if (message.requestId !== expectedRequestId) {
       failTerminal(
         new RunProtocolError(
@@ -750,14 +802,19 @@ function startWorkerRun({
     }
 
     totalBridgeRequests += 1;
+    asyncBridgeRequests += 1;
     inFlightBridgeRequests += 1;
-    return totalBridgeRequests;
+    return {
+      bridgeIndex: asyncBridgeRequests,
+      requestIndex: totalBridgeRequests,
+    };
   }
 
   async function handleHostFunctionRequest(
     message: WorkerHostFunctionRequest,
-    bridgeIndex: number,
+    indexes: { bridgeIndex: number; requestIndex: number },
   ): Promise<void> {
+    const { bridgeIndex, requestIndex } = indexes;
     const entryIndex = bridgeIndex - 1;
     const replayEntry = ledger[entryIndex];
     try {
@@ -799,7 +856,7 @@ function startWorkerRun({
           invocationId,
           logicalRunId,
           requestId: message.requestId,
-          requestIndex: bridgeIndex,
+          requestIndex,
           ...(replayEntry?.status === 'interrupted'
             ? {
                 resume: {
@@ -825,6 +882,7 @@ function startWorkerRun({
           normalizedOptions.maxHostFunctionOutputBytes,
       });
       if (outcome.status === 'interrupted') {
+        assertCanCreateContinuation();
         const interruptionId =
           replayEntry?.status === 'interrupted'
             ? replayEntry.interruptionId
@@ -900,6 +958,193 @@ function startWorkerRun({
       if (pendingInterruptionIndexes.size > 0 && inFlightBridgeRequests === 0) {
         settleInterruptionsIfQuiescent();
       }
+    }
+  }
+
+  function assertCanCreateContinuation(): void {
+    if (moduleLoader !== undefined || syncBridgeRequests > 0) {
+      throw new RunProtocolError(
+        'A run cannot create a continuation after using synchronous host functions or module loading.',
+      );
+    }
+  }
+
+  async function runSyncBridgeLoop(): Promise<void> {
+    try {
+      for (;;) {
+        const state = Atomics.load(syncBridgeHeader, SyncBridgeHeader.State);
+        if (state === SyncBridgeState.Closed || terminalReached) {
+          return;
+        }
+        if (state === SyncBridgeState.Idle) {
+          await waitAsyncForSyncBridgeChange(
+            syncBridgeHeader,
+            SyncBridgeState.Idle,
+          );
+          continue;
+        }
+        if (state !== SyncBridgeState.Request) {
+          throw new RunProtocolError(
+            'Synchronous bridge entered an invalid request state.',
+          );
+        }
+        const request = readSyncBridgeRequest(syncBridge);
+        if (request.sequence !== syncBridgeRequests + 1) {
+          throw new RunProtocolError(
+            `Synchronous bridge request sequence mismatch: expected ${syncBridgeRequests + 1}, received ${request.sequence}.`,
+          );
+        }
+        if (Buffer.byteLength(request.name) > 1024) {
+          throw new RunProtocolError(
+            'Synchronous bridge request name exceeds 1024 bytes.',
+          );
+        }
+        assertJsonPayloadSize(
+          request.payload,
+          normalizedOptions.maxHostFunctionInputBytes,
+          'Synchronous bridge request arguments',
+        );
+        if (totalBridgeRequests >= normalizedOptions.maxBridgeRequests) {
+          throw new RunBridgeLimitError(
+            `JavaScript runtime exceeded the ${normalizedOptions.maxBridgeRequests} bridge request limit.`,
+          );
+        }
+        syncBridgeRequests += 1;
+        totalBridgeRequests += 1;
+        const response = await dispatchSyncBridgeRequest(
+          request.kind,
+          request.name,
+          request.payload,
+          request.sequence,
+          totalBridgeRequests,
+        );
+        if (terminalReached) {
+          return;
+        }
+        writeSyncBridgeResponse(syncBridge, response);
+        Atomics.store(
+          syncBridgeHeader,
+          SyncBridgeHeader.State,
+          SyncBridgeState.Response,
+        );
+        Atomics.notify(syncBridgeHeader, SyncBridgeHeader.State);
+        await waitAsyncForSyncBridgeChange(
+          syncBridgeHeader,
+          SyncBridgeState.Response,
+        );
+      }
+    } catch (error) {
+      failTerminal(
+        error instanceof RunError
+          ? error
+          : new RunProtocolError('Synchronous bridge protocol failed.', {
+              cause: error instanceof Error ? error.message : String(error),
+            }),
+      );
+    }
+  }
+
+  async function dispatchSyncBridgeRequest(
+    kind: SyncBridgeRequestKind,
+    name: string,
+    payload: string,
+    sequence: number,
+    requestIndex: number,
+  ) {
+    const context: HostFunctionContext = {
+      abortSignal: invocationAbortController.signal,
+      hostFunctionName: getSyncBridgeHostFunctionName(kind, name),
+      interrupt,
+      invocationId,
+      logicalRunId,
+      requestId: `${invocationId}:sync-${sequence}`,
+      requestIndex,
+    };
+    try {
+      if (kind === SyncBridgeRequestKind.HostFunction) {
+        const outcome = await invokeHostFunction({
+          context,
+          hostFunctionManifest: syncHostFunctionManifest,
+          hostFunctionName: name,
+          hostFunctions: syncHostFunctions,
+          inputJson: payload,
+          maxHostFunctionInputBytes:
+            normalizedOptions.maxHostFunctionInputBytes,
+          maxHostFunctionOutputBytes:
+            normalizedOptions.maxHostFunctionOutputBytes,
+        });
+        if (outcome.status === 'interrupted') {
+          throw new RunProtocolError(
+            'Synchronous host functions cannot interrupt a run.',
+          );
+        }
+        return {
+          payload: outcome.valueJson,
+          sequence,
+          success: true as const,
+        };
+      }
+
+      if (moduleLoader === undefined) {
+        throw new RunProtocolError(
+          'Worker requested module loading without a configured module loader.',
+        );
+      }
+      const args = JSON.parse(payload) as unknown;
+      if (
+        !Array.isArray(args) ||
+        args.some(value => typeof value !== 'string')
+      ) {
+        throw new RunProtocolError('Module loader arguments are malformed.');
+      }
+      const output = await raceAgainstAbort(
+        runWithHostFunctionContext(context, async () => {
+          if (kind === SyncBridgeRequestKind.ModuleNormalize) {
+            if (args.length !== 2) {
+              throw new RunProtocolError(
+                'Module normalize arguments are malformed.',
+              );
+            }
+            return await (moduleLoader.normalize?.(
+              args[0] as string,
+              args[1] as string,
+            ) ?? args[0]);
+          }
+          if (args.length !== 1) {
+            throw new RunProtocolError('Module load arguments are malformed.');
+          }
+          return await moduleLoader.load(args[0] as string);
+        }),
+        context.abortSignal,
+      );
+      if (typeof output !== 'string') {
+        throw new TypeError(
+          `${context.hostFunctionName} must return a string.`,
+        );
+      }
+      const bridgeOutput =
+        kind === SyncBridgeRequestKind.ModuleLoad
+          ? transformSource(output, true)
+          : output;
+      assertJsonPayloadSize(
+        bridgeOutput,
+        normalizedOptions.maxHostFunctionOutputBytes,
+        `${context.hostFunctionName} output`,
+      );
+      return {
+        payload: JSON.stringify(bridgeOutput),
+        sequence,
+        success: true as const,
+      };
+    } catch (error) {
+      return {
+        error:
+          kind === SyncBridgeRequestKind.HostFunction
+            ? serializeBridgeErrorForGuest(error, 'hostFunction')
+            : serializeError(error),
+        sequence,
+        success: false as const,
+      };
     }
   }
 

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -12,7 +12,6 @@ import {
   RunTimeoutError,
   MAX_SERIALIZED_ERROR_BYTES,
   deserializeError,
-  serializeError,
   serializeBridgeErrorForGuest,
 } from '../errors.js';
 import {
@@ -68,7 +67,9 @@ import {
   SyncBridgeHeader,
   SyncBridgeRequestKind,
   SyncBridgeState,
+  MAX_SYNC_BRIDGE_BUFFER_BYTES,
   createSyncBridgeBuffer,
+  getSyncBridgeBufferBytes,
   getSyncBridgeViews,
   readSyncBridgeRequest,
   waitAsyncForSyncBridgeChange,
@@ -342,7 +343,34 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
   if (input.abortSignal?.aborted) {
     throw new RunAbortedError();
   }
+  const needsSyncBridge =
+    input.moduleLoader !== undefined || input.syncHostFunctionManifest.size > 0;
+  const syncBridgeBytes = needsSyncBridge
+    ? getSyncBridgeBufferBytes(
+        normalizedOptions.maxHostFunctionInputBytes,
+        normalizedOptions.maxHostFunctionOutputBytes,
+      )
+    : 0;
+  if (syncBridgeBytes > normalizedOptions.memoryLimitBytes) {
+    throw new RunBridgeLimitError(
+      `Synchronous bridge requires ${syncBridgeBytes} bytes, exceeding the ${normalizedOptions.memoryLimitBytes} byte invocation memory limit.`,
+      {
+        memoryLimitBytes: normalizedOptions.memoryLimitBytes,
+        syncBridgeBytes,
+      },
+    );
+  }
+  if (syncBridgeBytes > MAX_SYNC_BRIDGE_BUFFER_BYTES) {
+    throw new RunBridgeLimitError(
+      `Synchronous bridge requires ${syncBridgeBytes} bytes, exceeding the ${MAX_SYNC_BRIDGE_BUFFER_BYTES} byte bridge capacity limit.`,
+      {
+        maxSyncBridgeBytes: MAX_SYNC_BRIDGE_BUFFER_BYTES,
+        syncBridgeBytes,
+      },
+    );
+  }
   const maxWorkers = getMaxWorkers({
+    additionalMemoryBytes: syncBridgeBytes,
     memoryLimitBytes: normalizedOptions.memoryLimitBytes,
   });
   if (activeInvocations >= maxWorkers) {
@@ -350,6 +378,7 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
   }
   const reservedMemoryBytes = reserveWorkerMemory(
     normalizedOptions.memoryLimitBytes,
+    syncBridgeBytes,
   );
   if (reservedMemoryBytes === undefined) {
     throw new RunConcurrencyError(Math.max(1, activeInvocations));
@@ -361,6 +390,7 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
       input.source,
       input.moduleLoader !== undefined,
     );
+    assertSourceSize(transformedSource, normalizedOptions.maxSourceBytes);
     const scopeHash = createContinuationScopeHash(input, normalizedOptions);
     const continuationState = await readContinuation(
       input,
@@ -432,6 +462,17 @@ function startWorkerRun({
 }): ManagedWorkerRun {
   invocationCounter += 1;
   const invocationId = `run-${invocationCounter}`;
+  const syncBridge =
+    moduleLoader !== undefined || syncHostFunctionManifest.size > 0
+      ? createSyncBridgeBuffer(
+          normalizedOptions.maxHostFunctionInputBytes,
+          normalizedOptions.maxHostFunctionOutputBytes,
+        )
+      : undefined;
+  const syncBridgeHeader =
+    syncBridge === undefined
+      ? undefined
+      : getSyncBridgeViews(syncBridge).header;
   const pooledWorker = acquireWorker(maxWorkers);
   const { worker } = pooledWorker;
   const invocationContext = new AsyncResource('run:invocation');
@@ -452,14 +493,22 @@ function startWorkerRun({
   let workerCleanedUp = false;
   let workerCleanup: Promise<void> | undefined;
   let totalBridgeRequests = 0;
+  let nextBridgeRequestIndex = 1;
+  let bridgeRequestTurnHeld = false;
   let asyncBridgeRequests = 0;
   let syncBridgeRequests = 0;
+  let syncBridgeOperationInFlight = false;
   let inFlightBridgeRequests = 0;
   let suspensionSettling = false;
   let interruptedResultPending: RunInterruptedResult | undefined;
   let workerReady = false;
   let workerIdleRequestCount = 0;
   const seenWorkerRequestIds = new Set<string>();
+  const arrivedBridgeRequestIndexes = new Set<number>();
+  const bridgeRequestTurnWaiters = new Map<
+    number,
+    ReturnType<typeof createPromiseWithResolvers<null>>
+  >();
   const ledger: RunLedgerEntry[] = structuredClone(
     continuationState?.ledger ?? [],
   );
@@ -483,12 +532,6 @@ function startWorkerRun({
   };
   const logicalRunId =
     continuationState?.logicalRunId ?? randomBytes(16).toString('hex');
-  const syncBridge = createSyncBridgeBuffer(
-    normalizedOptions.maxHostFunctionInputBytes,
-    normalizedOptions.maxHostFunctionOutputBytes,
-  );
-  const { header: syncBridgeHeader } = getSyncBridgeViews(syncBridge);
-
   const {
     promise: result,
     reject: rejectResult,
@@ -509,12 +552,14 @@ function startWorkerRun({
       return Promise.resolve();
     }
     workerCleanedUp = true;
-    Atomics.store(
-      syncBridgeHeader,
-      SyncBridgeHeader.State,
-      SyncBridgeState.Closed,
-    );
-    Atomics.notify(syncBridgeHeader, SyncBridgeHeader.State);
+    if (syncBridgeHeader !== undefined) {
+      Atomics.store(
+        syncBridgeHeader,
+        SyncBridgeHeader.State,
+        SyncBridgeState.Closed,
+      );
+      Atomics.notify(syncBridgeHeader, SyncBridgeHeader.State);
+    }
     clearTimeout(timeoutHandle);
     outerAbortSignal?.removeEventListener('abort', onAbort);
     worker.off('message', onMessage);
@@ -555,8 +600,99 @@ function startWorkerRun({
       return;
     }
     terminalReached = true;
+    for (const waiter of bridgeRequestTurnWaiters.values()) {
+      waiter.reject(error);
+    }
+    bridgeRequestTurnWaiters.clear();
     abortInvocation(error);
     runInBackground(settleAfterWorkerCleanup(false, () => rejectResult(error)));
+  };
+
+  const admitBridgeRequest = async (requestIndex: number): Promise<boolean> => {
+    if (terminalReached) {
+      return false;
+    }
+    if (
+      !Number.isSafeInteger(requestIndex) ||
+      requestIndex < nextBridgeRequestIndex ||
+      arrivedBridgeRequestIndexes.has(requestIndex)
+    ) {
+      failTerminal(
+        new RunProtocolError(
+          `Worker sent invalid aggregate bridge request index ${requestIndex}.`,
+          { nextBridgeRequestIndex, requestIndex },
+        ),
+      );
+      return false;
+    }
+    arrivedBridgeRequestIndexes.add(requestIndex);
+    if (requestIndex === nextBridgeRequestIndex) {
+      bridgeRequestTurnHeld = true;
+    } else {
+      const waiter = createPromiseWithResolvers<null>();
+      bridgeRequestTurnWaiters.set(requestIndex, waiter);
+      try {
+        await waiter.promise;
+      } catch {
+        return false;
+      }
+    }
+    if (terminalReached) {
+      return false;
+    }
+    if (
+      !bridgeRequestTurnHeld ||
+      requestIndex !== nextBridgeRequestIndex ||
+      totalBridgeRequests + 1 !== requestIndex
+    ) {
+      failTerminal(
+        new RunProtocolError(
+          `Aggregate bridge request order mismatch: expected ${nextBridgeRequestIndex}, received ${requestIndex}.`,
+        ),
+      );
+      return false;
+    }
+    if (totalBridgeRequests >= normalizedOptions.maxBridgeRequests) {
+      failTerminal(
+        new RunBridgeLimitError(
+          `JavaScript runtime exceeded the ${normalizedOptions.maxBridgeRequests} bridge request limit.`,
+          {
+            invocationId,
+            maxBridgeRequests: normalizedOptions.maxBridgeRequests,
+          },
+        ),
+      );
+      return false;
+    }
+    totalBridgeRequests += 1;
+    return true;
+  };
+
+  const releaseBridgeRequestTurn = (requestIndex: number): boolean => {
+    if (
+      terminalReached ||
+      !bridgeRequestTurnHeld ||
+      requestIndex !== nextBridgeRequestIndex
+    ) {
+      if (!terminalReached) {
+        failTerminal(
+          new RunProtocolError(
+            `Aggregate bridge request turn mismatch for ${requestIndex}.`,
+          ),
+        );
+      }
+      return false;
+    }
+    arrivedBridgeRequestIndexes.delete(requestIndex);
+    bridgeRequestTurnHeld = false;
+    nextBridgeRequestIndex += 1;
+    const waiter = bridgeRequestTurnWaiters.get(nextBridgeRequestIndex);
+    if (waiter !== undefined) {
+      bridgeRequestTurnWaiters.delete(nextBridgeRequestIndex);
+      bridgeRequestTurnHeld = true;
+      waiter.resolve(null);
+    }
+    return true;
   };
 
   const onAbort = bindInvocationContext(() => {
@@ -735,7 +871,9 @@ function startWorkerRun({
     type: 'run',
   };
 
-  runInBackground(runSyncBridgeLoop());
+  if (syncBridge !== undefined && syncBridgeHeader !== undefined) {
+    runInBackground(runSyncBridgeLoop(syncBridge, syncBridgeHeader));
+  }
 
   if (!terminalReached) {
     try {
@@ -750,7 +888,7 @@ function startWorkerRun({
 
   function markWorkerRequest(
     message: WorkerHostFunctionRequest,
-  ): { bridgeIndex: number; requestIndex: number } | undefined {
+  ): { bridgeIndex: number } | undefined {
     if (terminalReached) {
       return undefined;
     }
@@ -775,17 +913,20 @@ function startWorkerRun({
     }
     seenWorkerRequestIds.add(message.requestId);
 
-    if (totalBridgeRequests >= normalizedOptions.maxBridgeRequests) {
-      failTerminal(
-        new RunBridgeLimitError(
-          `JavaScript runtime exceeded the ${normalizedOptions.maxBridgeRequests} bridge request limit.`,
-          {
-            invocationId,
-            maxBridgeRequests: normalizedOptions.maxBridgeRequests,
-          },
-        ),
-      );
-      return undefined;
+    asyncBridgeRequests += 1;
+    return { bridgeIndex: asyncBridgeRequests };
+  }
+
+  async function handleHostFunctionRequest(
+    message: WorkerHostFunctionRequest,
+    indexes: { bridgeIndex: number },
+  ): Promise<void> {
+    const { bridgeIndex } = indexes;
+    const { requestIndex } = message;
+    const entryIndex = bridgeIndex - 1;
+    const replayEntry = ledger[entryIndex];
+    if (!(await admitBridgeRequest(requestIndex))) {
+      return;
     }
     if (inFlightBridgeRequests >= normalizedOptions.maxInFlightBridgeRequests) {
       failTerminal(
@@ -798,26 +939,13 @@ function startWorkerRun({
           },
         ),
       );
-      return undefined;
+      return;
     }
-
-    totalBridgeRequests += 1;
-    asyncBridgeRequests += 1;
     inFlightBridgeRequests += 1;
-    return {
-      bridgeIndex: asyncBridgeRequests,
-      requestIndex: totalBridgeRequests,
-    };
-  }
-
-  async function handleHostFunctionRequest(
-    message: WorkerHostFunctionRequest,
-    indexes: { bridgeIndex: number; requestIndex: number },
-  ): Promise<void> {
-    const { bridgeIndex, requestIndex } = indexes;
-    const entryIndex = bridgeIndex - 1;
-    const replayEntry = ledger[entryIndex];
     try {
+      if (!releaseBridgeRequestTurn(requestIndex)) {
+        return;
+      }
       if (replayEntry !== undefined) {
         assertReplayMatches(replayEntry, message);
         if (replayEntry.status === 'fulfilled') {
@@ -843,6 +971,7 @@ function startWorkerRun({
           return;
         }
         if (!resolutionMap.has(replayEntry.interruptionId)) {
+          assertCanCreateContinuation();
           pendingInterruptionIndexes.add(entryIndex);
           return;
         }
@@ -919,40 +1048,7 @@ function startWorkerRun({
         valueJson: outcome.valueJson,
       });
     } catch (error) {
-      if (error instanceof RunProtocolError) {
-        failTerminal(error);
-        return;
-      }
-      const serialized = serializeBridgeErrorForGuest(error, 'hostFunction');
-      try {
-        nextSettlementOrder += 1;
-        setLedgerEntry(entryIndex, {
-          bindingName: message.hostFunctionName,
-          dateNowMs: Date.now(),
-          error: serialized,
-          inputJson: message.inputJson,
-          settledOrder: nextSettlementOrder,
-          status: 'rejected',
-        });
-      } catch (recordError) {
-        failTerminal(recordError);
-        return;
-      }
-      const rejectedEntry = ledger[entryIndex];
-      if (rejectedEntry?.status !== 'rejected') {
-        failTerminal(
-          new RunProtocolError('Rejected ledger entry was not recorded.'),
-        );
-        return;
-      }
-      queueBridgeResponse(rejectedEntry.settledOrder, {
-        dateNowMs: rejectedEntry.dateNowMs,
-        error: serialized,
-        invocationId,
-        requestId: message.requestId,
-        success: false,
-        type: 'bridge-response',
-      });
+      handleHostFunctionFailure(error, entryIndex, message);
     } finally {
       inFlightBridgeRequests -= 1;
       if (pendingInterruptionIndexes.size > 0 && inFlightBridgeRequests === 0) {
@@ -961,24 +1057,75 @@ function startWorkerRun({
     }
   }
 
+  function handleHostFunctionFailure(
+    error: unknown,
+    entryIndex: number,
+    message: WorkerHostFunctionRequest,
+  ): void {
+    if (terminalReached) {
+      return;
+    }
+    if (error instanceof RunProtocolError) {
+      failTerminal(error);
+      return;
+    }
+    const serialized = serializeBridgeErrorForGuest(error, 'hostFunction');
+    try {
+      nextSettlementOrder += 1;
+      setLedgerEntry(entryIndex, {
+        bindingName: message.hostFunctionName,
+        dateNowMs: Date.now(),
+        error: serialized,
+        inputJson: message.inputJson,
+        settledOrder: nextSettlementOrder,
+        status: 'rejected',
+      });
+    } catch (recordError) {
+      failTerminal(recordError);
+      return;
+    }
+    const rejectedEntry = ledger[entryIndex];
+    if (rejectedEntry?.status !== 'rejected') {
+      failTerminal(
+        new RunProtocolError('Rejected ledger entry was not recorded.'),
+      );
+      return;
+    }
+    queueBridgeResponse(rejectedEntry.settledOrder, {
+      dateNowMs: rejectedEntry.dateNowMs,
+      error: serialized,
+      invocationId,
+      requestId: message.requestId,
+      success: false,
+      type: 'bridge-response',
+    });
+  }
+
   function assertCanCreateContinuation(): void {
-    if (moduleLoader !== undefined || syncBridgeRequests > 0) {
+    if (
+      moduleLoader !== undefined ||
+      syncBridgeRequests > 0 ||
+      syncBridgeOperationInFlight
+    ) {
       throw new RunProtocolError(
         'A run cannot create a continuation after using synchronous host functions or module loading.',
       );
     }
   }
 
-  async function runSyncBridgeLoop(): Promise<void> {
+  async function runSyncBridgeLoop(
+    bridge: SharedArrayBuffer,
+    bridgeHeader: Int32Array,
+  ): Promise<void> {
     try {
       for (;;) {
-        const state = Atomics.load(syncBridgeHeader, SyncBridgeHeader.State);
+        const state = Atomics.load(bridgeHeader, SyncBridgeHeader.State);
         if (state === SyncBridgeState.Closed || terminalReached) {
           return;
         }
         if (state === SyncBridgeState.Idle) {
           await waitAsyncForSyncBridgeChange(
-            syncBridgeHeader,
+            bridgeHeader,
             SyncBridgeState.Idle,
           );
           continue;
@@ -988,7 +1135,7 @@ function startWorkerRun({
             'Synchronous bridge entered an invalid request state.',
           );
         }
-        const request = readSyncBridgeRequest(syncBridge);
+        const request = readSyncBridgeRequest(bridge);
         if (request.sequence !== syncBridgeRequests + 1) {
           throw new RunProtocolError(
             `Synchronous bridge request sequence mismatch: expected ${syncBridgeRequests + 1}, received ${request.sequence}.`,
@@ -1004,32 +1151,53 @@ function startWorkerRun({
           normalizedOptions.maxHostFunctionInputBytes,
           'Synchronous bridge request arguments',
         );
-        if (totalBridgeRequests >= normalizedOptions.maxBridgeRequests) {
-          throw new RunBridgeLimitError(
-            `JavaScript runtime exceeded the ${normalizedOptions.maxBridgeRequests} bridge request limit.`,
+        if (!(await admitBridgeRequest(request.requestIndex))) {
+          return;
+        }
+        if (continuationState !== undefined) {
+          throw new RunProtocolError(
+            'Synchronous bridge requests are forbidden during continuation replay.',
+          );
+        }
+        if (
+          pendingInterruptionIndexes.size > 0 ||
+          suspensionSettling ||
+          interruptedResultPending !== undefined
+        ) {
+          throw new RunProtocolError(
+            'Synchronous bridge requests are forbidden while creating a continuation.',
           );
         }
         syncBridgeRequests += 1;
-        totalBridgeRequests += 1;
-        const response = await dispatchSyncBridgeRequest(
-          request.kind,
-          request.name,
-          request.payload,
-          request.sequence,
-          totalBridgeRequests,
-        );
+        syncBridgeOperationInFlight = true;
+        if (!releaseBridgeRequestTurn(request.requestIndex)) {
+          return;
+        }
+        let response;
+        try {
+          response = await dispatchSyncBridgeRequest(
+            request.kind,
+            request.name,
+            request.payload,
+            request.sequence,
+            request.requestIndex,
+          );
+        } finally {
+          syncBridgeOperationInFlight = false;
+          settleInterruptionsIfQuiescent();
+        }
         if (terminalReached) {
           return;
         }
-        writeSyncBridgeResponse(syncBridge, response);
+        writeSyncBridgeResponse(bridge, response);
         Atomics.store(
-          syncBridgeHeader,
+          bridgeHeader,
           SyncBridgeHeader.State,
           SyncBridgeState.Response,
         );
-        Atomics.notify(syncBridgeHeader, SyncBridgeHeader.State);
+        Atomics.notify(bridgeHeader, SyncBridgeHeader.State);
         await waitAsyncForSyncBridgeChange(
-          syncBridgeHeader,
+          bridgeHeader,
           SyncBridgeState.Response,
         );
       }
@@ -1090,7 +1258,12 @@ function startWorkerRun({
           'Worker requested module loading without a configured module loader.',
         );
       }
-      const args = JSON.parse(payload) as unknown;
+      let args: unknown;
+      try {
+        args = JSON.parse(payload) as unknown;
+      } catch {
+        throw new RunProtocolError('Module loader arguments are malformed.');
+      }
       if (
         !Array.isArray(args) ||
         args.some(value => typeof value !== 'string')
@@ -1105,10 +1278,10 @@ function startWorkerRun({
                 'Module normalize arguments are malformed.',
               );
             }
-            return await (moduleLoader.normalize?.(
-              args[0] as string,
-              args[1] as string,
-            ) ?? args[0]);
+            const { normalize } = moduleLoader;
+            return normalize === undefined
+              ? args[0]
+              : await normalize(args[0] as string, args[1] as string);
           }
           if (args.length !== 1) {
             throw new RunProtocolError('Module load arguments are malformed.');
@@ -1122,26 +1295,32 @@ function startWorkerRun({
           `${context.hostFunctionName} must return a string.`,
         );
       }
-      const bridgeOutput =
-        kind === SyncBridgeRequestKind.ModuleLoad
-          ? transformSource(output, true)
-          : output;
+      let bridgeOutput = output;
+      if (kind === SyncBridgeRequestKind.ModuleLoad) {
+        assertSourceSize(output, normalizedOptions.maxSourceBytes);
+        bridgeOutput = transformSource(output, true);
+        assertSourceSize(bridgeOutput, normalizedOptions.maxSourceBytes);
+      }
+      const encodedOutput = JSON.stringify(bridgeOutput);
       assertJsonPayloadSize(
-        bridgeOutput,
+        encodedOutput,
         normalizedOptions.maxHostFunctionOutputBytes,
         `${context.hostFunctionName} output`,
       );
       return {
-        payload: JSON.stringify(bridgeOutput),
+        payload: encodedOutput,
         sequence,
         success: true as const,
       };
     } catch (error) {
+      if (error instanceof RunProtocolError) {
+        throw error;
+      }
       return {
         error:
           kind === SyncBridgeRequestKind.HostFunction
             ? serializeBridgeErrorForGuest(error, 'hostFunction')
-            : serializeError(error),
+            : serializeBridgeErrorForGuest(error, 'bridge'),
         sequence,
         success: false as const,
       };
@@ -1195,7 +1374,8 @@ function startWorkerRun({
     if (
       pendingInterruptionIndexes.size > 0 &&
       inFlightBridgeRequests === 0 &&
-      workerIdleRequestCount >= totalBridgeRequests
+      !syncBridgeOperationInFlight &&
+      workerIdleRequestCount >= asyncBridgeRequests
     ) {
       runInBackground(settleInterruptions());
     }
@@ -1226,6 +1406,7 @@ function startWorkerRun({
     }
     suspensionSettling = true;
     try {
+      assertCanCreateContinuation();
       const interruptions = [...pendingInterruptionIndexes]
         .toSorted((left, right) => left - right)
         .map(index => {
@@ -1272,6 +1453,10 @@ function startWorkerRun({
         continuation,
         normalizedOptions.maxContinuationBytes,
       );
+      if (terminalReached) {
+        return;
+      }
+      assertCanCreateContinuation();
       const interruptedResult: RunInterruptedResult = {
         continuation,
         interruptions,
@@ -1309,19 +1494,7 @@ function startWorkerRun({
       return;
     }
     if (interruptedResultPending !== undefined) {
-      if (resultMessage === undefined) {
-        failTerminal(
-          new RunProtocolError(
-            `Worker cancelled ${message.invocationId} without a terminal result.`,
-          ),
-        );
-        return;
-      }
-      terminalReached = true;
-      const interruptedResult = interruptedResultPending;
-      runInBackground(
-        settleAfterWorkerCleanup(true, () => resolveResult(interruptedResult)),
-      );
+      finalizeInterruptedResult(interruptedResultPending);
       return;
     }
     if (resultMessage === undefined) {
@@ -1340,7 +1513,7 @@ function startWorkerRun({
     }
     if (
       continuationState !== undefined &&
-      totalBridgeRequests < continuationState.ledger.length
+      asyncBridgeRequests < continuationState.ledger.length
     ) {
       failTerminal(
         new RunProtocolError(
@@ -1387,6 +1560,12 @@ function startWorkerRun({
     if (terminalReached) {
       return;
     }
+    try {
+      assertCanCreateContinuation();
+    } catch (error) {
+      failTerminal(error);
+      return;
+    }
     if (resultMessage === undefined) {
       failTerminal(
         new RunProtocolError(
@@ -1418,6 +1597,13 @@ function createContinuationScopeHash(
         .toSorted()
         .map(name => `${namespace}.${name}`),
     );
+  const syncHostFunctionManifest = [...input.syncHostFunctionManifest.keys()]
+    .toSorted()
+    .flatMap(namespace =>
+      [...(input.syncHostFunctionManifest.get(namespace) ?? [])]
+        .toSorted()
+        .map(name => `${namespace}.${name}`),
+    );
   return createHash('sha256')
     .update(
       toJsonPayload(
@@ -1425,6 +1611,9 @@ function createContinuationScopeHash(
           audience: input.continuationAudience,
           bindingManifest: hostFunctionManifest,
           continuationContext,
+          ...(syncHostFunctionManifest.length === 0
+            ? {}
+            : { syncBindingManifest: syncHostFunctionManifest }),
           // Keep the existing key so continuations whose transform was an
           // identity remain valid across this change. The original source is
           // stable across hosts and is also exact-matched during validation.

--- a/packages/run/src/runtime/max-workers.test.ts
+++ b/packages/run/src/runtime/max-workers.test.ts
@@ -86,6 +86,23 @@ describe('max workers', () => {
     }
   });
 
+  it('includes additional invocation memory in worker admission', () => {
+    const mib = 1024 * 1024;
+    vi.spyOn(process, 'availableMemory').mockReturnValue(160 * mib);
+
+    expect(
+      getMaxWorkers({
+        additionalMemoryBytes: 16 * mib,
+        memoryLimitBytes: 16 * mib,
+      }),
+    ).toBe(2);
+    const reservation = reserveWorkerMemory(16 * mib, 16 * mib);
+    expect(reservation).toBe(80 * mib);
+    if (reservation !== undefined) {
+      releaseWorkerMemory(reservation);
+    }
+  });
+
   it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
     'rejects invalid configured cap %s',
     value => {

--- a/packages/run/src/runtime/max-workers.ts
+++ b/packages/run/src/runtime/max-workers.ts
@@ -18,8 +18,11 @@ const availableMemory = (): number => {
   return Number.isFinite(bytes) && bytes > 0 ? bytes : 0;
 };
 
-const estimatedWorkerBytes = (memoryLimitBytes: number): number =>
-  memoryLimitBytes + DEFAULT_WORKER_OVERHEAD_BYTES;
+const estimatedWorkerBytes = (
+  memoryLimitBytes: number,
+  additionalMemoryBytes = 0,
+): number =>
+  memoryLimitBytes + DEFAULT_WORKER_OVERHEAD_BYTES + additionalMemoryBytes;
 
 /**
  * Sets the process-global maximum number of active run workers.
@@ -47,8 +50,10 @@ export const setMaxWorkers = (maxWorkers?: number): void => {
  * @internal
  */
 export const getMaxWorkers = ({
+  additionalMemoryBytes = 0,
   memoryLimitBytes,
 }: {
+  additionalMemoryBytes?: number;
   memoryLimitBytes: number;
 }): number => {
   if (configuredMaxWorkers !== undefined) {
@@ -56,7 +61,8 @@ export const getMaxWorkers = ({
   }
 
   const memoryBasedMaxWorkers = Math.floor(
-    availableMemory() / estimatedWorkerBytes(memoryLimitBytes),
+    availableMemory() /
+      estimatedWorkerBytes(memoryLimitBytes, additionalMemoryBytes),
   );
   return Math.max(1, Math.min(DEFAULT_MAX_WORKERS_CAP, memoryBasedMaxWorkers));
 };
@@ -71,12 +77,16 @@ export const getMaxWorkers = ({
  */
 export const reserveWorkerMemory = (
   memoryLimitBytes: number,
+  additionalMemoryBytes = 0,
 ): number | undefined => {
   if (configuredMaxWorkers !== undefined) {
     return 0;
   }
 
-  const reservationBytes = estimatedWorkerBytes(memoryLimitBytes);
+  const reservationBytes = estimatedWorkerBytes(
+    memoryLimitBytes,
+    additionalMemoryBytes,
+  );
   memoryBudgetBytes ??= Math.max(reservationBytes, availableMemory());
   if (reservedMemoryBytes + reservationBytes > memoryBudgetBytes) {
     return undefined;

--- a/packages/run/src/runtime/protocol-validation.ts
+++ b/packages/run/src/runtime/protocol-validation.ts
@@ -194,8 +194,11 @@ export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
       'determinism',
       'hostFunctionNamespaces',
       'invocationId',
+      'moduleLoader',
       'options',
       'source',
+      'syncBridge',
+      'syncHostFunctionNamespaces',
       'type',
     ]);
     if (
@@ -205,6 +208,12 @@ export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
       value.hostFunctionNamespaces.some(item => !isIdentifier(item)) ||
       new Set(value.hostFunctionNamespaces).size !==
         value.hostFunctionNamespaces.length ||
+      !Array.isArray(value.syncHostFunctionNamespaces) ||
+      value.syncHostFunctionNamespaces.some(item => !isIdentifier(item)) ||
+      new Set(value.syncHostFunctionNamespaces).size !==
+        value.syncHostFunctionNamespaces.length ||
+      typeof value.moduleLoader !== 'boolean' ||
+      !(value.syncBridge instanceof SharedArrayBuffer) ||
       !isDeterminism(value.determinism) ||
       !isRunOptions(value.options)
     ) {

--- a/packages/run/src/runtime/protocol-validation.ts
+++ b/packages/run/src/runtime/protocol-validation.ts
@@ -129,11 +129,14 @@ const assertHostFunctionRequest = (value: Record<string, unknown>): void => {
     'inputJson',
     'invocationId',
     'requestId',
+    'requestIndex',
     'type',
   ]);
   if (
     !isIdentifier(value.invocationId) ||
     !isIdentifier(value.requestId) ||
+    !Number.isSafeInteger(value.requestIndex) ||
+    (value.requestIndex as number) <= 0 ||
     typeof value.hostFunctionName !== 'string' ||
     value.hostFunctionName.length === 0 ||
     Buffer.byteLength(value.hostFunctionName) > 1024 ||
@@ -185,6 +188,16 @@ type AssertMainToWorkerMessage = (
   value: unknown,
 ) => asserts value is MainToWorkerMessage;
 
+const hasValidSyncBridgeConfiguration = (
+  value: Record<string, unknown>,
+): boolean =>
+  (value.syncBridge === undefined ||
+    value.syncBridge instanceof SharedArrayBuffer) &&
+  (!value.moduleLoader || value.syncBridge !== undefined) &&
+  (!Array.isArray(value.syncHostFunctionNamespaces) ||
+    value.syncHostFunctionNamespaces.length === 0 ||
+    value.syncBridge !== undefined);
+
 export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
   if (!isRecord(value) || typeof value.type !== 'string') {
     throw invalidMessage('main-to-worker');
@@ -213,7 +226,7 @@ export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
       new Set(value.syncHostFunctionNamespaces).size !==
         value.syncHostFunctionNamespaces.length ||
       typeof value.moduleLoader !== 'boolean' ||
-      !(value.syncBridge instanceof SharedArrayBuffer) ||
+      !hasValidSyncBridgeConfiguration(value) ||
       !isDeterminism(value.determinism) ||
       !isRunOptions(value.options)
     ) {

--- a/packages/run/src/runtime/protocol.test.ts
+++ b/packages/run/src/runtime/protocol.test.ts
@@ -23,8 +23,11 @@ const createRunMessage = (invocationId: string) => ({
   determinism: DETERMINISM,
   hostFunctionNamespaces: ['tools'],
   invocationId,
+  moduleLoader: false,
   options: WORKER_OPTIONS,
   source: 'return await tools.echo({ value: 1 });',
+  syncBridge: undefined,
+  syncHostFunctionNamespaces: [],
   type: 'run',
 });
 
@@ -37,6 +40,18 @@ const requireEntry = <T>(values: readonly T[], index: number): T => {
 };
 
 describe('worker protocol hardening', () => {
+  it('accepts an omitted bridge only when synchronous features are disabled', () => {
+    expect(() =>
+      assertMainToWorkerMessage(createRunMessage('run-a')),
+    ).not.toThrow();
+    expect(() =>
+      assertMainToWorkerMessage({
+        ...createRunMessage('run-b'),
+        syncHostFunctionNamespaces: ['fs'],
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }));
+  });
+
   it.each([
     null,
     {},
@@ -77,6 +92,7 @@ describe('worker protocol hardening', () => {
       inputJson: '[]',
       invocationId: 'run-1',
       requestId: 'request-1',
+      requestIndex: 1,
       type: 'host-function-request',
     },
     { invocationId: 'run-1', success: true, type: 'result' },
@@ -171,6 +187,7 @@ describe('worker protocol hardening', () => {
           inputJson: 'null',
           invocationId: 'run-a',
           requestId: 'request-a',
+          requestIndex: 1,
           type: 'host-function-request',
         },
       },

--- a/packages/run/src/runtime/protocol.ts
+++ b/packages/run/src/runtime/protocol.ts
@@ -9,6 +9,9 @@ export interface WorkerRunMessage {
   invocationId: string;
   source: string;
   hostFunctionNamespaces: string[];
+  syncHostFunctionNamespaces: string[];
+  moduleLoader: boolean;
+  syncBridge: SharedArrayBuffer;
   determinism: RunDeterminismState;
   options: Pick<
     NormalizedRunOptions,

--- a/packages/run/src/runtime/protocol.ts
+++ b/packages/run/src/runtime/protocol.ts
@@ -11,7 +11,7 @@ export interface WorkerRunMessage {
   hostFunctionNamespaces: string[];
   syncHostFunctionNamespaces: string[];
   moduleLoader: boolean;
-  syncBridge: SharedArrayBuffer;
+  syncBridge: SharedArrayBuffer | undefined;
   determinism: RunDeterminismState;
   options: Pick<
     NormalizedRunOptions,
@@ -35,6 +35,7 @@ export interface WorkerHostFunctionRequest {
   type: 'host-function-request';
   invocationId: string;
   requestId: string;
+  requestIndex: number;
   hostFunctionName: string;
   inputJson: string;
 }

--- a/packages/run/src/runtime/sync-bridge-protocol.test.ts
+++ b/packages/run/src/runtime/sync-bridge-protocol.test.ts
@@ -17,12 +17,14 @@ describe('synchronous bridge protocol', () => {
       kind: SyncBridgeRequestKind.HostFunction,
       name: 'fs.readFile',
       payload: '["/value"]',
+      requestIndex: 3,
       sequence: 1,
     });
     expect(readSyncBridgeRequest(buffer)).toEqual({
       kind: SyncBridgeRequestKind.HostFunction,
       name: 'fs.readFile',
       payload: '["/value"]',
+      requestIndex: 3,
       sequence: 1,
     });
 
@@ -44,10 +46,11 @@ describe('synchronous bridge protocol', () => {
       kind: SyncBridgeRequestKind.HostFunction,
       name: 'values.read',
       payload: '[]',
+      requestIndex: 1,
       sequence: 1,
     });
     const { header } = getSyncBridgeViews(buffer);
-    Atomics.store(header, SyncBridgeHeader.ReservedOne, 1);
+    Atomics.store(header, SyncBridgeHeader.Reserved, 1);
     expect(() => readSyncBridgeRequest(buffer)).toThrow(
       'Invalid synchronous bridge request header',
     );
@@ -70,6 +73,7 @@ describe('synchronous bridge protocol', () => {
         kind: SyncBridgeRequestKind.HostFunction,
         name: 'values.read',
         payload: 'x'.repeat(bytes.byteLength),
+        requestIndex: 1,
         sequence: 1,
       }),
     ).toThrow('exceeds the synchronous bridge capacity');

--- a/packages/run/src/runtime/sync-bridge-protocol.test.ts
+++ b/packages/run/src/runtime/sync-bridge-protocol.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SyncBridgeHeader,
+  SyncBridgeRequestKind,
+  createSyncBridgeBuffer,
+  getSyncBridgeViews,
+  readSyncBridgeRequest,
+  readSyncBridgeResponse,
+  writeSyncBridgeRequest,
+  writeSyncBridgeResponse,
+} from './sync-bridge-protocol.js';
+
+describe('synchronous bridge protocol', () => {
+  it('round-trips bounded requests and responses', () => {
+    const buffer = createSyncBridgeBuffer(128, 128);
+    writeSyncBridgeRequest(buffer, {
+      kind: SyncBridgeRequestKind.HostFunction,
+      name: 'fs.readFile',
+      payload: '["/value"]',
+      sequence: 1,
+    });
+    expect(readSyncBridgeRequest(buffer)).toEqual({
+      kind: SyncBridgeRequestKind.HostFunction,
+      name: 'fs.readFile',
+      payload: '["/value"]',
+      sequence: 1,
+    });
+
+    writeSyncBridgeResponse(buffer, {
+      payload: '"contents"',
+      sequence: 1,
+      success: true,
+    });
+    expect(readSyncBridgeResponse(buffer, 1)).toEqual({
+      payload: '"contents"',
+      sequence: 1,
+      success: true,
+    });
+  });
+
+  it('rejects malformed headers and forged sequence numbers', () => {
+    const buffer = createSyncBridgeBuffer(128, 128);
+    writeSyncBridgeRequest(buffer, {
+      kind: SyncBridgeRequestKind.HostFunction,
+      name: 'values.read',
+      payload: '[]',
+      sequence: 1,
+    });
+    const { header } = getSyncBridgeViews(buffer);
+    Atomics.store(header, SyncBridgeHeader.ReservedOne, 1);
+    expect(() => readSyncBridgeRequest(buffer)).toThrow(
+      'Invalid synchronous bridge request header',
+    );
+
+    writeSyncBridgeResponse(buffer, {
+      payload: '1',
+      sequence: 2,
+      success: true,
+    });
+    expect(() => readSyncBridgeResponse(buffer, 1)).toThrow(
+      'Invalid synchronous bridge response header',
+    );
+  });
+
+  it('rejects oversized payloads before publishing them', () => {
+    const buffer = createSyncBridgeBuffer(1, 1);
+    const { bytes } = getSyncBridgeViews(buffer);
+    expect(() =>
+      writeSyncBridgeRequest(buffer, {
+        kind: SyncBridgeRequestKind.HostFunction,
+        name: 'values.read',
+        payload: 'x'.repeat(bytes.byteLength),
+        sequence: 1,
+      }),
+    ).toThrow('exceeds the synchronous bridge capacity');
+  });
+});

--- a/packages/run/src/runtime/sync-bridge-protocol.ts
+++ b/packages/run/src/runtime/sync-bridge-protocol.ts
@@ -1,0 +1,201 @@
+import { Buffer } from 'node:buffer';
+import type { SerializableError } from '../types.js';
+
+export const SYNC_BRIDGE_HEADER_INTS = 8;
+export const SYNC_BRIDGE_HEADER_BYTES =
+  SYNC_BRIDGE_HEADER_INTS * Int32Array.BYTES_PER_ELEMENT;
+
+export enum SyncBridgeState {
+  Idle = 0,
+  Request = 1,
+  Response = 2,
+  Closed = 3,
+}
+
+export enum SyncBridgeRequestKind {
+  HostFunction = 1,
+  ModuleNormalize = 2,
+  ModuleLoad = 3,
+}
+
+export enum SyncBridgeHeader {
+  State = 0,
+  Sequence = 1,
+  Kind = 2,
+  NameBytes = 3,
+  PayloadBytes = 4,
+  Success = 5,
+  ReservedOne = 6,
+  ReservedTwo = 7,
+}
+
+export interface SyncBridgeRequest {
+  sequence: number;
+  kind: SyncBridgeRequestKind;
+  name: string;
+  payload: string;
+}
+
+export type SyncBridgeResponse =
+  | { sequence: number; success: true; payload: string }
+  | {
+      sequence: number;
+      success: false;
+      error: SerializableError;
+    };
+
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+export const createSyncBridgeBuffer = (
+  maxInputBytes: number,
+  maxOutputBytes: number,
+): SharedArrayBuffer =>
+  new SharedArrayBuffer(
+    SYNC_BRIDGE_HEADER_BYTES +
+      Math.max(1024 + maxInputBytes, maxOutputBytes, 64 * 1024),
+  );
+
+export const getSyncBridgeViews = (buffer: SharedArrayBuffer) => ({
+  bytes: new Uint8Array(buffer, SYNC_BRIDGE_HEADER_BYTES),
+  header: new Int32Array(buffer, 0, SYNC_BRIDGE_HEADER_INTS),
+});
+
+const encodeUtf8 = (value: string): Uint8Array => Buffer.from(value, 'utf8');
+
+const assertWritableBytes = (
+  bytes: Uint8Array,
+  required: number,
+  label: string,
+): void => {
+  if (
+    !Number.isSafeInteger(required) ||
+    required < 0 ||
+    required > bytes.length
+  ) {
+    throw new RangeError(`${label} exceeds the synchronous bridge capacity.`);
+  }
+};
+
+export const writeSyncBridgeRequest = (
+  buffer: SharedArrayBuffer,
+  request: SyncBridgeRequest,
+): void => {
+  const { bytes, header } = getSyncBridgeViews(buffer);
+  const name = encodeUtf8(request.name);
+  const payload = encodeUtf8(request.payload);
+  assertWritableBytes(bytes, name.byteLength + payload.byteLength, 'Request');
+  bytes.set(name, 0);
+  bytes.set(payload, name.byteLength);
+  Atomics.store(header, SyncBridgeHeader.Sequence, request.sequence);
+  Atomics.store(header, SyncBridgeHeader.Kind, request.kind);
+  Atomics.store(header, SyncBridgeHeader.NameBytes, name.byteLength);
+  Atomics.store(header, SyncBridgeHeader.PayloadBytes, payload.byteLength);
+  Atomics.store(header, SyncBridgeHeader.Success, 0);
+  Atomics.store(header, SyncBridgeHeader.ReservedOne, 0);
+  Atomics.store(header, SyncBridgeHeader.ReservedTwo, 0);
+};
+
+export const readSyncBridgeRequest = (
+  buffer: SharedArrayBuffer,
+): SyncBridgeRequest => {
+  const { bytes, header } = getSyncBridgeViews(buffer);
+  const sequence = Atomics.load(header, SyncBridgeHeader.Sequence);
+  const kind = Atomics.load(header, SyncBridgeHeader.Kind);
+  const nameBytes = Atomics.load(header, SyncBridgeHeader.NameBytes);
+  const payloadBytes = Atomics.load(header, SyncBridgeHeader.PayloadBytes);
+  if (
+    !Number.isSafeInteger(sequence) ||
+    sequence <= 0 ||
+    (kind !== SyncBridgeRequestKind.HostFunction &&
+      kind !== SyncBridgeRequestKind.ModuleNormalize &&
+      kind !== SyncBridgeRequestKind.ModuleLoad) ||
+    nameBytes < 0 ||
+    payloadBytes < 0 ||
+    nameBytes + payloadBytes > bytes.length ||
+    Atomics.load(header, SyncBridgeHeader.Success) !== 0 ||
+    Atomics.load(header, SyncBridgeHeader.ReservedOne) !== 0 ||
+    Atomics.load(header, SyncBridgeHeader.ReservedTwo) !== 0
+  ) {
+    throw new TypeError('Invalid synchronous bridge request header.');
+  }
+  return {
+    kind: kind as SyncBridgeRequestKind,
+    name: decoder.decode(bytes.subarray(0, nameBytes)),
+    payload: decoder.decode(
+      bytes.subarray(nameBytes, nameBytes + payloadBytes),
+    ),
+    sequence,
+  };
+};
+
+export const writeSyncBridgeResponse = (
+  buffer: SharedArrayBuffer,
+  response: SyncBridgeResponse,
+): void => {
+  const { bytes, header } = getSyncBridgeViews(buffer);
+  const encoded = encodeUtf8(
+    response.success ? response.payload : JSON.stringify(response.error),
+  );
+  assertWritableBytes(bytes, encoded.byteLength, 'Response');
+  bytes.set(encoded, 0);
+  Atomics.store(header, SyncBridgeHeader.Sequence, response.sequence);
+  Atomics.store(header, SyncBridgeHeader.Kind, 0);
+  Atomics.store(header, SyncBridgeHeader.NameBytes, 0);
+  Atomics.store(header, SyncBridgeHeader.PayloadBytes, encoded.byteLength);
+  Atomics.store(header, SyncBridgeHeader.Success, response.success ? 1 : 0);
+  Atomics.store(header, SyncBridgeHeader.ReservedOne, 0);
+  Atomics.store(header, SyncBridgeHeader.ReservedTwo, 0);
+};
+
+export const readSyncBridgeResponse = (
+  buffer: SharedArrayBuffer,
+  expectedSequence: number,
+): SyncBridgeResponse => {
+  const { bytes, header } = getSyncBridgeViews(buffer);
+  const sequence = Atomics.load(header, SyncBridgeHeader.Sequence);
+  const payloadBytes = Atomics.load(header, SyncBridgeHeader.PayloadBytes);
+  const success = Atomics.load(header, SyncBridgeHeader.Success);
+  if (
+    sequence !== expectedSequence ||
+    Atomics.load(header, SyncBridgeHeader.Kind) !== 0 ||
+    Atomics.load(header, SyncBridgeHeader.NameBytes) !== 0 ||
+    payloadBytes <= 0 ||
+    payloadBytes > bytes.length ||
+    (success !== 0 && success !== 1) ||
+    Atomics.load(header, SyncBridgeHeader.ReservedOne) !== 0 ||
+    Atomics.load(header, SyncBridgeHeader.ReservedTwo) !== 0
+  ) {
+    throw new TypeError('Invalid synchronous bridge response header.');
+  }
+  const payload = decoder.decode(bytes.subarray(0, payloadBytes));
+  if (success === 1) {
+    return { payload, sequence, success: true };
+  }
+  const error = JSON.parse(payload) as SerializableError;
+  if (
+    typeof error !== 'object' ||
+    error === null ||
+    typeof error.name !== 'string' ||
+    typeof error.message !== 'string'
+  ) {
+    throw new TypeError('Invalid synchronous bridge error response.');
+  }
+  return { error, sequence, success: false };
+};
+
+export const waitAsyncForSyncBridgeChange = async (
+  header: Int32Array,
+  expectedState: SyncBridgeState,
+): Promise<void> => {
+  const { waitAsync } = Atomics as typeof Atomics & {
+    waitAsync(
+      array: Int32Array,
+      index: number,
+      value: number,
+    ): { async: boolean; value: string | Promise<string> };
+  };
+  const result = waitAsync(header, SyncBridgeHeader.State, expectedState);
+  if (result.async) {
+    await result.value;
+  }
+};

--- a/packages/run/src/runtime/sync-bridge-protocol.ts
+++ b/packages/run/src/runtime/sync-bridge-protocol.ts
@@ -4,6 +4,7 @@ import type { SerializableError } from '../types.js';
 export const SYNC_BRIDGE_HEADER_INTS = 8;
 export const SYNC_BRIDGE_HEADER_BYTES =
   SYNC_BRIDGE_HEADER_INTS * Int32Array.BYTES_PER_ELEMENT;
+export const MAX_SYNC_BRIDGE_BUFFER_BYTES = 64 * 1024 * 1024;
 
 export enum SyncBridgeState {
   Idle = 0,
@@ -25,12 +26,13 @@ export enum SyncBridgeHeader {
   NameBytes = 3,
   PayloadBytes = 4,
   Success = 5,
-  ReservedOne = 6,
-  ReservedTwo = 7,
+  RequestIndex = 6,
+  Reserved = 7,
 }
 
 export interface SyncBridgeRequest {
   sequence: number;
+  requestIndex: number;
   kind: SyncBridgeRequestKind;
   name: string;
   payload: string;
@@ -46,13 +48,19 @@ export type SyncBridgeResponse =
 
 const decoder = new TextDecoder('utf-8', { fatal: true });
 
+export const getSyncBridgeBufferBytes = (
+  maxInputBytes: number,
+  maxOutputBytes: number,
+): number =>
+  SYNC_BRIDGE_HEADER_BYTES +
+  Math.max(1024 + maxInputBytes, maxOutputBytes, 64 * 1024);
+
 export const createSyncBridgeBuffer = (
   maxInputBytes: number,
   maxOutputBytes: number,
 ): SharedArrayBuffer =>
   new SharedArrayBuffer(
-    SYNC_BRIDGE_HEADER_BYTES +
-      Math.max(1024 + maxInputBytes, maxOutputBytes, 64 * 1024),
+    getSyncBridgeBufferBytes(maxInputBytes, maxOutputBytes),
   );
 
 export const getSyncBridgeViews = (buffer: SharedArrayBuffer) => ({
@@ -91,8 +99,8 @@ export const writeSyncBridgeRequest = (
   Atomics.store(header, SyncBridgeHeader.NameBytes, name.byteLength);
   Atomics.store(header, SyncBridgeHeader.PayloadBytes, payload.byteLength);
   Atomics.store(header, SyncBridgeHeader.Success, 0);
-  Atomics.store(header, SyncBridgeHeader.ReservedOne, 0);
-  Atomics.store(header, SyncBridgeHeader.ReservedTwo, 0);
+  Atomics.store(header, SyncBridgeHeader.RequestIndex, request.requestIndex);
+  Atomics.store(header, SyncBridgeHeader.Reserved, 0);
 };
 
 export const readSyncBridgeRequest = (
@@ -103,6 +111,7 @@ export const readSyncBridgeRequest = (
   const kind = Atomics.load(header, SyncBridgeHeader.Kind);
   const nameBytes = Atomics.load(header, SyncBridgeHeader.NameBytes);
   const payloadBytes = Atomics.load(header, SyncBridgeHeader.PayloadBytes);
+  const requestIndex = Atomics.load(header, SyncBridgeHeader.RequestIndex);
   if (
     !Number.isSafeInteger(sequence) ||
     sequence <= 0 ||
@@ -111,10 +120,11 @@ export const readSyncBridgeRequest = (
       kind !== SyncBridgeRequestKind.ModuleLoad) ||
     nameBytes < 0 ||
     payloadBytes < 0 ||
+    !Number.isSafeInteger(requestIndex) ||
+    requestIndex <= 0 ||
     nameBytes + payloadBytes > bytes.length ||
     Atomics.load(header, SyncBridgeHeader.Success) !== 0 ||
-    Atomics.load(header, SyncBridgeHeader.ReservedOne) !== 0 ||
-    Atomics.load(header, SyncBridgeHeader.ReservedTwo) !== 0
+    Atomics.load(header, SyncBridgeHeader.Reserved) !== 0
   ) {
     throw new TypeError('Invalid synchronous bridge request header.');
   }
@@ -124,6 +134,7 @@ export const readSyncBridgeRequest = (
     payload: decoder.decode(
       bytes.subarray(nameBytes, nameBytes + payloadBytes),
     ),
+    requestIndex,
     sequence,
   };
 };
@@ -143,8 +154,8 @@ export const writeSyncBridgeResponse = (
   Atomics.store(header, SyncBridgeHeader.NameBytes, 0);
   Atomics.store(header, SyncBridgeHeader.PayloadBytes, encoded.byteLength);
   Atomics.store(header, SyncBridgeHeader.Success, response.success ? 1 : 0);
-  Atomics.store(header, SyncBridgeHeader.ReservedOne, 0);
-  Atomics.store(header, SyncBridgeHeader.ReservedTwo, 0);
+  Atomics.store(header, SyncBridgeHeader.RequestIndex, 0);
+  Atomics.store(header, SyncBridgeHeader.Reserved, 0);
 };
 
 export const readSyncBridgeResponse = (
@@ -162,8 +173,8 @@ export const readSyncBridgeResponse = (
     payloadBytes <= 0 ||
     payloadBytes > bytes.length ||
     (success !== 0 && success !== 1) ||
-    Atomics.load(header, SyncBridgeHeader.ReservedOne) !== 0 ||
-    Atomics.load(header, SyncBridgeHeader.ReservedTwo) !== 0
+    Atomics.load(header, SyncBridgeHeader.RequestIndex) !== 0 ||
+    Atomics.load(header, SyncBridgeHeader.Reserved) !== 0
   ) {
     throw new TypeError('Invalid synchronous bridge response header.');
   }

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -15,6 +15,7 @@ const createRunMessage = (
   },
   hostFunctionNamespaces: ['tools'],
   invocationId,
+  moduleLoader: false,
   options: {
     executionTimeoutMs: 950,
     maxConsoleOutputBytes: 64 * 1024,
@@ -25,6 +26,8 @@ const createRunMessage = (
     timeoutMs: 1000,
   },
   source,
+  syncBridge: new SharedArrayBuffer(1024),
+  syncHostFunctionNamespaces: [],
   type: 'run',
 });
 

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -4,6 +4,7 @@ import { parentPort } from 'node:worker_threads';
 import { EvalFlags, JSException, QuickJS } from 'quickjs-wasi';
 import type { Deferred, JSValueHandle } from 'quickjs-wasi';
 import {
+  deserializeError,
   RunProtocolError,
   RunTimeoutError,
   serializeError,
@@ -39,6 +40,7 @@ const pendingBridgeRequests = new Map<
   }
 >();
 let activeInvocationId: string | undefined;
+let aggregateBridgeRequestCounter = 0;
 let bridgeRequestCounter = 0;
 let bridgeIdleGeneration = 0;
 let syncBridgeRequestCounter = 0;
@@ -116,6 +118,7 @@ async function handleMainMessage(value: unknown): Promise<void> {
     }
 
     activeInvocationId = message.invocationId;
+    aggregateBridgeRequestCounter = 0;
     bridgeRequestCounter = 0;
     syncBridgeRequestCounter = 0;
     bridgeIdleGeneration += 1;
@@ -397,11 +400,16 @@ async function evaluateUserSource(
       modulePromise.dispose();
     }
     if ('error' in resolvedModule) {
+      const trustedCode = readTrustedErrorCode(
+        context,
+        getTrustedErrorCode,
+        resolvedModule.error,
+      );
       const error = dumpQuickJSErrorHandle(context, resolvedModule.error);
       if (!resolvedModule.error.disposed) {
         resolvedModule.error.dispose();
       }
-      throw toUserSourceError(error, message.source);
+      throw toUserSourceError(error, message.source, trustedCode);
     }
     if (!resolvedModule.value.disposed) {
       resolvedModule.value.dispose();
@@ -764,7 +772,7 @@ function requestSyncModuleNormalize(
     JSON.stringify([specifier, importer]),
   );
   if (!response.success) {
-    throw new Error(response.error.message);
+    throwModuleBridgeError(response.error);
   }
   const value = JSON.parse(response.payload) as unknown;
   if (typeof value !== 'string') {
@@ -784,7 +792,7 @@ function requestSyncModuleLoad(
     JSON.stringify([name]),
   );
   if (!response.success) {
-    throw new Error(response.error.message);
+    throwModuleBridgeError(response.error);
   }
   const value = JSON.parse(response.payload) as unknown;
   if (typeof value !== 'string') {
@@ -793,23 +801,50 @@ function requestSyncModuleLoad(
   return value;
 }
 
+function throwModuleBridgeError(
+  error: NonNullable<WorkerBridgeResponse['error']>,
+): never {
+  if (error.code !== undefined && error.code !== 'RUN_HOST_BRIDGE_ERROR') {
+    const trustedError = deserializeError(error);
+    trustedError.message = error.message;
+    activeCancellation?.fail(trustedError);
+  }
+  throw new Error(error.message);
+}
+
 function requestSyncHost(
   message: WorkerRunMessage,
   kind: SyncBridgeRequestKind,
   name: string,
   payload: string,
 ) {
-  const { header } = getSyncBridgeViews(message.syncBridge);
+  const { syncBridge } = message;
+  if (syncBridge === undefined) {
+    throw new RunProtocolError('Synchronous bridge is unavailable.');
+  }
+  if (Buffer.byteLength(name) > 1024) {
+    throw new Error('Synchronous bridge request name exceeds 1024 bytes.');
+  }
+  if (Buffer.byteLength(payload) > message.options.maxHostFunctionInputBytes) {
+    throw new Error(
+      `Synchronous bridge request arguments exceed the ${message.options.maxHostFunctionInputBytes} byte size limit.`,
+    );
+  }
+  const { header } = getSyncBridgeViews(syncBridge);
   if (Atomics.load(header, SyncBridgeHeader.State) !== SyncBridgeState.Idle) {
     throw new RunProtocolError('Synchronous bridge was not idle.');
   }
-  syncBridgeRequestCounter += 1;
-  writeSyncBridgeRequest(message.syncBridge, {
+  const sequence = syncBridgeRequestCounter + 1;
+  const requestIndex = aggregateBridgeRequestCounter + 1;
+  writeSyncBridgeRequest(syncBridge, {
     kind,
     name,
     payload,
-    sequence: syncBridgeRequestCounter,
+    requestIndex,
+    sequence,
   });
+  syncBridgeRequestCounter = sequence;
+  aggregateBridgeRequestCounter = requestIndex;
   Atomics.store(header, SyncBridgeHeader.State, SyncBridgeState.Request);
   Atomics.notify(header, SyncBridgeHeader.State);
   while (
@@ -822,10 +857,7 @@ function requestSyncHost(
   ) {
     throw new RunProtocolError('Synchronous bridge closed before responding.');
   }
-  const response = readSyncBridgeResponse(
-    message.syncBridge,
-    syncBridgeRequestCounter,
-  );
+  const response = readSyncBridgeResponse(syncBridge, syncBridgeRequestCounter);
   Atomics.store(header, SyncBridgeHeader.State, SyncBridgeState.Idle);
   Atomics.notify(header, SyncBridgeHeader.State);
   return response;
@@ -838,6 +870,7 @@ function requestHost(
   resetDateNow?: JSValueHandle,
   registerTrustedError?: JSValueHandle,
 ): JSValueHandle {
+  aggregateBridgeRequestCounter += 1;
   bridgeRequestCounter += 1;
   const requestId = `${invocationId}:bridge-${bridgeRequestCounter}`;
   const deferred = context.newPromise();
@@ -852,6 +885,7 @@ function requestHost(
   parentPort?.postMessage({
     invocationId,
     requestId,
+    requestIndex: aggregateBridgeRequestCounter,
     type: 'host-function-request',
     ...payload,
   });

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -1,7 +1,7 @@
 import { writeSync } from 'node:fs';
 import { formatWithOptions } from 'node:util';
 import { parentPort } from 'node:worker_threads';
-import { JSException, QuickJS } from 'quickjs-wasi';
+import { EvalFlags, JSException, QuickJS } from 'quickjs-wasi';
 import type { Deferred, JSValueHandle } from 'quickjs-wasi';
 import {
   RunProtocolError,
@@ -15,6 +15,14 @@ import { buildGuestRuntimeSetupSource, wrapUserCode } from './guest-sources.js';
 import { normalizeUserSourceStack } from './source-stack.js';
 import type { WorkerBridgeResponse, WorkerRunMessage } from './protocol.js';
 import { assertMainToWorkerMessage } from './protocol-validation.js';
+import {
+  SyncBridgeHeader,
+  SyncBridgeRequestKind,
+  SyncBridgeState,
+  getSyncBridgeViews,
+  readSyncBridgeResponse,
+  writeSyncBridgeRequest,
+} from './sync-bridge-protocol.js';
 
 if (!parentPort) {
   throw new Error('JavaScript runtime worker must run inside a worker thread');
@@ -33,6 +41,7 @@ const pendingBridgeRequests = new Map<
 let activeInvocationId: string | undefined;
 let bridgeRequestCounter = 0;
 let bridgeIdleGeneration = 0;
+let syncBridgeRequestCounter = 0;
 let embeddedQuickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
 let activeCancellation:
   | {
@@ -108,6 +117,7 @@ async function handleMainMessage(value: unknown): Promise<void> {
 
     activeInvocationId = message.invocationId;
     bridgeRequestCounter = 0;
+    syncBridgeRequestCounter = 0;
     bridgeIdleGeneration += 1;
     try {
       await run(message);
@@ -181,8 +191,22 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     },
     maxStackSizeBytes: message.options.maxStackSizeBytes,
     memoryLimitBytes: message.options.memoryLimitBytes,
+    ...(message.moduleLoader
+      ? {
+          moduleLoader: {
+            load: name => requestSyncModuleLoad(message, name),
+            normalize: (baseName, specifier) =>
+              requestSyncModuleNormalize(message, specifier, baseName),
+          },
+        }
+      : {}),
   });
-  let bridgeFunctions: { invokeHostFunction: JSValueHandle } | undefined;
+  let bridgeFunctions:
+    | {
+        invokeHostFunction: JSValueHandle;
+        invokeSyncHostFunction: JSValueHandle;
+      }
+    | undefined;
   let consoleFormatter: JSValueHandle | undefined;
   let determinismHandle: JSValueHandle | undefined;
   let getTrustedErrorCodeHandle: JSValueHandle | undefined;
@@ -236,6 +260,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       context,
       message,
       bridgeFunctions.invokeHostFunction,
+      bridgeFunctions.invokeSyncHostFunction,
       determinismHandle,
     );
     getTrustedErrorCodeHandle = guestRuntimeHandles.getTrustedErrorCode;
@@ -283,6 +308,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       pendingBridgeRequests.delete(requestId);
     }
     disposeHandle(bridgeFunctions?.invokeHostFunction);
+    disposeHandle(bridgeFunctions?.invokeSyncHostFunction);
     disposeHandle(consoleFormatter);
     disposeHandle(getTrustedErrorCodeHandle);
     disposeHandle(registerTrustedErrorHandle);
@@ -297,6 +323,7 @@ function initializeGuestRuntime(
   context: QuickJS,
   message: WorkerRunMessage,
   invokeHostFunction: JSValueHandle,
+  invokeSyncHostFunction: JSValueHandle,
   determinismHandle: JSValueHandle,
 ): {
   getTrustedErrorCode: JSValueHandle;
@@ -306,6 +333,7 @@ function initializeGuestRuntime(
 } {
   const setupSource = buildGuestRuntimeSetupSource(
     message.hostFunctionNamespaces,
+    message.syncHostFunctionNamespaces,
   );
   let setupFunction: JSValueHandle;
   try {
@@ -320,6 +348,7 @@ function initializeGuestRuntime(
         setupFunction,
         context.undefined,
         invokeHostFunction,
+        invokeSyncHostFunction,
         determinismHandle,
       );
     } catch (error) {
@@ -352,6 +381,37 @@ async function evaluateUserSource(
   serializeJsonPayload: JSValueHandle,
   getTrustedErrorCode: JSValueHandle,
 ): Promise<string> {
+  if (message.moduleLoader) {
+    let modulePromise: JSValueHandle;
+    try {
+      modulePromise = context.evalCode(
+        message.source,
+        '<entry>',
+        EvalFlags.TYPE_MODULE,
+      );
+    } catch (error) {
+      throw toUserSourceError(dumpQuickJSError(context, error), message.source);
+    }
+    const resolvedModule = await resolveQuickJSPromise(context, modulePromise);
+    if (!modulePromise.disposed) {
+      modulePromise.dispose();
+    }
+    if ('error' in resolvedModule) {
+      const error = dumpQuickJSErrorHandle(context, resolvedModule.error);
+      if (!resolvedModule.error.disposed) {
+        resolvedModule.error.dispose();
+      }
+      throw toUserSourceError(error, message.source);
+    }
+    if (!resolvedModule.value.disposed) {
+      resolvedModule.value.dispose();
+    }
+    return serializeQuickJSJsonPayload(
+      context,
+      serializeJsonPayload,
+      context.undefined,
+    );
+  }
   const wrapped = wrapUserCode(message.source);
   try {
     context.evalCode(wrapped, 'run.js').dispose();
@@ -417,6 +477,10 @@ async function createQuickJSContext(options: {
   interruptHandler: () => boolean;
   maxStackSizeBytes: number;
   memoryLimitBytes: number;
+  moduleLoader?: {
+    normalize: (baseName: string, specifier: string) => string;
+    load: (name: string) => string;
+  };
 }): Promise<QuickJS> {
   const embeddedWasmBase64 = getEmbeddedQuickJsWasmBase64();
   if (embeddedWasmBase64 === undefined) {
@@ -429,6 +493,7 @@ async function createQuickJSContext(options: {
       MAX_SAFE_WASI_STACK_LIMIT_BYTES,
     ),
     memoryLimit: options.memoryLimitBytes,
+    moduleLoader: options.moduleLoader,
     wasm: await getEmbeddedQuickJsWasmModule(embeddedWasmBase64),
   });
 }
@@ -623,7 +688,10 @@ function createBridgeFunctions(
   message: WorkerRunMessage,
   getResetDateNow: () => JSValueHandle | undefined,
   getRegisterTrustedError: () => JSValueHandle | undefined,
-): { invokeHostFunction: JSValueHandle } {
+): {
+  invokeHostFunction: JSValueHandle;
+  invokeSyncHostFunction: JSValueHandle;
+} {
   const invokeHostFunction = context.newFunction(
     '__runInvokeHostFunction',
     (hostFunctionNameHandle: JSValueHandle, inputJsonHandle: JSValueHandle) => {
@@ -652,7 +720,115 @@ function createBridgeFunctions(
     },
   );
 
-  return { invokeHostFunction };
+  const invokeSyncHostFunction = context.newFunction(
+    '__runInvokeSyncHostFunction',
+    (hostFunctionNameHandle: JSValueHandle, inputJsonHandle: JSValueHandle) => {
+      const hostFunctionName = hostFunctionNameHandle.toString();
+      const inputJson = inputJsonHandle.toString();
+      if (Buffer.byteLength(hostFunctionName) > 1024) {
+        throw new Error('Host function name exceeds 1024 bytes.');
+      }
+      if (
+        Buffer.byteLength(inputJson) > message.options.maxHostFunctionInputBytes
+      ) {
+        throw new Error(
+          `Host function arguments exceed the ${message.options.maxHostFunctionInputBytes} byte size limit.`,
+        );
+      }
+      const response = requestSyncHost(
+        message,
+        SyncBridgeRequestKind.HostFunction,
+        hostFunctionName,
+        inputJson,
+      );
+      return context.newString(
+        response.success
+          ? `\u0001${response.payload}`
+          : `\u0000${JSON.stringify(response.error)}`,
+      );
+    },
+  );
+
+  return { invokeHostFunction, invokeSyncHostFunction };
+}
+
+function requestSyncModuleNormalize(
+  message: WorkerRunMessage,
+  specifier: string,
+  importer: string,
+): string {
+  const response = requestSyncHost(
+    message,
+    SyncBridgeRequestKind.ModuleNormalize,
+    specifier,
+    JSON.stringify([specifier, importer]),
+  );
+  if (!response.success) {
+    throw new Error(response.error.message);
+  }
+  const value = JSON.parse(response.payload) as unknown;
+  if (typeof value !== 'string') {
+    throw new TypeError('Module loader normalize() must return a string.');
+  }
+  return value;
+}
+
+function requestSyncModuleLoad(
+  message: WorkerRunMessage,
+  name: string,
+): string {
+  const response = requestSyncHost(
+    message,
+    SyncBridgeRequestKind.ModuleLoad,
+    name,
+    JSON.stringify([name]),
+  );
+  if (!response.success) {
+    throw new Error(response.error.message);
+  }
+  const value = JSON.parse(response.payload) as unknown;
+  if (typeof value !== 'string') {
+    throw new TypeError('Module loader load() must return source text.');
+  }
+  return value;
+}
+
+function requestSyncHost(
+  message: WorkerRunMessage,
+  kind: SyncBridgeRequestKind,
+  name: string,
+  payload: string,
+) {
+  const { header } = getSyncBridgeViews(message.syncBridge);
+  if (Atomics.load(header, SyncBridgeHeader.State) !== SyncBridgeState.Idle) {
+    throw new RunProtocolError('Synchronous bridge was not idle.');
+  }
+  syncBridgeRequestCounter += 1;
+  writeSyncBridgeRequest(message.syncBridge, {
+    kind,
+    name,
+    payload,
+    sequence: syncBridgeRequestCounter,
+  });
+  Atomics.store(header, SyncBridgeHeader.State, SyncBridgeState.Request);
+  Atomics.notify(header, SyncBridgeHeader.State);
+  while (
+    Atomics.load(header, SyncBridgeHeader.State) === SyncBridgeState.Request
+  ) {
+    Atomics.wait(header, SyncBridgeHeader.State, SyncBridgeState.Request);
+  }
+  if (
+    Atomics.load(header, SyncBridgeHeader.State) !== SyncBridgeState.Response
+  ) {
+    throw new RunProtocolError('Synchronous bridge closed before responding.');
+  }
+  const response = readSyncBridgeResponse(
+    message.syncBridge,
+    syncBridgeRequestCounter,
+  );
+  Atomics.store(header, SyncBridgeHeader.State, SyncBridgeState.Idle);
+  Atomics.notify(header, SyncBridgeHeader.State);
+  return response;
 }
 
 function requestHost(

--- a/packages/run/src/sync-host-functions.test.ts
+++ b/packages/run/src/sync-host-functions.test.ts
@@ -1,5 +1,4 @@
-import { setTimeout as delay } from 'node:timers/promises';
-import { once } from 'node:events';
+import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import {
   RunBridgeLimitError,
@@ -7,6 +6,20 @@ import {
   createRunner,
   getHostFunctionContext,
 } from './index.js';
+import { createPromiseWithResolvers } from './utils/promise-with-resolvers.js';
+import { toJsonPayload } from './utils/serialization.js';
+
+const waitForAbort = (abortSignal: AbortSignal): Promise<null> => {
+  const aborted = createPromiseWithResolvers<null>();
+  if (abortSignal.aborted) {
+    aborted.resolve(null);
+  } else {
+    abortSignal.addEventListener('abort', () => aborted.resolve(null), {
+      once: true,
+    });
+  }
+  return aborted.promise;
+};
 
 describe('synchronous host functions', () => {
   it('returns serializable values synchronously and throws synchronously', async () => {
@@ -29,7 +42,10 @@ describe('synchronous host functions', () => {
     ).resolves.toEqual({ status: 'completed', value: 'ok' });
     await expect(
       runner.run({ source: 'values.fail(); return "unreachable";' }),
-    ).rejects.toThrow('Host function failed.');
+    ).rejects.toMatchObject({
+      code: 'RUN_HOST_FUNCTION_ERROR',
+      message: 'Host function failed.',
+    });
   });
 
   it('provides live read-after-write semantics', async () => {
@@ -67,17 +83,125 @@ describe('synchronous host functions', () => {
     ).rejects.toBeInstanceOf(RunBridgeLimitError);
   });
 
+  it('preserves aggregate request order across async and sync transports', async () => {
+    const observed: string[] = [];
+    const runner = createRunner({
+      syncHostFunctions: {
+        syncValues: {
+          read() {
+            observed.push(`sync:${getHostFunctionContext().requestIndex}`);
+            return 'sync';
+          },
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        hostFunctions: {
+          asyncValues: {
+            read() {
+              observed.push(`async:${getHostFunctionContext().requestIndex}`);
+              return 'async';
+            },
+          },
+        },
+        source: `
+          const pending = asyncValues.read();
+          const observed = pending.then(value => value);
+          await Promise.resolve();
+          const immediate = syncValues.read();
+          return [await observed, immediate];
+        `,
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: ['async', 'sync'],
+    });
+    expect(observed).toEqual(['async:1', 'sync:2']);
+  });
+
+  it('does not execute a later sync request beyond the aggregate limit', async () => {
+    let sideEffect = false;
+    const runner = createRunner({
+      limits: { maxBridgeRequests: 1 },
+      syncHostFunctions: {
+        effects: { write: () => (sideEffect = true) },
+      },
+    });
+
+    await expect(
+      runner.run({
+        hostFunctions: { values: { read: () => 1 } },
+        source: `
+          const pending = values.read();
+          const observed = pending.then(value => value);
+          await Promise.resolve();
+          try { effects.write(); } catch {}
+          return await observed;
+        `,
+      }),
+    ).rejects.toBeInstanceOf(RunBridgeLimitError);
+    expect(sideEffect).toBe(false);
+  });
+
+  it('terminates when a synchronous binding attempts to interrupt', async () => {
+    let continued = false;
+    const runner = createRunner({
+      syncHostFunctions: {
+        gate: {
+          check: () => getHostFunctionContext().interrupt('approval'),
+          continued: () => (continued = true),
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        source: `
+          try { gate.check(); } catch {}
+          gate.continued();
+        `,
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_PROTOCOL_ERROR' });
+    expect(continued).toBe(false);
+  });
+
+  it('rejects bridge allocations outside invocation and hard memory bounds', async () => {
+    await expect(
+      createRunner({
+        limits: {
+          maxHostFunctionOutputBytes: 2 * 1024 * 1024,
+          memoryLimitBytes: 1024 * 1024,
+        },
+        syncHostFunctions: { values: { read: () => 1 } },
+      }).run({ source: 'return values.read();' }),
+    ).rejects.toBeInstanceOf(RunBridgeLimitError);
+
+    await expect(
+      createRunner({
+        limits: {
+          maxHostFunctionOutputBytes: 128 * 1024 * 1024,
+          memoryLimitBytes: 256 * 1024 * 1024,
+        },
+        syncHostFunctions: { values: { read: () => 1 } },
+      }).run({ source: 'return values.read();' }),
+    ).rejects.toBeInstanceOf(RunBridgeLimitError);
+  });
+
   it('aborts the host context and tears down a blocked worker on timeout', async () => {
     let lateSideEffect = false;
-    let observedAbort = false;
+    const started = createPromiseWithResolvers<null>();
+    const observedAbort = createPromiseWithResolvers<null>();
     const runner = createRunner({
-      limits: { timeoutMs: 200 },
+      limits: { timeoutMs: 1000 },
       syncHostFunctions: {
         operations: {
           async blocked() {
             const { abortSignal } = getHostFunctionContext();
-            await once(abortSignal, 'abort');
-            observedAbort = true;
+            started.resolve(null);
+            await waitForAbort(abortSignal);
+            observedAbort.resolve(null);
             if (!abortSignal.aborted) {
               lateSideEffect = true;
             }
@@ -86,11 +210,13 @@ describe('synchronous host functions', () => {
       },
     });
 
-    await expect(
-      runner.run({ source: 'operations.blocked(); return 1;' }),
-    ).rejects.toBeInstanceOf(RunTimeoutError);
-    await delay(20);
-    expect(observedAbort).toBe(true);
+    await runner.run({ source: 'return 0;' });
+    const execution = runner.run({
+      source: 'operations.blocked(); return 1;',
+    });
+    await started.promise;
+    await expect(execution).rejects.toBeInstanceOf(RunTimeoutError);
+    await observedAbort.promise;
     expect(lateSideEffect).toBe(false);
   });
 
@@ -107,6 +233,165 @@ describe('synchronous host functions', () => {
       status: 'completed',
       value: ['undefined', 'undefined', 1],
     });
+  });
+
+  it('binds synchronous capabilities into continuation scope', async () => {
+    const secret = 's'.repeat(32);
+    const source = 'return await tools.pause();';
+    const firstRunner = createRunner({
+      continuationSecret: secret,
+      syncHostFunctions: { safe: { read: () => 1 } },
+    });
+    const interrupted = await firstRunner.run({
+      hostFunctions: {
+        tools: {
+          pause: () => getHostFunctionContext().interrupt('pause'),
+        },
+      },
+      source,
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected the run to be interrupted.');
+    }
+
+    const changedRunner = createRunner({
+      continuationSecret: secret,
+      syncHostFunctions: { privileged: { write: () => {} } },
+    });
+    await expect(
+      changedRunner.run({
+        continuation: interrupted.continuation,
+        hostFunctions: { tools: { pause: () => {} } },
+        resolutions: [
+          { interruptionId: interrupted.interruptions[0]?.id ?? '', value: 1 },
+        ],
+        source,
+      }),
+    ).rejects.toThrow(/scope|binding|continuation/iu);
+  });
+
+  it('preserves the legacy continuation scope without sync bindings', async () => {
+    const source = 'return await tools.pause();';
+    let actualScopeHash: string | undefined;
+    const runner = createRunner({
+      continuationCodec: {
+        decode: () => {
+          throw new Error('decode is unused');
+        },
+        encode(state) {
+          actualScopeHash = state.scopeHash;
+          return 'legacy-compatible-token';
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        hostFunctions: {
+          tools: {
+            pause: () => getHostFunctionContext().interrupt('pause'),
+          },
+        },
+        source,
+      }),
+    ).resolves.toMatchObject({
+      continuation: 'legacy-compatible-token',
+      status: 'interrupted',
+    });
+
+    const legacyScope = toJsonPayload(
+      {
+        audience: 'run',
+        bindingManifest: ['tools.pause'],
+        continuationContext: undefined,
+        transformedSourceHash: createHash('sha256')
+          .update(source)
+          .digest('hex'),
+      },
+      Number.MAX_SAFE_INTEGER,
+      'Continuation scope',
+    );
+    expect(actualScopeHash).toBe(
+      createHash('sha256').update(legacyScope).digest('hex'),
+    );
+  });
+
+  it('rejects synchronous side effects during continuation replay', async () => {
+    const secret = 'r'.repeat(32);
+    let sideEffect = false;
+    const createReplayRunner = () =>
+      createRunner({
+        continuationSecret: secret,
+        syncHostFunctions: {
+          effects: {
+            write() {
+              sideEffect = true;
+            },
+          },
+        },
+      });
+    const source = `
+      const shouldWrite = await tools.pause();
+      if (shouldWrite) effects.write();
+      return 'done';
+    `;
+    const pause = () => {
+      const context = getHostFunctionContext();
+      if (context.resume !== undefined) {
+        return context.resume.resolution;
+      }
+      return context.interrupt('pause');
+    };
+    const interrupted = await createReplayRunner().run({
+      hostFunctions: {
+        tools: {
+          pause,
+        },
+      },
+      source,
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected the run to be interrupted.');
+    }
+
+    await expect(
+      createReplayRunner().run({
+        continuation: interrupted.continuation,
+        hostFunctions: { tools: { pause } },
+        resolutions: [
+          {
+            interruptionId: interrupted.interruptions[0]?.id ?? '',
+            value: true,
+          },
+        ],
+        source,
+      }),
+    ).rejects.toThrow('forbidden during continuation replay');
+    expect(sideEffect).toBe(false);
+  });
+
+  it('never mints a continuation after a racing synchronous call', async () => {
+    let sideEffects = 0;
+    const runner = createRunner({
+      continuationSecret: 'q'.repeat(32),
+      limits: { timeoutMs: 3000 },
+      syncHostFunctions: {
+        effects: { write: () => (sideEffects += 1) },
+      },
+    });
+
+    await expect(
+      runner.run({
+        hostFunctions: {
+          tools: {
+            pause: () => getHostFunctionContext().interrupt('pause'),
+          },
+        },
+        source:
+          'const pending = tools.pause(); effects.write(); await pending;',
+      }),
+    ).rejects.toThrow(/continuation|synchronous bridge/iu);
+    expect(sideEffects).toBeLessThanOrEqual(1);
   });
 });
 
@@ -188,23 +473,187 @@ describe('native module loading', () => {
     ).rejects.toThrow('cannot create a continuation');
   });
 
-  it('aborts a blocked module loader on timeout', async () => {
-    let observedAbort = false;
-    const runner = createRunner({ limits: { timeoutMs: 200 } });
+  it('redacts module loader errors from guest code', async () => {
+    const seen: string[] = [];
+    const runner = createRunner({
+      syncHostFunctions: {
+        report: { error: (message: string) => seen.push(message) },
+      },
+    });
 
     await expect(
       runner.run({
         moduleLoader: {
-          async load() {
-            const { abortSignal } = getHostFunctionContext();
-            await once(abortSignal, 'abort');
-            observedAbort = true;
-            return 'export const value = 1;';
+          load() {
+            const error = new Error('ENOENT: /private/tenant/secret.ts');
+            Object.assign(error, { code: 'ENOENT' });
+            throw error;
           },
         },
-        source: "import './blocked.js';",
+        source: `
+          try {
+            await import('/private/tenant/secret.ts');
+          } catch (error) {
+            report.error(error.message);
+          }
+        `,
       }),
-    ).rejects.toBeInstanceOf(RunTimeoutError);
-    expect(observedAbort).toBe(true);
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(seen).toEqual(['Host bridge request failed.']);
+  });
+
+  it('rejects a non-string result from a configured normalizer', async () => {
+    let loaded = false;
+    const runner = createRunner({
+      syncHostFunctions: { report: { value: () => {} } },
+    });
+
+    await expect(
+      runner.run({
+        moduleLoader: {
+          load() {
+            loaded = true;
+            return 'export {};';
+          },
+          normalize: () => undefined as never,
+        },
+        source: `
+          try { await import('/forbidden.js'); } catch {}
+          report.value();
+        `,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(loaded).toBe(false);
+  });
+
+  it('preserves trusted synchronous binding errors in module runs', async () => {
+    const runner = createRunner({
+      syncHostFunctions: {
+        values: {
+          fail() {
+            throw new Error('private failure');
+          },
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        moduleLoader: { load: () => 'export {};' },
+        source: 'values.fail();',
+      }),
+    ).rejects.toMatchObject({
+      code: 'RUN_HOST_FUNCTION_ERROR',
+      details: undefined,
+      message: 'Host function failed.',
+    });
+  });
+
+  it('rejects oversized module requests without desynchronizing the bridge', async () => {
+    const seen: string[] = [];
+    const runner = createRunner({
+      limits: { maxHostFunctionArgumentsBytes: 64 },
+      syncHostFunctions: {
+        report: { value: (value: string) => seen.push(value) },
+      },
+    });
+
+    await expect(
+      runner.run({
+        moduleLoader: {
+          load: specifier =>
+            specifier === '/ok.js'
+              ? "export const value = 'ok';"
+              : 'export {};',
+        },
+        source: `
+          try { await import('x'.repeat(70_000)); } catch {}
+          const loaded = await import('/ok.js');
+          report.value(loaded.value);
+        `,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(seen).toEqual(['ok']);
+  });
+
+  it('preserves side-effectful imports whose bindings are unused', async () => {
+    const seen: string[] = [];
+    const runner = createRunner({
+      syncHostFunctions: {
+        report: { value: (value: string) => seen.push(value) },
+      },
+    });
+
+    await expect(
+      runner.run({
+        moduleLoader: {
+          load: specifier => {
+            if (specifier === '/side.ts') {
+              return "report.value('side'); export const unused: number = 1;";
+            }
+            throw new Error('not found');
+          },
+        },
+        source: "import { unused } from '/side.ts';",
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(seen).toEqual(['side']);
+  });
+
+  it('bounds encoded and transformed module source', async () => {
+    const escapedSource = `export const value = ${JSON.stringify('\\'.repeat(48))};`;
+    const encodedRunner = createRunner({
+      limits: {
+        maxHostFunctionOutputBytes: 128,
+        maxSourceBytes: 512,
+      },
+    });
+    await expect(
+      encodedRunner.run({
+        moduleLoader: { load: () => escapedSource },
+        source: "import './escaped.js';",
+      }),
+    ).rejects.toThrow(
+      'moduleLoader.load output exceeds the 128 byte size limit.',
+    );
+
+    const sourceRunner = createRunner({
+      limits: {
+        maxHostFunctionOutputBytes: 1024,
+        maxSourceBytes: 128,
+      },
+    });
+    await expect(
+      sourceRunner.run({
+        moduleLoader: { load: () => `/*${'x'.repeat(256)}*/ export {};` },
+        source: "import './large.js';",
+      }),
+    ).rejects.toMatchObject({
+      code: 'RUN_SOURCE_TOO_LARGE',
+      message: expect.stringMatching(/source.*128 byte size limit/iu),
+    });
+  });
+
+  it('aborts a blocked module loader on timeout', async () => {
+    const started = createPromiseWithResolvers<null>();
+    const observedAbort = createPromiseWithResolvers<null>();
+    const runner = createRunner({ limits: { timeoutMs: 1000 } });
+
+    await runner.run({ source: 'return 0;' });
+    const execution = runner.run({
+      moduleLoader: {
+        async load() {
+          const { abortSignal } = getHostFunctionContext();
+          started.resolve(null);
+          await waitForAbort(abortSignal);
+          observedAbort.resolve(null);
+          return 'export const value = 1;';
+        },
+      },
+      source: "import './blocked.js';",
+    });
+    await started.promise;
+    await expect(execution).rejects.toBeInstanceOf(RunTimeoutError);
+    await observedAbort.promise;
   });
 });

--- a/packages/run/src/sync-host-functions.test.ts
+++ b/packages/run/src/sync-host-functions.test.ts
@@ -1,0 +1,210 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { once } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import {
+  RunBridgeLimitError,
+  RunTimeoutError,
+  createRunner,
+  getHostFunctionContext,
+} from './index.js';
+
+describe('synchronous host functions', () => {
+  it('returns serializable values synchronously and throws synchronously', async () => {
+    const runner = createRunner({
+      syncHostFunctions: {
+        values: {
+          fail() {
+            throw new Error('private failure');
+          },
+          async read(value: string) {
+            await Promise.resolve();
+            return { value };
+          },
+        },
+      },
+    });
+
+    await expect(
+      runner.run({ source: 'return values.read("ok").value;' }),
+    ).resolves.toEqual({ status: 'completed', value: 'ok' });
+    await expect(
+      runner.run({ source: 'values.fail(); return "unreachable";' }),
+    ).rejects.toThrow('Host function failed.');
+  });
+
+  it('provides live read-after-write semantics', async () => {
+    const files = new Map<string, string>();
+    const runner = createRunner({
+      syncHostFunctions: {
+        fs: {
+          readFile(path: string) {
+            return files.get(path);
+          },
+          writeFile(path: string, value: string) {
+            files.set(path, value);
+          },
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        source: 'fs.writeFile("/value", "new"); return fs.readFile("/value");',
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 'new' });
+  });
+
+  it('shares the aggregate bridge request limit with async calls', async () => {
+    const runner = createRunner({
+      limits: { maxBridgeRequests: 2 },
+      syncHostFunctions: { values: { read: () => 1 } },
+    });
+
+    await expect(
+      runner.run({
+        source: 'values.read(); values.read(); values.read(); return 1;',
+      }),
+    ).rejects.toBeInstanceOf(RunBridgeLimitError);
+  });
+
+  it('aborts the host context and tears down a blocked worker on timeout', async () => {
+    let lateSideEffect = false;
+    let observedAbort = false;
+    const runner = createRunner({
+      limits: { timeoutMs: 200 },
+      syncHostFunctions: {
+        operations: {
+          async blocked() {
+            const { abortSignal } = getHostFunctionContext();
+            await once(abortSignal, 'abort');
+            observedAbort = true;
+            if (!abortSignal.aborted) {
+              lateSideEffect = true;
+            }
+          },
+        },
+      },
+    });
+
+    await expect(
+      runner.run({ source: 'operations.blocked(); return 1;' }),
+    ).rejects.toBeInstanceOf(RunTimeoutError);
+    await delay(20);
+    expect(observedAbort).toBe(true);
+    expect(lateSideEffect).toBe(false);
+  });
+
+  it('does not expose the bridge SharedArrayBuffer to guest code', async () => {
+    const runner = createRunner({
+      syncHostFunctions: { values: { read: () => 1 } },
+    });
+    await expect(
+      runner.run({
+        source:
+          'return [typeof SharedArrayBuffer, typeof Atomics, values.read()];',
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: ['undefined', 'undefined', 1],
+    });
+  });
+});
+
+describe('native module loading', () => {
+  it('loads static, aliased, cyclic, and dynamic ESM', async () => {
+    const seen: string[] = [];
+    const modules = new Map<string, string>([
+      [
+        '/a.js',
+        "import { b } from './b.js'; export function getA(){ return 'a'; } export const a = getA() + b;",
+      ],
+      [
+        '/b.js',
+        "import { getA } from './a.js'; export const b = 'b'; export const cycle = () => getA();",
+      ],
+      ['/dynamic.js', "export const value = 'dynamic';"],
+      ['/typed.ts', 'export const typed: number = 42;'],
+    ]);
+    const runner = createRunner({
+      syncHostFunctions: {
+        report: { value: (value: string) => seen.push(value) },
+      },
+    });
+
+    await expect(
+      runner.run({
+        moduleLoader: {
+          identity: 'test-loader',
+          load(specifier) {
+            const source = modules.get(specifier);
+            if (source === undefined) {
+              throw new Error('not found');
+            }
+            return source;
+          },
+          normalize(specifier, importer) {
+            if (specifier === 'alias') {
+              return '/a.js';
+            }
+            if (specifier.startsWith('/')) {
+              return specifier;
+            }
+            const base = importer.includes('/')
+              ? importer.slice(0, importer.lastIndexOf('/'))
+              : '';
+            const parts = `${base}/${specifier}`.split('/');
+            const normalized: string[] = [];
+            for (const part of parts) {
+              if (part === '..') {
+                normalized.pop();
+              } else if (part && part !== '.') {
+                normalized.push(part);
+              }
+            }
+            return `/${normalized.join('/')}`;
+          },
+        },
+        source:
+          "import { a } from 'alias'; import { typed } from './typed.ts'; const dynamic = await import('./dynamic.js'); report.value(a + ':' + dynamic.value + ':' + typed);",
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(seen).toEqual(['ab:dynamic:42']);
+  });
+
+  it('does not allow module-backed runs to create continuations', async () => {
+    const runner = createRunner({ continuationSecret: 'x'.repeat(32) });
+    await expect(
+      runner.run({
+        hostFunctions: {
+          tools: {
+            pause() {
+              getHostFunctionContext().interrupt('pause');
+            },
+          },
+        },
+        moduleLoader: { load: () => 'export {};' },
+        source: 'await tools.pause();',
+      }),
+    ).rejects.toThrow('cannot create a continuation');
+  });
+
+  it('aborts a blocked module loader on timeout', async () => {
+    let observedAbort = false;
+    const runner = createRunner({ limits: { timeoutMs: 200 } });
+
+    await expect(
+      runner.run({
+        moduleLoader: {
+          async load() {
+            const { abortSignal } = getHostFunctionContext();
+            await once(abortSignal, 'abort');
+            observedAbort = true;
+            return 'export const value = 1;';
+          },
+        },
+        source: "import './blocked.js';",
+      }),
+    ).rejects.toBeInstanceOf(RunTimeoutError);
+    expect(observedAbort).toBe(true);
+  });
+});

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -102,12 +102,17 @@ export interface RunnerOptions<TOKEN = string> {
 /** Input accepted by `run` and `Runner.run`. */
 export interface RunInput<TOKEN = unknown> {
   /**
-   * JavaScript or type-stripped TypeScript function-body source.
+   * JavaScript or type-stripped TypeScript function-body source. Runtime type
+   * stripping is used when provided natively by Node or Bun, or through the
+   * optional TypeScript peer dependency on Node 20.
    * Top-level `await` and `return` are supported.
    */
   source: string;
   hostFunctions?: HostFunctions;
-  /** Optional native ES module loader. Its presence evaluates source as ESM. */
+  /**
+   * Optional native ES module loader. Its presence evaluates source as ESM;
+   * entry-module evaluation completes with an undefined run value.
+   */
   moduleLoader?: RunModuleLoader;
   abortSignal?: AbortSignal;
   limits?: RunLimits;

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -45,6 +45,19 @@ export type HostFunctionGroup = Record<string, HostFunction<never[], unknown>>;
  */
 export type HostFunctions = Record<string, HostFunctionGroup>;
 
+/** Host functions exposed to guest JavaScript with synchronous call semantics. */
+export type SyncHostFunctions = HostFunctions;
+
+/** Native ES module resolver used by QuickJS. */
+export interface RunModuleLoader {
+  /** Stable identity used for diagnostics and future continuation scoping. */
+  identity?: string;
+  /** Resolve a raw specifier relative to its importing module. */
+  normalize?(specifier: string, importer: string): string | Promise<string>;
+  /** Return source code for a normalized module specifier. */
+  load(specifier: string): string | Promise<string>;
+}
+
 /** @internal */
 export type HostFunctionManifest = ReadonlyMap<string, ReadonlySet<string>>;
 
@@ -77,6 +90,8 @@ export interface RunLimits {
 /** Shared defaults used by a runner. */
 export interface RunnerOptions<TOKEN = string> {
   limits?: RunLimits;
+  /** Host functions exposed with synchronous guest call semantics. */
+  syncHostFunctions?: SyncHostFunctions;
   /** HMAC key used for signed continuations. Cannot be combined with continuationCodec. */
   continuationSecret?: string | Uint8Array;
   continuationCodec?: ContinuationCodec<TOKEN>;
@@ -92,6 +107,8 @@ export interface RunInput<TOKEN = unknown> {
    */
   source: string;
   hostFunctions?: HostFunctions;
+  /** Optional native ES module loader. Its presence evaluates source as ESM. */
+  moduleLoader?: RunModuleLoader;
   abortSignal?: AbortSignal;
   limits?: RunLimits;
   continuation?: TOKEN;
@@ -228,6 +245,8 @@ export interface Runner<TOKEN = unknown> {
 export interface InternalRunInput extends RunInput<unknown> {
   hostFunctions: HostFunctions;
   hostFunctionManifest: HostFunctionManifest;
+  syncHostFunctions: SyncHostFunctions;
+  syncHostFunctionManifest: HostFunctionManifest;
   limits: RunLimits;
   continuationCodec: ContinuationCodec;
   continuationAudience: string;

--- a/packages/run/src/utils/promise-with-resolvers.ts
+++ b/packages/run/src/utils/promise-with-resolvers.ts
@@ -4,9 +4,17 @@ interface PromiseWithResolvers<T> {
   resolve: (value: T | PromiseLike<T>) => void;
 }
 
-interface PromiseConstructorWithResolvers extends PromiseConstructor {
-  withResolvers<T>(): PromiseWithResolvers<T>;
-}
-
-export const createPromiseWithResolvers = <T>(): PromiseWithResolvers<T> =>
-  (Promise as PromiseConstructorWithResolvers).withResolvers<T>();
+export const createPromiseWithResolvers = <T>(): PromiseWithResolvers<T> => {
+  let resolveDeferred!: PromiseWithResolvers<T>['resolve'];
+  let rejectDeferred!: PromiseWithResolvers<T>['reject'];
+  // eslint-disable-next-line promise/avoid-new -- Node.js 20 lacks Promise.withResolvers.
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveDeferred = resolve;
+    rejectDeferred = reject;
+  });
+  return {
+    promise,
+    reject: rejectDeferred,
+    resolve: resolveDeferred,
+  };
+};

--- a/packages/run/src/utils/source-cache.test.ts
+++ b/packages/run/src/utils/source-cache.test.ts
@@ -31,6 +31,18 @@ describe('source limits and transform cache', () => {
     expect(transformed.split('\n')).toHaveLength(source.split('\n').length);
   });
 
+  it('strips TypeScript syntax from ES module source', () => {
+    const source = 'export const value: number = 42;';
+    const transformed = transformSource(source, true);
+    expect(transformed).not.toContain(': number');
+    expect(transformed).toContain('export const value');
+  });
+
+  it('falls back when the host transformer rejects deeply nested source', () => {
+    const source = `${'('.repeat(1000)}1${')'.repeat(1000)}`;
+    expect(() => transformSource(source, true)).not.toThrow();
+  });
+
   it('does not extract Bun transforms that inject external helpers', () => {
     if ((globalThis as { Bun?: unknown }).Bun === undefined) {
       return;

--- a/packages/run/src/utils/source-cache.ts
+++ b/packages/run/src/utils/source-cache.ts
@@ -107,23 +107,40 @@ const stripSnippetTypes = (source: string, moduleMode: boolean): string => {
   }
 
   if (bunTypeScriptTranspiler === undefined) {
-    typeScriptRuntime ??= require('typescript') as typeof ts;
+    try {
+      typeScriptRuntime ??= require('typescript') as typeof ts;
+    } catch {
+      // TypeScript is an optional Node 20 fallback. Without it, QuickJS reports
+      // unsupported syntax using guest coordinates rather than exposing a host
+      // module-resolution failure.
+      return source;
+    }
     const wrapperDeclaration = 'async function __runUser__()';
     const input = moduleMode ? source : `${wrapperDeclaration}{\n${source}\n}`;
-    const transformed = typeScriptRuntime.transpileModule(input, {
-      compilerOptions: {
-        module: typeScriptRuntime.ModuleKind.ESNext,
-        target: typeScriptRuntime.ScriptTarget.ES2023,
-      },
-    }).outputText;
-    if (moduleMode) {
-      return transformed;
+    try {
+      const transformed = typeScriptRuntime.transpileModule(input, {
+        compilerOptions: {
+          isolatedModules: true,
+          module: typeScriptRuntime.ModuleKind.ESNext,
+          target: typeScriptRuntime.ScriptTarget.ES2023,
+          verbatimModuleSyntax: true,
+        },
+      }).outputText;
+      if (moduleMode) {
+        return transformed;
+      }
+      return (
+        extractTransformedFunctionBody(transformed, wrapperDeclaration) ??
+        source
+      );
+    } catch {
+      return source;
     }
-    return (
-      extractTransformedFunctionBody(transformed, wrapperDeclaration) ?? source
-    );
   }
   try {
+    if (moduleMode) {
+      return bunTypeScriptTranspiler.transformSync(source);
+    }
     const wrapperDeclaration = 'async function __runUser__()';
     const transformed = bunTypeScriptTranspiler.transformSync(
       `${wrapperDeclaration}{\n${source}\n}`,

--- a/packages/run/src/utils/source-cache.ts
+++ b/packages/run/src/utils/source-cache.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import * as nodeModule from 'node:module';
 import { RunSourceTooLargeError } from '../errors.js';
+import type ts from 'typescript';
 
 const MAX_CACHE_ENTRIES = 256;
 const MAX_CACHE_BYTES = 4 * 1024 * 1024;
@@ -19,6 +20,8 @@ const bunTypeScriptTranspiler =
   bunRuntime === undefined
     ? undefined
     : new bunRuntime.Transpiler({ loader: 'ts' });
+const require = nodeModule.createRequire(import.meta.url);
+let typeScriptRuntime: typeof ts | undefined;
 const transformedSourceCache = new Map<
   string,
   {
@@ -45,11 +48,47 @@ const evictTransformedSourceCache = (): void => {
   }
 };
 
-const stripSnippetTypes = (source: string): string => {
+const extractTransformedFunctionBody = (
+  transformed: string,
+  wrapperDeclaration: string,
+): string | undefined => {
+  const declarationStart = transformed.indexOf(wrapperDeclaration);
+  if (
+    declarationStart === -1 ||
+    transformed.slice(0, declarationStart).trim() !== ''
+  ) {
+    return undefined;
+  }
+  const bodyStart = transformed.indexOf(
+    '{',
+    declarationStart + wrapperDeclaration.length,
+  );
+  const bodyEnd = transformed.lastIndexOf('}');
+  if (
+    bodyStart === -1 ||
+    bodyEnd <= bodyStart ||
+    transformed.slice(bodyEnd + 1).trim() !== ''
+  ) {
+    return undefined;
+  }
+  return transformed
+    .slice(bodyStart + 1, bodyEnd)
+    .replace(/^\n/u, '')
+    .replace(/\n$/u, '');
+};
+
+const stripSnippetTypes = (source: string, moduleMode: boolean): string => {
   const { stripTypeScriptTypes } = nodeModule as typeof nodeModule & {
     stripTypeScriptTypes?: (source: string) => string;
   };
   if (stripTypeScriptTypes !== undefined) {
+    if (moduleMode) {
+      try {
+        return stripTypeScriptTypes(source);
+      } catch {
+        return source;
+      }
+    }
     const prefix = 'async function __runUser__(){\n';
     const suffix = '\n}';
     let stripped: string;
@@ -68,36 +107,30 @@ const stripSnippetTypes = (source: string): string => {
   }
 
   if (bunTypeScriptTranspiler === undefined) {
-    return source;
+    typeScriptRuntime ??= require('typescript') as typeof ts;
+    const wrapperDeclaration = 'async function __runUser__()';
+    const input = moduleMode ? source : `${wrapperDeclaration}{\n${source}\n}`;
+    const transformed = typeScriptRuntime.transpileModule(input, {
+      compilerOptions: {
+        module: typeScriptRuntime.ModuleKind.ESNext,
+        target: typeScriptRuntime.ScriptTarget.ES2023,
+      },
+    }).outputText;
+    if (moduleMode) {
+      return transformed;
+    }
+    return (
+      extractTransformedFunctionBody(transformed, wrapperDeclaration) ?? source
+    );
   }
   try {
     const wrapperDeclaration = 'async function __runUser__()';
     const transformed = bunTypeScriptTranspiler.transformSync(
       `${wrapperDeclaration}{\n${source}\n}`,
     );
-    const declarationStart = transformed.indexOf(wrapperDeclaration);
-    if (
-      declarationStart === -1 ||
-      transformed.slice(0, declarationStart).trim() !== ''
-    ) {
-      return source;
-    }
-    const bodyStart = transformed.indexOf(
-      '{',
-      declarationStart + wrapperDeclaration.length,
+    return (
+      extractTransformedFunctionBody(transformed, wrapperDeclaration) ?? source
     );
-    const bodyEnd = transformed.lastIndexOf('}');
-    if (
-      bodyStart === -1 ||
-      bodyEnd <= bodyStart ||
-      transformed.slice(bodyEnd + 1).trim() !== ''
-    ) {
-      return source;
-    }
-    return transformed
-      .slice(bodyStart + 1, bodyEnd)
-      .replace(/^\n/u, '')
-      .replace(/\n$/u, '');
   } catch {
     return source;
   }
@@ -113,9 +146,9 @@ export const assertSourceSize = (
   }
 };
 
-export const transformSource = (source: string): string => {
+export const transformSource = (source: string, moduleMode = false): string => {
   const hash = createHash('sha256')
-    .update('strip:')
+    .update(moduleMode ? 'strip-module:' : 'strip:')
     .update(source)
     .digest('hex');
   const cached = transformedSourceCache.get(hash);
@@ -125,7 +158,7 @@ export const transformSource = (source: string): string => {
     return cached.source;
   }
 
-  const transformed = stripSnippetTypes(source);
+  const transformed = stripSnippetTypes(source, moduleMode);
   const transformedBytes = byteLength(transformed);
   if (transformedBytes <= MAX_CACHE_ENTRY_BYTES) {
     transformedSourceCache.set(hash, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,10 +32,6 @@ importers:
         version: 22.19.19
 
   packages/run:
-    dependencies:
-      typescript:
-        specifier: 5.8.3
-        version: 5.8.3
     devDependencies:
       '@types/node':
         specifier: 22.19.19
@@ -61,6 +57,9 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.5)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
       ultracite:
         specifier: 7.3.2
         version: 7.3.2(oxlint@1.56.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,10 @@ importers:
         version: 22.19.19
 
   packages/run:
+    dependencies:
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
     devDependencies:
       '@types/node':
         specifier: 22.19.19
@@ -57,9 +61,6 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.5)(typescript@5.8.3)(yaml@2.9.0)
-      typescript:
-        specifier: 5.8.3
-        version: 5.8.3
       ultracite:
         specifier: 7.3.2
         version: 7.3.2(oxlint@1.56.0)


### PR DESCRIPTION
## Summary

- add a separate syncHostFunctions API with immediate guest return and throw semantics
- add a bounded per-invocation SharedArrayBuffer bridge using Atomics wait/waitAsync
- add native static, cyclic, aliased, dynamic, and TypeScript ES module loading
- preserve existing asynchronous host functions and continuation behavior

## Safety

- validate bridge state, sequence numbers, payload sizes, names, and aggregate request counts
- propagate cancellation through HostFunctionContext and tear down uncertain workers
- keep SharedArrayBuffer and Atomics inaccessible to guest JavaScript
- prohibit continuations after synchronous bridge use or module loading

## Compatibility

- support Node.js 20.19+ with a TypeScript transform fallback
- document the new APIs and add Node 20 and Node 22 CI coverage
- include a minor changeset and update package verification for the new runtime artifact

## Testing

- add synchronous return, throw, read-after-write, cancellation, isolation, flooding, and protocol hardening coverage
- add static, cyclic, aliased, dynamic, and TypeScript module coverage
- verify 273 tests plus formatting, typechecking, Node 20 smoke tests, and npm/pnpm package installation