### PR TITLE
feat: replay sync and module operations in continuations

### DIFF
--- a/.changeset/warm-ledgers-replay.md
+++ b/.changeset/warm-ledgers-replay.md
@@ -1,0 +1,5 @@
+---
+'run': minor
+---
+
+Generalize continuation replay ledgers to record synchronous host functions and native module-loader operations, allowing runs that use either capability to create and resume continuations without repeating recorded side effects.

--- a/.changeset/warm-ledgers-replay.md
+++ b/.changeset/warm-ledgers-replay.md
@@ -1,5 +1,5 @@
 ---
-'run': minor
+'run': patch
 ---
 
 Generalize continuation replay ledgers to record synchronous host functions and native module-loader operations, allowing runs that use either capability to create and resume continuations without repeating recorded side effects.

--- a/content/docs/advanced/continuations.mdx
+++ b/content/docs/advanced/continuations.mdx
@@ -125,9 +125,10 @@ if (resumed.status === 'completed') {
 }
 ```
 
-The original source, asynchronous and synchronous host function names, audience,
-and continuation context must match when the run resumes. A mismatch rejects
-the continuation before the interrupted host function is invoked.
+The original source, asynchronous and synchronous host function names, module
+loader identity, audience, and continuation context must match when the run
+resumes. A mismatch rejects the continuation before the interrupted host
+function is invoked.
 
 Host function implementations are not compared. Deployments must preserve
 compatible behavior for interrupted host functions while old continuations
@@ -137,10 +138,15 @@ Several host functions can interrupt during the same invocation. The result
 contains the full batch, and the host must resolve every interruption in that
 batch together. Replay may later reach another batch of interruptions.
 
-Continuations are limited to asynchronous host functions. A run cannot mint a
-continuation after it has used a synchronous binding, and replay rejects a
-synchronous bridge request before dispatching it. Module-backed runs cannot
-create or resume continuations.
+The continuation ledger records asynchronous calls, synchronous calls, and
+module normalization and loading in their aggregate request order. Replay uses
+recorded synchronous and module outcomes without invoking those integrations
+again. Calls reached for the first time after the recorded frontier dispatch
+normally and are added to a later continuation if the run interrupts again.
+
+A module loader needs a non-empty, stable `identity` to create or resume a
+continuation. Change the identity whenever its resolution rules, module graph,
+or configuration changes incompatibly.
 
 ## Signing
 

--- a/content/docs/foundations/host-functions.mdx
+++ b/content/docs/foundations/host-functions.mdx
@@ -131,10 +131,11 @@ bindings or runs that use a module loader. Its allocation is included in memory
 admission and capped at 64 MiB. `SharedArrayBuffer` and `Atomics` remain
 unavailable to guest code.
 
-A run cannot create a continuation after using a synchronous binding, and
-synchronous calls are forbidden during continuation replay. The synchronous
-binding-name manifest is part of continuation scope, so changing it invalidates
-an existing continuation before replay.
+Synchronous outcomes are recorded in the continuation ledger. Replay returns a
+recorded value or throws the recorded error without invoking the binding again;
+calls first reached after the recorded frontier dispatch normally. The
+synchronous binding-name manifest is part of continuation scope, so changing it
+invalidates an existing continuation before replay.
 
 ## Context
 

--- a/content/docs/foundations/modules.mdx
+++ b/content/docs/foundations/modules.mdx
@@ -99,6 +99,11 @@ callback returns a promise. The worker waits while the host callback runs. Pass
 `getHostFunctionContext().abortSignal` to filesystem, network, or other
 cancellable work so timeouts and caller cancellation can stop it.
 
-Module-backed runs cannot create or resume continuations. Do not combine
-`moduleLoader` with `continuation`; an interruption reached during module
-evaluation fails instead of minting a continuation.
+Module-backed runs can create and resume continuations when `moduleLoader`
+provides a non-empty, stable `identity`. Normalize and load outcomes are stored
+in the continuation ledger and replayed without calling the loader again. Calls
+reached after the recorded frontier use the configured loader normally.
+
+The loader identity is authenticated as part of continuation scope. Change it
+whenever resolution rules, module contents, or other loader configuration
+changes incompatibly; a mismatched identity rejects replay before evaluation.

--- a/content/docs/reference/run.mdx
+++ b/content/docs/reference/run.mdx
@@ -89,7 +89,7 @@ import { run } from 'run';
     "name": "moduleLoader",
     "type": "RunModuleLoader",
     "isOptional": true,
-    "description": "A host-controlled native ES module loader. Its presence evaluates source as a module; completed module-backed runs have value undefined and cannot create or resume continuations.",
+    "description": "A host-controlled native ES module loader. Its presence evaluates source as a module; completed module-backed runs have value undefined. A non-empty stable identity is required to create or resume continuations.",
     "properties": [
       {
         "type": "RunModuleLoader",
@@ -98,7 +98,7 @@ import { run } from 'run';
             "name": "identity",
             "type": "string",
             "isOptional": true,
-            "description": "A stable loader identity, limited to 512 bytes."
+            "description": "A stable loader identity authenticated by continuations, limited to 512 bytes and required to create or resume one."
           },
           {
             "name": "normalize",

--- a/content/docs/reference/types.mdx
+++ b/content/docs/reference/types.mdx
@@ -405,7 +405,7 @@ import type {
             "name": "identity",
             "type": "string",
             "isOptional": true,
-            "description": "A stable loader identity, limited to 512 bytes."
+            "description": "A stable loader identity authenticated by continuations, limited to 512 bytes and required to create or resume one."
           },
           {
             "name": "normalize",

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -152,9 +152,9 @@ await runner.run({
 
 `normalize` and `load` may be synchronous or asynchronous. Their results are
 bounded by the host-function bridge limits, and `SharedArrayBuffer` and
-`Atomics` remain unavailable to guest JavaScript. Module-backed runs cannot
-create or resume continuations. Loader failures are redacted before entering the
-sandbox.
+`Atomics` remain unavailable to guest JavaScript. Module-backed runs can create
+and resume continuations when the loader has a non-empty stable `identity`.
+Loader failures are redacted before entering the sandbox.
 
 Entry modules execute for their side effects and a completed module-backed run
 has `value: undefined`; the module namespace is not serialized as the run
@@ -347,14 +347,16 @@ verifying old tokens.
 ### Replay behavior
 
 A continuation contains a replay ledger. On resume, completed and rejected
-host functions are read from that ledger instead of being invoked again. The
-runtime replays the program and reinvokes only interrupted host functions that
-now have a resolution.
+asynchronous host functions, synchronous host functions, and module-loader
+operations are read from that ledger instead of being invoked again. The
+runtime reinvokes only interrupted host functions that now have a resolution;
+operations first reached after the recorded frontier dispatch normally.
 
-Replay verifies the source, host-function-name manifest, and complete
-serialized argument list for every host function call. Guest `Date`,
-`Date.now()`, and `Math.random()` remain deterministic across replay.
-Divergence is rejected before a mismatched host function executes.
+Replay verifies the source, asynchronous and synchronous host-function-name
+manifests, module-loader identity, and complete serialized argument list for
+every bridge call. Guest `Date`, `Date.now()`, and `Math.random()` remain
+deterministic across replay. Divergence is rejected before a mismatched
+integration executes.
 
 An interrupted host function itself is reinvoked. Call `interrupt()` before
 doing non-idempotent work. For writes that may be retried, use
@@ -400,10 +402,10 @@ array.
 
 ### Scope and authorization
 
-Signed continuations are bound to the runner audience, transformed source,
-host-function-name manifest, and `continuationContext`. For tenant-, user-, or
-policy-scoped execution, provide authenticated context on both the initial run
-and every resume:
+Signed continuations are bound to the runner audience, source, asynchronous and
+synchronous host-function-name manifests, module-loader identity, and
+`continuationContext`. For tenant-, user-, or policy-scoped execution, provide
+authenticated context on both the initial run and every resume:
 
 ```ts
 await runner.run({

--- a/packages/run/src/continuation-validation-hardening.test.ts
+++ b/packages/run/src/continuation-validation-hardening.test.ts
@@ -63,6 +63,62 @@ const expectInvalid = (value: unknown): void => {
 };
 
 describe('continuation state validation hardening', () => {
+  it('validates mixed synchronous, module, and asynchronous ledger entries', () => {
+    const state = validState();
+    state.ledger = [
+      {
+        bindingName: 'effects.write',
+        bridgeKind: 'sync-host',
+        inputJson: '[[1],"value"]',
+        status: 'fulfilled',
+        valueJson: '[1]',
+      },
+      {
+        bindingName: 'moduleLoader.normalize',
+        bridgeKind: 'module-normalize',
+        inputJson: '["./value.js","<entry>"]',
+        status: 'fulfilled',
+        valueJson: '"/value.js"',
+      },
+      {
+        bindingName: 'moduleLoader.load',
+        bridgeKind: 'module-load',
+        inputJson: '["/value.js"]',
+        status: 'fulfilled',
+        valueJson: '"export const value = 1;"',
+      },
+      {
+        bindingName: 'tools.pause',
+        inputJson: '[[]]',
+        interruptionId: 'interrupt-4',
+        payloadJson: '["pause"]',
+        status: 'interrupted',
+      },
+    ];
+    expect(() =>
+      assertContinuationState(state, source, scopeHash, normalizeOptions()),
+    ).not.toThrow();
+
+    const malformed = structuredClone(state) as unknown as {
+      ledger: Record<string, unknown>[];
+    };
+    requireEntry(malformed.ledger, 1).inputJson = '["missing-importer"]';
+    expectInvalid(malformed);
+
+    const oversized = structuredClone(state) as unknown as {
+      ledger: Record<string, unknown>[];
+    };
+    requireEntry(oversized.ledger, 2).valueJson = JSON.stringify(
+      'x'.repeat(33),
+    );
+    expect(() =>
+      assertContinuationState(oversized, source, scopeHash, {
+        ...normalizeOptions(),
+        maxSourceBytes: 32,
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'RUN_PROTOCOL_ERROR' }));
+  });
+
   it('accepts only the exact versioned state shape', () => {
     expect(() =>
       assertContinuationState(

--- a/packages/run/src/continuation-validation.ts
+++ b/packages/run/src/continuation-validation.ts
@@ -82,12 +82,16 @@ const assertSerializedPayload = (
   }
 };
 
-type FulfilledLedgerEntry = Extract<RunLedgerEntry, { status: 'fulfilled' }>;
-type RejectedLedgerEntry = Extract<RunLedgerEntry, { status: 'rejected' }>;
+type FulfilledLedgerEntry = Extract<RunLedgerEntry, { settledOrder: number }>;
+type RejectedLedgerEntry = Extract<
+  RunLedgerEntry,
+  { settledOrder: number; status: 'rejected' }
+>;
 type InterruptedLedgerEntry = Extract<
   RunLedgerEntry,
   { status: 'interrupted' }
 >;
+type SynchronousLedgerEntry = Extract<RunLedgerEntry, { bridgeKind: string }>;
 
 type AssertFulfilledEntry = (
   value: Record<string, unknown>,
@@ -194,6 +198,146 @@ const assertInterruptedEntry: AssertInterruptedEntry = (
   );
 };
 
+const assertPlainJsonPayload = (
+  value: string,
+  maxBytes: number,
+  index: number,
+): unknown => {
+  const bytes = Buffer.byteLength(value);
+  if (bytes > maxBytes) {
+    throw new RunProtocolError('Continuation ledger payload is too large.', {
+      bytes,
+      index,
+      maxBytes,
+    });
+  }
+  try {
+    return parseJson(value);
+  } catch {
+    throw new RunProtocolError('Continuation module payload is invalid JSON.', {
+      index,
+    });
+  }
+};
+
+type AssertSynchronousEntry = (
+  value: Record<string, unknown>,
+  index: number,
+  options: NormalizedRunOptions,
+) => asserts value is SynchronousLedgerEntry;
+
+const assertSynchronousEntry: AssertSynchronousEntry = (
+  value,
+  index,
+  options,
+) => {
+  if (
+    !['sync-host', 'module-normalize', 'module-load'].includes(
+      String(value.bridgeKind),
+    ) ||
+    !['fulfilled', 'rejected'].includes(String(value.status)) ||
+    (value.status === 'fulfilled'
+      ? !hasExactKeys(value, [
+          'bindingName',
+          'bridgeKind',
+          'inputJson',
+          'status',
+          'valueJson',
+        ]) || typeof value.valueJson !== 'string'
+      : !hasExactKeys(value, [
+          'bindingName',
+          'bridgeKind',
+          'error',
+          'inputJson',
+          'status',
+        ]) || !isSerializableError(value.error))
+  ) {
+    throw new RunProtocolError('Synchronous continuation entry is malformed.', {
+      index,
+    });
+  }
+
+  if (value.bridgeKind === 'sync-host') {
+    assertSerializedPayload(
+      value.inputJson as string,
+      options.maxHostFunctionInputBytes,
+      index,
+    );
+    if (
+      !Array.isArray(
+        parseJsonPayload(
+          value.inputJson as string,
+          'Continuation ledger arguments',
+        ),
+      )
+    ) {
+      throw new RunProtocolError(
+        'Continuation ledger arguments must be encoded as an array.',
+        { index },
+      );
+    }
+    if (value.status === 'fulfilled') {
+      assertSerializedPayload(
+        value.valueJson as string,
+        options.maxHostFunctionOutputBytes,
+        index,
+      );
+    }
+  } else {
+    const input = assertPlainJsonPayload(
+      value.inputJson as string,
+      options.maxHostFunctionInputBytes,
+      index,
+    );
+    const expectedLength = value.bridgeKind === 'module-normalize' ? 2 : 1;
+    if (
+      !Array.isArray(input) ||
+      input.length !== expectedLength ||
+      input.some(argument => typeof argument !== 'string')
+    ) {
+      throw new RunProtocolError(
+        'Continuation module arguments are malformed.',
+        { index },
+      );
+    }
+    if (value.status === 'fulfilled') {
+      const output = assertPlainJsonPayload(
+        value.valueJson as string,
+        options.maxHostFunctionOutputBytes,
+        index,
+      );
+      if (typeof output !== 'string') {
+        throw new RunProtocolError(
+          'Continuation module result must be a string.',
+          { index },
+        );
+      }
+      if (
+        value.bridgeKind === 'module-load' &&
+        Buffer.byteLength(output) > options.maxSourceBytes
+      ) {
+        throw new RunProtocolError('Continuation module source is too large.', {
+          bytes: Buffer.byteLength(output),
+          index,
+          maxBytes: options.maxSourceBytes,
+        });
+      }
+    }
+  }
+
+  if (value.status === 'rejected') {
+    assertJsonValue(value.error);
+    const errorBytes = Buffer.byteLength(JSON.stringify(value.error));
+    if (errorBytes > options.maxHostFunctionOutputBytes) {
+      throw new RunProtocolError('Continuation error payload is too large.', {
+        bytes: errorBytes,
+        index,
+        maxBytes: options.maxHostFunctionOutputBytes,
+      });
+    }
+  }
+};
+
 type AssertLedgerEntry = (
   value: unknown,
   index: number,
@@ -212,6 +356,10 @@ const assertLedgerEntry: AssertLedgerEntry = (value, index, options) => {
     throw new RunProtocolError('Continuation ledger entry is malformed.', {
       index,
     });
+  }
+  if ('bridgeKind' in value) {
+    assertSynchronousEntry(value, index, options);
+    return;
   }
   assertSerializedPayload(
     value.inputJson,
@@ -299,7 +447,13 @@ const validateLedger = (
     assertLedgerEntry(entry, index, options);
     totalBytes += Buffer.byteLength(entry.bindingName);
     totalBytes += Buffer.byteLength(entry.inputJson);
-    if (entry.status === 'fulfilled') {
+    if ('bridgeKind' in entry) {
+      totalBytes += Buffer.byteLength(
+        entry.status === 'fulfilled'
+          ? entry.valueJson
+          : JSON.stringify(entry.error),
+      );
+    } else if (entry.status === 'fulfilled') {
       addSettledOrder(settledOrders, entry.settledOrder);
       totalBytes += Buffer.byteLength(entry.valueJson);
     } else if (entry.status === 'rejected') {

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -242,6 +242,9 @@ export const createRunner = <TOKEN = string>(
         ...input,
         continuationAudience,
         continuationCodec,
+        continuationEnabled:
+          options.continuationCodec !== undefined ||
+          configuredSecret !== undefined,
         hostFunctionManifest,
         hostFunctions,
         limits: {

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -230,10 +230,12 @@ export const createRunner = <TOKEN = string>(
       }
       if (
         input.moduleLoader !== undefined &&
-        input.continuation !== undefined
+        input.continuation !== undefined &&
+        (input.moduleLoader.identity === undefined ||
+          input.moduleLoader.identity.length === 0)
       ) {
         throw new TypeError(
-          'Continuations cannot be resumed with a module loader configured.',
+          'A module loader must have a non-empty identity to resume a continuation.',
         );
       }
       const value = await runManaged({

--- a/packages/run/src/runtime/manager-protocol.test.ts
+++ b/packages/run/src/runtime/manager-protocol.test.ts
@@ -200,7 +200,12 @@ describe('manager protocol state machine', () => {
     {
       message: /bridge-idle count mismatch/u,
       messages: (invocationId: string) => [
-        { invocationId, requestCount: 1, type: 'bridge-idle' },
+        {
+          invocationId,
+          requestCount: 1,
+          responseCount: 0,
+          type: 'bridge-idle',
+        },
       ],
       name: 'wrong idle count',
     },
@@ -292,6 +297,7 @@ describe('manager protocol state machine', () => {
             emit('message', {
               invocationId: message.invocationId,
               requestCount: 1,
+              responseCount: 0,
               type: 'bridge-idle',
             });
           });

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -465,6 +465,7 @@ function startWorkerRun({
   abortSignal,
   resolutions,
   continuationCodec,
+  continuationEnabled,
   continuationState,
   normalizedOptions,
   timeoutErrorMs,
@@ -523,6 +524,8 @@ function startWorkerRun({
   let interruptedResultPending: RunInterruptedResult | undefined;
   let workerReady = false;
   let workerIdleRequestCount = 0;
+  let workerIdleResponseCount = 0;
+  let bridgeResponsesSent = 0;
   const seenWorkerRequestIds = new Set<string>();
   const arrivedBridgeRequestIndexes = new Set<number>();
   const bridgeRequestTurnWaiters = new Map<
@@ -813,13 +816,18 @@ function startWorkerRun({
     }
 
     if (message.type === 'bridge-idle') {
-      if (message.requestCount !== asyncBridgeRequests) {
+      if (
+        message.requestCount > totalBridgeRequests ||
+        message.responseCount > bridgeResponsesSent
+      ) {
         failTerminal(
           new RunProtocolError(
-            `Worker bridge-idle count mismatch: expected ${asyncBridgeRequests}, received ${message.requestCount}.`,
+            `Worker bridge-idle count mismatch: expected ${totalBridgeRequests} requests and ${bridgeResponsesSent} responses, received ${message.requestCount} requests and ${message.responseCount} responses.`,
             {
-              expectedRequestCount: asyncBridgeRequests,
+              expectedRequestCount: totalBridgeRequests,
+              expectedResponseCount: bridgeResponsesSent,
               receivedRequestCount: message.requestCount,
+              receivedResponseCount: message.responseCount,
             },
           ),
         );
@@ -828,6 +836,10 @@ function startWorkerRun({
       workerIdleRequestCount = Math.max(
         workerIdleRequestCount,
         message.requestCount,
+      );
+      workerIdleResponseCount = Math.max(
+        workerIdleResponseCount,
+        message.responseCount,
       );
       settleInterruptionsIfQuiescent();
       return;
@@ -1198,18 +1210,21 @@ function startWorkerRun({
               request.sequence,
               request.requestIndex,
             );
-            recordSyncBridgeResponse(entryIndex, request, response);
+            assertSyncBridgeResponseSize(response);
+            if (continuationEnabled || continuationState !== undefined) {
+              recordSyncBridgeResponse(entryIndex, request, response);
+            }
           } else {
             response = replaySyncBridgeResponse(request, replayEntry);
           }
         } finally {
           syncBridgeOperationInFlight = false;
-          settleInterruptionsIfQuiescent();
         }
         if (terminalReached) {
           return;
         }
         writeSyncBridgeResponse(bridge, response);
+        bridgeResponsesSent += 1;
         Atomics.store(
           bridgeHeader,
           SyncBridgeHeader.State,
@@ -1277,6 +1292,16 @@ function startWorkerRun({
           }
         : { ...common, error: response.error, status: 'rejected' },
     );
+  }
+
+  function assertSyncBridgeResponseSize(response: SyncBridgeResponse): void {
+    if (!response.success) {
+      assertJsonPayloadSize(
+        JSON.stringify(response.error),
+        normalizedOptions.maxHostFunctionOutputBytes,
+        'Synchronous host bridge error',
+      );
+    }
   }
 
   async function dispatchSyncBridgeRequest(
@@ -1442,7 +1467,8 @@ function startWorkerRun({
       pendingInterruptionIndexes.size > 0 &&
       inFlightBridgeRequests === 0 &&
       !syncBridgeOperationInFlight &&
-      workerIdleRequestCount >= asyncBridgeRequests
+      workerIdleRequestCount === totalBridgeRequests &&
+      workerIdleResponseCount === bridgeResponsesSent
     ) {
       runInBackground(settleInterruptions());
     }
@@ -1550,6 +1576,7 @@ function startWorkerRun({
       return;
     }
     try {
+      bridgeResponsesSent += 1;
       // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
       worker.postMessage(message);
     } catch (error) {

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -75,6 +75,7 @@ import {
   waitAsyncForSyncBridgeChange,
   writeSyncBridgeResponse,
 } from './sync-bridge-protocol.js';
+import type { SyncBridgeResponse } from './sync-bridge-protocol.js';
 
 interface PooledWorker {
   worker: Worker;
@@ -93,6 +94,25 @@ const getSyncBridgeHostFunctionName = (
   }
   return 'moduleLoader.load';
 };
+
+const getSyncBridgeLedgerKind = (
+  kind: SyncBridgeRequestKind,
+): 'sync-host' | 'module-normalize' | 'module-load' => {
+  if (kind === SyncBridgeRequestKind.HostFunction) {
+    return 'sync-host';
+  }
+  if (kind === SyncBridgeRequestKind.ModuleNormalize) {
+    return 'module-normalize';
+  }
+  return 'module-load';
+};
+
+type AsyncLedgerEntry = Exclude<RunLedgerEntry, { bridgeKind: string }>;
+
+const getLedgerSettlementOrder = (entry: RunLedgerEntry): number =>
+  'bridgeKind' in entry || entry.status === 'interrupted'
+    ? 0
+    : entry.settledOrder;
 
 interface ManagedWorkerRun {
   result: Promise<RunResult>;
@@ -520,9 +540,10 @@ function startWorkerRun({
   let nextSettlementOrder = 0;
   for (const entry of ledger) {
     ledgerBytes += ledgerEntryBytes(entry);
-    if (entry.status !== 'interrupted') {
-      nextSettlementOrder = Math.max(nextSettlementOrder, entry.settledOrder);
-    }
+    nextSettlementOrder = Math.max(
+      nextSettlementOrder,
+      getLedgerSettlementOrder(entry),
+    );
   }
   let nextResponseOrder = 1;
   const queuedBridgeResponses = new Map<number, WorkerBridgeResponse>();
@@ -812,9 +833,8 @@ function startWorkerRun({
       return;
     }
 
-    const bridgeIndex = markWorkerRequest(message);
-    if (bridgeIndex !== undefined) {
-      runInBackground(handleHostFunctionRequest(message, bridgeIndex));
+    if (markWorkerRequest(message)) {
+      runInBackground(handleHostFunctionRequest(message));
     }
   });
 
@@ -886,11 +906,9 @@ function startWorkerRun({
 
   return { result };
 
-  function markWorkerRequest(
-    message: WorkerHostFunctionRequest,
-  ): { bridgeIndex: number } | undefined {
+  function markWorkerRequest(message: WorkerHostFunctionRequest): boolean {
     if (terminalReached) {
-      return undefined;
+      return false;
     }
     const expectedRequestId = `${invocationId}:bridge-${asyncBridgeRequests + 1}`;
     if (message.requestId !== expectedRequestId) {
@@ -900,7 +918,7 @@ function startWorkerRun({
           { expectedRequestId, invocationId, requestId: message.requestId },
         ),
       );
-      return undefined;
+      return false;
     }
     if (seenWorkerRequestIds.has(message.requestId)) {
       failTerminal(
@@ -909,21 +927,19 @@ function startWorkerRun({
           { invocationId, requestId: message.requestId },
         ),
       );
-      return undefined;
+      return false;
     }
     seenWorkerRequestIds.add(message.requestId);
 
     asyncBridgeRequests += 1;
-    return { bridgeIndex: asyncBridgeRequests };
+    return true;
   }
 
   async function handleHostFunctionRequest(
     message: WorkerHostFunctionRequest,
-    indexes: { bridgeIndex: number },
   ): Promise<void> {
-    const { bridgeIndex } = indexes;
     const { requestIndex } = message;
-    const entryIndex = bridgeIndex - 1;
+    const entryIndex = requestIndex - 1;
     const replayEntry = ledger[entryIndex];
     if (!(await admitBridgeRequest(requestIndex))) {
       return;
@@ -971,7 +987,6 @@ function startWorkerRun({
           return;
         }
         if (!resolutionMap.has(replayEntry.interruptionId)) {
-          assertCanCreateContinuation();
           pendingInterruptionIndexes.add(entryIndex);
           return;
         }
@@ -1011,11 +1026,10 @@ function startWorkerRun({
           normalizedOptions.maxHostFunctionOutputBytes,
       });
       if (outcome.status === 'interrupted') {
-        assertCanCreateContinuation();
         const interruptionId =
           replayEntry?.status === 'interrupted'
             ? replayEntry.interruptionId
-            : `interrupt-${bridgeIndex}`;
+            : `interrupt-${requestIndex}`;
         setLedgerEntry(entryIndex, {
           bindingName: message.hostFunctionName,
           inputJson: message.inputJson,
@@ -1036,7 +1050,10 @@ function startWorkerRun({
         valueJson: outcome.valueJson,
       });
       const fulfilledEntry = ledger[entryIndex];
-      if (fulfilledEntry?.status !== 'fulfilled') {
+      if (
+        fulfilledEntry?.status !== 'fulfilled' ||
+        'bridgeKind' in fulfilledEntry
+      ) {
         throw new RunProtocolError('Fulfilled ledger entry was not recorded.');
       }
       queueBridgeResponse(fulfilledEntry.settledOrder, {
@@ -1085,7 +1102,7 @@ function startWorkerRun({
       return;
     }
     const rejectedEntry = ledger[entryIndex];
-    if (rejectedEntry?.status !== 'rejected') {
+    if (rejectedEntry?.status !== 'rejected' || 'bridgeKind' in rejectedEntry) {
       failTerminal(
         new RunProtocolError('Rejected ledger entry was not recorded.'),
       );
@@ -1102,13 +1119,18 @@ function startWorkerRun({
   }
 
   function assertCanCreateContinuation(): void {
+    if (syncBridgeOperationInFlight) {
+      throw new RunProtocolError(
+        'A run cannot create a continuation while a synchronous bridge operation is in flight.',
+      );
+    }
     if (
-      moduleLoader !== undefined ||
-      syncBridgeRequests > 0 ||
-      syncBridgeOperationInFlight
+      moduleLoader !== undefined &&
+      (moduleLoader.identity === undefined ||
+        moduleLoader.identity.length === 0)
     ) {
       throw new RunProtocolError(
-        'A run cannot create a continuation after using synchronous host functions or module loading.',
+        'A module loader must have a non-empty identity to create a continuation.',
       );
     }
   }
@@ -1154,20 +1176,13 @@ function startWorkerRun({
         if (!(await admitBridgeRequest(request.requestIndex))) {
           return;
         }
-        if (continuationState !== undefined) {
-          throw new RunProtocolError(
-            'Synchronous bridge requests are forbidden during continuation replay.',
-          );
-        }
-        if (
-          pendingInterruptionIndexes.size > 0 ||
-          suspensionSettling ||
-          interruptedResultPending !== undefined
-        ) {
+        if (suspensionSettling || interruptedResultPending !== undefined) {
           throw new RunProtocolError(
             'Synchronous bridge requests are forbidden while creating a continuation.',
           );
         }
+        const entryIndex = request.requestIndex - 1;
+        const replayEntry = ledger[entryIndex];
         syncBridgeRequests += 1;
         syncBridgeOperationInFlight = true;
         if (!releaseBridgeRequestTurn(request.requestIndex)) {
@@ -1175,13 +1190,18 @@ function startWorkerRun({
         }
         let response;
         try {
-          response = await dispatchSyncBridgeRequest(
-            request.kind,
-            request.name,
-            request.payload,
-            request.sequence,
-            request.requestIndex,
-          );
+          if (replayEntry === undefined) {
+            response = await dispatchSyncBridgeRequest(
+              request.kind,
+              request.name,
+              request.payload,
+              request.sequence,
+              request.requestIndex,
+            );
+            recordSyncBridgeResponse(entryIndex, request, response);
+          } else {
+            response = replaySyncBridgeResponse(request, replayEntry);
+          }
         } finally {
           syncBridgeOperationInFlight = false;
           settleInterruptionsIfQuiescent();
@@ -1210,6 +1230,53 @@ function startWorkerRun({
             }),
       );
     }
+  }
+
+  function replaySyncBridgeResponse(
+    request: ReturnType<typeof readSyncBridgeRequest>,
+    entry: RunLedgerEntry,
+  ): SyncBridgeResponse {
+    const bridgeKind = getSyncBridgeLedgerKind(request.kind);
+    const bindingName = getSyncBridgeHostFunctionName(
+      request.kind,
+      request.name,
+    );
+    if (
+      !('bridgeKind' in entry) ||
+      entry.bridgeKind !== bridgeKind ||
+      entry.bindingName !== bindingName ||
+      entry.inputJson !== request.payload
+    ) {
+      throw new RunProtocolError(
+        'Continuation replay diverged from the recorded synchronous bridge ledger.',
+        { requestIndex: request.requestIndex },
+      );
+    }
+    return entry.status === 'fulfilled'
+      ? { payload: entry.valueJson, sequence: request.sequence, success: true }
+      : { error: entry.error, sequence: request.sequence, success: false };
+  }
+
+  function recordSyncBridgeResponse(
+    entryIndex: number,
+    request: ReturnType<typeof readSyncBridgeRequest>,
+    response: SyncBridgeResponse,
+  ): void {
+    const common = {
+      bindingName: getSyncBridgeHostFunctionName(request.kind, request.name),
+      bridgeKind: getSyncBridgeLedgerKind(request.kind),
+      inputJson: request.payload,
+    } as const;
+    setLedgerEntry(
+      entryIndex,
+      response.success
+        ? {
+            ...common,
+            status: 'fulfilled',
+            valueJson: response.payload,
+          }
+        : { ...common, error: response.error, status: 'rejected' },
+    );
   }
 
   async function dispatchSyncBridgeRequest(
@@ -1384,8 +1451,9 @@ function startWorkerRun({
   function assertReplayMatches(
     entry: RunLedgerEntry,
     message: WorkerHostFunctionRequest,
-  ): void {
+  ): asserts entry is AsyncLedgerEntry {
     if (
+      'bridgeKind' in entry ||
       entry.bindingName !== message.hostFunctionName ||
       entry.inputJson !== message.inputJson
     ) {
@@ -1513,7 +1581,7 @@ function startWorkerRun({
     }
     if (
       continuationState !== undefined &&
-      asyncBridgeRequests < continuationState.ledger.length
+      totalBridgeRequests < continuationState.ledger.length
     ) {
       failTerminal(
         new RunProtocolError(
@@ -1614,6 +1682,9 @@ function createContinuationScopeHash(
           ...(syncHostFunctionManifest.length === 0
             ? {}
             : { syncBindingManifest: syncHostFunctionManifest }),
+          ...(input.moduleLoader === undefined
+            ? {}
+            : { moduleLoaderIdentity: input.moduleLoader.identity }),
           // Keep the existing key so continuations whose transform was an
           // identity remain valid across this change. The original source is
           // stable across hosts and is also exact-matched during validation.

--- a/packages/run/src/runtime/protocol-validation.ts
+++ b/packages/run/src/runtime/protocol-validation.ts
@@ -113,11 +113,19 @@ const assertResult = (value: Record<string, unknown>): void => {
 };
 
 const assertBridgeIdle = (value: Record<string, unknown>): void => {
-  assertExactKeys(value, ['invocationId', 'requestCount', 'type']);
+  assertExactKeys(value, [
+    'invocationId',
+    'requestCount',
+    'responseCount',
+    'type',
+  ]);
   if (
     !isIdentifier(value.invocationId) ||
     !Number.isSafeInteger(value.requestCount) ||
-    (value.requestCount as number) < 0
+    (value.requestCount as number) < 0 ||
+    !Number.isSafeInteger(value.responseCount) ||
+    (value.responseCount as number) < 0 ||
+    (value.responseCount as number) > (value.requestCount as number)
   ) {
     throw invalidMessage('bridge-idle');
   }

--- a/packages/run/src/runtime/protocol.test.ts
+++ b/packages/run/src/runtime/protocol.test.ts
@@ -86,7 +86,12 @@ describe('worker protocol hardening', () => {
     {},
     { type: 'unknown' },
     { extra: true, invocationId: 'run-1', type: 'ready' },
-    { invocationId: 'run-1', requestCount: -1, type: 'bridge-idle' },
+    {
+      invocationId: 'run-1',
+      requestCount: -1,
+      responseCount: 0,
+      type: 'bridge-idle',
+    },
     {
       hostFunctionName: '',
       inputJson: '[]',

--- a/packages/run/src/runtime/protocol.ts
+++ b/packages/run/src/runtime/protocol.ts
@@ -67,6 +67,7 @@ export interface WorkerBridgeIdleMessage {
   type: 'bridge-idle';
   invocationId: string;
   requestCount: number;
+  responseCount: number;
 }
 
 export type WorkerToMainMessage =

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -41,6 +41,7 @@ const pendingBridgeRequests = new Map<
 >();
 let activeInvocationId: string | undefined;
 let aggregateBridgeRequestCounter = 0;
+let aggregateBridgeResponseCounter = 0;
 let bridgeRequestCounter = 0;
 let bridgeIdleGeneration = 0;
 let syncBridgeRequestCounter = 0;
@@ -103,6 +104,8 @@ async function handleMainMessage(value: unknown): Promise<void> {
       pending.registerTrustedError,
     );
     pendingBridgeRequests.delete(message.requestId);
+    aggregateBridgeResponseCounter += 1;
+    scheduleBridgeIdle(message.invocationId);
     return;
   }
 
@@ -119,6 +122,7 @@ async function handleMainMessage(value: unknown): Promise<void> {
 
     activeInvocationId = message.invocationId;
     aggregateBridgeRequestCounter = 0;
+    aggregateBridgeResponseCounter = 0;
     bridgeRequestCounter = 0;
     syncBridgeRequestCounter = 0;
     bridgeIdleGeneration += 1;
@@ -858,9 +862,29 @@ function requestSyncHost(
     throw new RunProtocolError('Synchronous bridge closed before responding.');
   }
   const response = readSyncBridgeResponse(syncBridge, syncBridgeRequestCounter);
+  aggregateBridgeResponseCounter += 1;
   Atomics.store(header, SyncBridgeHeader.State, SyncBridgeState.Idle);
   Atomics.notify(header, SyncBridgeHeader.State);
+  scheduleBridgeIdle(message.invocationId);
   return response;
+}
+
+function scheduleBridgeIdle(invocationId: string): void {
+  bridgeIdleGeneration += 1;
+  const idleGeneration = bridgeIdleGeneration;
+  setImmediate(() => {
+    if (
+      idleGeneration === bridgeIdleGeneration &&
+      activeInvocationId === invocationId
+    ) {
+      parentPort?.postMessage({
+        invocationId,
+        requestCount: aggregateBridgeRequestCounter,
+        responseCount: aggregateBridgeResponseCounter,
+        type: 'bridge-idle',
+      });
+    }
+  });
 }
 
 function requestHost(
@@ -889,17 +913,7 @@ function requestHost(
     type: 'host-function-request',
     ...payload,
   });
-  bridgeIdleGeneration += 1;
-  const idleGeneration = bridgeIdleGeneration;
-  setImmediate(() => {
-    if (idleGeneration === bridgeIdleGeneration) {
-      parentPort?.postMessage({
-        invocationId,
-        requestCount: bridgeRequestCounter,
-        type: 'bridge-idle',
-      });
-    }
-  });
+  scheduleBridgeIdle(invocationId);
   return deferred.handle;
 }
 

--- a/packages/run/src/sync-host-functions.test.ts
+++ b/packages/run/src/sync-host-functions.test.ts
@@ -496,7 +496,12 @@ describe('synchronous host functions', () => {
 
     await expect(
       runner.run({
-        source: 'try { effects.fail(); } catch {}',
+        hostFunctions: {
+          tools: {
+            pause: () => getHostFunctionContext().interrupt('pause'),
+          },
+        },
+        source: 'try { effects.fail(); } catch {} await tools.pause();',
       }),
     ).rejects.toThrow(
       'Synchronous host bridge error exceeds the 32 byte size limit.',

--- a/packages/run/src/sync-host-functions.test.ts
+++ b/packages/run/src/sync-host-functions.test.ts
@@ -393,13 +393,13 @@ describe('synchronous host functions', () => {
     expect(sideEffects).toEqual(['first', 'second']);
   });
 
-  it('waits for a racing synchronous call before minting its ledger', async () => {
-    let sideEffects = 0;
+  it('waits for racing synchronous calls before minting its ledger', async () => {
+    const sideEffects: string[] = [];
     const runner = createRunner({
       continuationSecret: 'q'.repeat(32),
       limits: { timeoutMs: 3000 },
       syncHostFunctions: {
-        effects: { write: () => (sideEffects += 1) },
+        effects: { write: (label: string) => sideEffects.push(label) },
       },
     });
 
@@ -408,7 +408,7 @@ describe('synchronous host functions', () => {
       return context.resume?.resolution ?? context.interrupt('pause');
     };
     const source =
-      'const pending = tools.pause(); effects.write(); await pending;';
+      "const pending = tools.pause(); effects.write('a'); effects.write('b'); await pending;";
     const interrupted = await runner.run({
       hostFunctions: { tools: { pause } },
       source,
@@ -416,7 +416,7 @@ describe('synchronous host functions', () => {
     if (interrupted.status !== 'interrupted') {
       throw new Error('Expected the run to be interrupted.');
     }
-    expect(sideEffects).toBe(1);
+    expect(sideEffects).toEqual(['a', 'b']);
     await expect(
       runner.run({
         continuation: interrupted.continuation,
@@ -430,7 +430,105 @@ describe('synchronous host functions', () => {
         source,
       }),
     ).resolves.toEqual({ status: 'completed', value: undefined });
-    expect(sideEffects).toBe(1);
+    expect(sideEffects).toEqual(['a', 'b']);
+  });
+
+  it('observes post-response synchronous calls before minting', async () => {
+    const sideEffects: string[] = [];
+    const runner = createRunner({
+      continuationSecret: 'w'.repeat(32),
+      limits: { timeoutMs: 3000 },
+      syncHostFunctions: {
+        effects: { write: (label: string) => sideEffects.push(label) },
+      },
+    });
+    const pause = () => {
+      const context = getHostFunctionContext();
+      return context.resume?.resolution ?? context.interrupt('pause');
+    };
+    const source = `
+      const pending = tools.pause();
+      const value = await tools.fetch();
+      effects.write(value + '-a');
+      effects.write(value + '-b');
+      await pending;
+    `;
+    const hostFunctions = {
+      tools: {
+        fetch: () => 'fetched',
+        pause,
+      },
+    };
+    const interrupted = await runner.run({ hostFunctions, source });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected the run to be interrupted.');
+    }
+    expect(sideEffects).toEqual(['fetched-a', 'fetched-b']);
+
+    await expect(
+      runner.run({
+        continuation: interrupted.continuation,
+        hostFunctions,
+        resolutions: [
+          {
+            interruptionId: interrupted.interruptions[0]?.id ?? '',
+            value: true,
+          },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(sideEffects).toEqual(['fetched-a', 'fetched-b']);
+  });
+
+  it('bounds rejected synchronous outcomes before recording them', async () => {
+    const runner = createRunner({
+      continuationSecret: 'e'.repeat(32),
+      limits: { maxHostFunctionOutputBytes: 32 },
+      syncHostFunctions: {
+        effects: {
+          fail() {
+            throw new Error('failure');
+          },
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        source: 'try { effects.fail(); } catch {}',
+      }),
+    ).rejects.toThrow(
+      'Synchronous host bridge error exceeds the 32 byte size limit.',
+    );
+  });
+
+  it('does not retain a continuation ledger when signing is disabled', async () => {
+    const previous = process.env.RUN_CONTINUATION_SECRET;
+    delete process.env.RUN_CONTINUATION_SECRET;
+    try {
+      const runner = createRunner({
+        limits: {
+          maxContinuationBytes: 128,
+          maxHostFunctionOutputBytes: 1024,
+        },
+        syncHostFunctions: {
+          values: { read: () => 'x'.repeat(256) },
+        },
+      });
+
+      await expect(
+        runner.run({
+          source: 'return values.read().length + values.read().length;',
+        }),
+      ).resolves.toEqual({ status: 'completed', value: 512 });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.RUN_CONTINUATION_SECRET;
+      } else {
+        process.env.RUN_CONTINUATION_SECRET = previous;
+      }
+    }
   });
 });
 

--- a/packages/run/src/sync-host-functions.test.ts
+++ b/packages/run/src/sync-host-functions.test.ts
@@ -316,33 +316,36 @@ describe('synchronous host functions', () => {
     );
   });
 
-  it('rejects synchronous side effects during continuation replay', async () => {
+  it('replays synchronous outcomes without repeating side effects', async () => {
     const secret = 'r'.repeat(32);
-    let sideEffect = false;
+    const sideEffects: string[] = [];
     const createReplayRunner = () =>
       createRunner({
         continuationSecret: secret,
         syncHostFunctions: {
           effects: {
-            write() {
-              sideEffect = true;
+            write(label: string) {
+              sideEffects.push(label);
+              return sideEffects.length;
             },
           },
         },
       });
     const source = `
-      const shouldWrite = await tools.pause();
-      if (shouldWrite) effects.write();
-      return 'done';
+      const first = effects.write('first');
+      const firstResolution = await tools.pause('first');
+      const second = effects.write('second');
+      const secondResolution = await tools.pause('second');
+      return [first, firstResolution, second, secondResolution];
     `;
-    const pause = () => {
+    const pause = (label: string) => {
       const context = getHostFunctionContext();
       if (context.resume !== undefined) {
         return context.resume.resolution;
       }
-      return context.interrupt('pause');
+      return context.interrupt(label);
     };
-    const interrupted = await createReplayRunner().run({
+    const first = await createReplayRunner().run({
       hostFunctions: {
         tools: {
           pause,
@@ -350,12 +353,72 @@ describe('synchronous host functions', () => {
       },
       source,
     });
-    if (interrupted.status !== 'interrupted') {
+    if (first.status !== 'interrupted') {
       throw new Error('Expected the run to be interrupted.');
     }
+    expect(sideEffects).toEqual(['first']);
+
+    const second = await createReplayRunner().run({
+      continuation: first.continuation,
+      hostFunctions: { tools: { pause } },
+      resolutions: [
+        {
+          interruptionId: first.interruptions[0]?.id ?? '',
+          value: 'approved-first',
+        },
+      ],
+      source,
+    });
+    if (second.status !== 'interrupted') {
+      throw new Error('Expected the resumed run to be interrupted.');
+    }
+    expect(sideEffects).toEqual(['first', 'second']);
 
     await expect(
       createReplayRunner().run({
+        continuation: second.continuation,
+        hostFunctions: { tools: { pause } },
+        resolutions: [
+          {
+            interruptionId: second.interruptions[0]?.id ?? '',
+            value: 'approved-second',
+          },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({
+      status: 'completed',
+      value: [1, 'approved-first', 2, 'approved-second'],
+    });
+    expect(sideEffects).toEqual(['first', 'second']);
+  });
+
+  it('waits for a racing synchronous call before minting its ledger', async () => {
+    let sideEffects = 0;
+    const runner = createRunner({
+      continuationSecret: 'q'.repeat(32),
+      limits: { timeoutMs: 3000 },
+      syncHostFunctions: {
+        effects: { write: () => (sideEffects += 1) },
+      },
+    });
+
+    const pause = () => {
+      const context = getHostFunctionContext();
+      return context.resume?.resolution ?? context.interrupt('pause');
+    };
+    const source =
+      'const pending = tools.pause(); effects.write(); await pending;';
+    const interrupted = await runner.run({
+      hostFunctions: { tools: { pause } },
+      source,
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected the run to be interrupted.');
+    }
+    expect(sideEffects).toBe(1);
+    await expect(
+      runner.run({
         continuation: interrupted.continuation,
         hostFunctions: { tools: { pause } },
         resolutions: [
@@ -366,32 +429,8 @@ describe('synchronous host functions', () => {
         ],
         source,
       }),
-    ).rejects.toThrow('forbidden during continuation replay');
-    expect(sideEffect).toBe(false);
-  });
-
-  it('never mints a continuation after a racing synchronous call', async () => {
-    let sideEffects = 0;
-    const runner = createRunner({
-      continuationSecret: 'q'.repeat(32),
-      limits: { timeoutMs: 3000 },
-      syncHostFunctions: {
-        effects: { write: () => (sideEffects += 1) },
-      },
-    });
-
-    await expect(
-      runner.run({
-        hostFunctions: {
-          tools: {
-            pause: () => getHostFunctionContext().interrupt('pause'),
-          },
-        },
-        source:
-          'const pending = tools.pause(); effects.write(); await pending;',
-      }),
-    ).rejects.toThrow(/continuation|synchronous bridge/iu);
-    expect(sideEffects).toBeLessThanOrEqual(1);
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(sideEffects).toBe(1);
   });
 });
 
@@ -456,21 +495,75 @@ describe('native module loading', () => {
     expect(seen).toEqual(['ab:dynamic:42']);
   });
 
-  it('does not allow module-backed runs to create continuations', async () => {
+  it('replays module loading without invoking the loader again', async () => {
     const runner = createRunner({ continuationSecret: 'x'.repeat(32) });
+    let loads = 0;
+    const pause = () => {
+      const context = getHostFunctionContext();
+      return context.resume?.resolution ?? context.interrupt('pause');
+    };
+    const moduleLoader = {
+      identity: 'modules-v1',
+      load() {
+        loads += 1;
+        return 'export const value = 1;';
+      },
+    };
+    const source = "import './dependency.js'; await tools.pause();";
+    const interrupted = await runner.run({
+      hostFunctions: { tools: { pause } },
+      moduleLoader,
+      source,
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected the module run to be interrupted.');
+    }
+    expect(loads).toBe(1);
+    await expect(
+      runner.run({
+        continuation: interrupted.continuation,
+        hostFunctions: { tools: { pause } },
+        moduleLoader: { ...moduleLoader, identity: 'modules-v2' },
+        resolutions: [
+          {
+            interruptionId: interrupted.interruptions[0]?.id ?? '',
+            value: true,
+          },
+        ],
+        source,
+      }),
+    ).rejects.toThrow(/continuation|scope/iu);
+    expect(loads).toBe(1);
+    await expect(
+      runner.run({
+        continuation: interrupted.continuation,
+        hostFunctions: { tools: { pause } },
+        moduleLoader,
+        resolutions: [
+          {
+            interruptionId: interrupted.interruptions[0]?.id ?? '',
+            value: true,
+          },
+        ],
+        source,
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+    expect(loads).toBe(1);
+  });
+
+  it('requires a stable module-loader identity for continuations', async () => {
+    const runner = createRunner({ continuationSecret: 'i'.repeat(32) });
     await expect(
       runner.run({
         hostFunctions: {
           tools: {
-            pause() {
-              getHostFunctionContext().interrupt('pause');
-            },
+            pause: () => getHostFunctionContext().interrupt('pause'),
           },
         },
         moduleLoader: { load: () => 'export {};' },
         source: 'await tools.pause();',
       }),
-    ).rejects.toThrow('cannot create a continuation');
+    ).rejects.toThrow('non-empty identity');
   });
 
   it('redacts module loader errors from guest code', async () => {

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -268,6 +268,7 @@ export interface InternalRunInput extends RunInput<unknown> {
   syncHostFunctionManifest: HostFunctionManifest;
   limits: RunLimits;
   continuationCodec: ContinuationCodec;
+  continuationEnabled: boolean;
   continuationAudience: string;
 }
 

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -50,7 +50,7 @@ export type SyncHostFunctions = HostFunctions;
 
 /** Native ES module resolver used by QuickJS. */
 export interface RunModuleLoader {
-  /** Stable identity used for diagnostics and future continuation scoping. */
+  /** Stable identity authenticated by continuations that use this loader. */
   identity?: string;
   /** Resolve a raw specifier relative to its importing module. */
   normalize?(specifier: string, importer: string): string | Promise<string>;
@@ -237,6 +237,20 @@ export type RunLedgerEntry =
       status: 'interrupted';
       interruptionId: string;
       payloadJson: string;
+    }
+  | {
+      bridgeKind: 'sync-host' | 'module-normalize' | 'module-load';
+      bindingName: string;
+      inputJson: string;
+      status: 'fulfilled';
+      valueJson: string;
+    }
+  | {
+      bridgeKind: 'sync-host' | 'module-normalize' | 'module-load';
+      bindingName: string;
+      inputJson: string;
+      status: 'rejected';
+      error: SerializableError;
     };
 
 /** Configured JavaScript runner. */


### PR DESCRIPTION
## Summary

- generalize the v2 continuation ledger around the aggregate bridge request index
- record and replay synchronous host-function returns, throws, and module normalize/load outcomes without invoking integrations twice
- permit module-backed continuations when the loader supplies a stable identity authenticated in continuation scope

This is a focused follow-up to #52. Existing async-only v2 continuations remain compatible, while calls first reached beyond the recorded frontier continue through live dispatch and can extend a later continuation.

## Safety and compatibility

- validate exact mixed-ledger entry shapes, payload encodings, module argument counts, source limits, errors, and aggregate continuation size
- wait for in-flight synchronous work and worker idle before minting a continuation
- reject replay divergence and module-loader identity changes before dispatch
- preserve the existing scope hash for runners without a module loader or synchronous bindings

## Testing

- add multi-stage sync/async replay coverage proving recorded side effects are not repeated
- add native module continuation replay and loader-identity mismatch coverage
- add malformed and oversized mixed-ledger validation coverage
- pass 296 tests, type checking, lint, and documentation formatting