### PR TITLE
Decouple module loading from source evaluation

### DIFF
--- a/.changeset/clean-entry-source-types.md
+++ b/.changeset/clean-entry-source-types.md
@@ -1,0 +1,5 @@
+---
+'run': patch
+---
+
+Allow a module loader to serve dynamic imports without forcing entry source to be evaluated as an ES module.

--- a/content/docs/foundations/sandbox.mdx
+++ b/content/docs/foundations/sandbox.mdx
@@ -39,9 +39,11 @@ const result = await run({
 - TypeScript annotations are stripped before execution when the runtime has a
   native stripper. Node 20 uses the optional `typescript` peer dependency as a
   fallback. Nothing is type-checked.
-- Default function-body source cannot import modules. Passing a `moduleLoader`
-  evaluates source as an ES module and enables static and dynamic imports
-  through host-controlled resolution.
+- A `moduleLoader` enables dynamic imports through host-controlled resolution.
+  Set `sourceType: 'function-body'` to keep top-level `await` and `return`, or
+  `sourceType: 'module'` to enable static imports. For compatibility, omitting
+  `sourceType` selects module mode when a loader is present and function-body
+  mode otherwise.
 - The sandbox does not provide Node.js globals such as `process`, `require`,
   `module`, or `Buffer`. It also does not provide browser networking APIs such
   as `fetch`, `WebSocket`, or `XMLHttpRequest`.

--- a/content/docs/reference/run.mdx
+++ b/content/docs/reference/run.mdx
@@ -53,7 +53,13 @@ import { run } from 'run';
   {
     "name": "source",
     "type": "string",
-    "description": "JavaScript or type-stripped TypeScript source. Without moduleLoader it is an async function body with top-level await and return; with moduleLoader it is an ES module."
+    "description": "JavaScript or type-stripped TypeScript source. Its evaluation mode is selected by sourceType, with backward-compatible defaults based on whether moduleLoader is present."
+  },
+  {
+    "name": "sourceType",
+    "type": "'function-body' | 'module'",
+    "isOptional": true,
+    "description": "How to evaluate the entry source. Function-body source supports top-level await and return. Module source supports static imports and completes with value undefined. Defaults to module when moduleLoader is present and function-body otherwise."
   },
   {
     "name": "hostFunctions",
@@ -89,7 +95,7 @@ import { run } from 'run';
     "name": "moduleLoader",
     "type": "RunModuleLoader",
     "isOptional": true,
-    "description": "A host-controlled native ES module loader. Its presence evaluates source as a module; completed module-backed runs have value undefined. A non-empty stable identity is required to create or resume continuations.",
+    "description": "A host-controlled native ES module loader. It enables dynamic imports from function-body source and static and dynamic imports from module source. A non-empty stable identity is required to create or resume continuations.",
     "properties": [
       {
         "type": "RunModuleLoader",

--- a/content/docs/reference/types.mdx
+++ b/content/docs/reference/types.mdx
@@ -66,7 +66,13 @@ import type {
           {
             "name": "source",
             "type": "string",
-            "description": "JavaScript or type-stripped TypeScript source, evaluated as a function body by default or as ESM when moduleLoader is present."
+            "description": "JavaScript or type-stripped TypeScript source. Its evaluation mode is selected by sourceType, with backward-compatible defaults based on whether moduleLoader is present."
+          },
+          {
+            "name": "sourceType",
+            "type": "'function-body' | 'module'",
+            "isOptional": true,
+            "description": "How to evaluate the entry source. Defaults to module when moduleLoader is present and function-body otherwise."
           },
           {
             "name": "hostFunctions",
@@ -78,7 +84,7 @@ import type {
             "name": "moduleLoader",
             "type": "RunModuleLoader",
             "isOptional": true,
-            "description": "A host-controlled native ES module loader. Its presence evaluates source as ESM."
+            "description": "A host-controlled native ES module loader for dynamic imports from function bodies and static or dynamic imports from modules."
           },
           {
             "name": "abortSignal",

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -132,8 +132,9 @@ loader, is included in invocation memory admission, and is capped at 64 MiB.
 
 ### Native ES modules
 
-Passing `moduleLoader` evaluates `source` as an ES module and enables static,
-cyclic, and dynamic imports through QuickJS's native module loader:
+Passing `moduleLoader` enables native module resolution. For compatibility,
+its presence evaluates `source` as an ES module unless `sourceType` is set
+explicitly. Module source supports static, cyclic, and dynamic imports:
 
 ```ts
 await runner.run({
@@ -150,16 +151,33 @@ await runner.run({
 });
 ```
 
+Set `sourceType: 'function-body'` to retain top-level `await`, `return`, and a
+serialized run value while enabling native dynamic imports:
+
+```ts
+const result = await runner.run({
+  source: `
+    const { value } = await import('./value.js');
+    return value;
+  `,
+  sourceType: 'function-body',
+  moduleLoader,
+});
+```
+
+Set `sourceType: 'module'` to evaluate an entry module even when it has no
+imports and no module loader. Entry modules execute for their side effects and
+a completed module run has `value: undefined`; the module namespace is not
+serialized as the run result.
+
 `normalize` and `load` may be synchronous or asynchronous. Their results are
 bounded by the host-function bridge limits, and `SharedArrayBuffer` and
 `Atomics` remain unavailable to guest JavaScript. Module-backed runs can create
 and resume continuations when the loader has a non-empty stable `identity`.
 Loader failures are redacted before entering the sandbox.
 
-Entry modules execute for their side effects and a completed module-backed run
-has `value: undefined`; the module namespace is not serialized as the run
-result. This allows modules to export functions and cyclic namespaces without
-turning those exports into result-serialization failures.
+This allows modules to export functions and cyclic namespaces without turning
+those exports into result-serialization failures.
 
 Native Node type stripping is used when the runtime provides it, and Bun uses
 its native TypeScript transpiler. On Node 20, install the optional `typescript`

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -39,6 +39,7 @@ export type {
   RunLedgerEntry,
   RunLimits,
   RunResolution,
+  RunSourceType,
   Runner,
   RunnerOptions,
   RunResult,

--- a/packages/run/src/run-configuration.test.ts
+++ b/packages/run/src/run-configuration.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { getHostFunctionContext, run } from './index.js';
 
 describe('run configuration', () => {
+  it('rejects an invalid source type', async () => {
+    await expect(
+      run({ source: 'return 1;', sourceType: 'script' as never }),
+    ).rejects.toThrow('Invalid sourceType configuration.');
+  });
+
   it('observes a continuation secret configured after first use', async () => {
     const previous = process.env.RUN_CONTINUATION_SECRET;
     delete process.env.RUN_CONTINUATION_SECRET;

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -12,6 +12,11 @@ import type {
   RunResult,
 } from './types.js';
 
+const isRunSourceType = (
+  value: unknown,
+): value is NonNullable<RunInput['sourceType']> =>
+  value === 'function-body' || value === 'module';
+
 function missingContinuationCodec<TOKEN>(): ContinuationCodec<TOKEN> {
   const message =
     'Continuation signing is not configured. Set RUN_CONTINUATION_SECRET or pass continuationSecret or continuationCodec to createRunner().';
@@ -217,6 +222,12 @@ export const createRunner = <TOKEN = string>(
             `Host function namespace "${namespace}" cannot be both asynchronous and synchronous.`,
           );
         }
+      }
+      if (
+        input.sourceType !== undefined &&
+        !isRunSourceType(input.sourceType)
+      ) {
+        throw new TypeError('Invalid sourceType configuration.');
       }
       if (
         input.moduleLoader !== undefined &&

--- a/packages/run/src/runtime/manager.ts
+++ b/packages/run/src/runtime/manager.ts
@@ -406,9 +406,12 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
   activeInvocations += 1;
   try {
     assertSourceSize(input.source, normalizedOptions.maxSourceBytes);
+    const sourceType =
+      input.sourceType ??
+      (input.moduleLoader === undefined ? 'function-body' : 'module');
     const transformedSource = transformSource(
       input.source,
-      input.moduleLoader !== undefined,
+      sourceType === 'module',
     );
     assertSourceSize(transformedSource, normalizedOptions.maxSourceBytes);
     const scopeHash = createContinuationScopeHash(input, normalizedOptions);
@@ -443,6 +446,7 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
       resolutions: normalizedResolutions,
       scopeHash,
       source: transformedSource,
+      sourceType,
       timeoutErrorMs: normalizedOptions.timeoutMs,
     });
     return await run.result;
@@ -456,6 +460,7 @@ export async function runManaged(input: InternalRunInput): Promise<RunResult> {
 
 function startWorkerRun({
   source,
+  sourceType,
   originalSource,
   hostFunctions,
   hostFunctionManifest,
@@ -474,6 +479,7 @@ function startWorkerRun({
   deadlineMs,
 }: InternalRunInput & {
   originalSource: string;
+  sourceType: 'function-body' | 'module';
   continuationState?: RunContinuationState;
   normalizedOptions: NormalizedRunOptions;
   timeoutErrorMs: number;
@@ -898,6 +904,7 @@ function startWorkerRun({
       timeoutMs: timeoutErrorMs,
     },
     source,
+    sourceType,
     syncBridge,
     syncHostFunctionNamespaces: [...syncHostFunctionManifest.keys()],
     type: 'run',
@@ -1711,6 +1718,11 @@ function createContinuationScopeHash(
           ...(input.moduleLoader === undefined
             ? {}
             : { moduleLoaderIdentity: input.moduleLoader.identity }),
+          ...(input.sourceType === undefined ||
+          input.sourceType ===
+            (input.moduleLoader === undefined ? 'function-body' : 'module')
+            ? {}
+            : { sourceType: input.sourceType }),
           // Keep the existing key so continuations whose transform was an
           // identity remain valid across this change. The original source is
           // stable across hosts and is also exact-matched during validation.

--- a/packages/run/src/runtime/protocol-validation.ts
+++ b/packages/run/src/runtime/protocol-validation.ts
@@ -206,6 +206,9 @@ const hasValidSyncBridgeConfiguration = (
     value.syncHostFunctionNamespaces.length === 0 ||
     value.syncBridge !== undefined);
 
+const hasValidSourceType = (value: unknown): boolean =>
+  value === 'function-body' || value === 'module';
+
 export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
   if (!isRecord(value) || typeof value.type !== 'string') {
     throw invalidMessage('main-to-worker');
@@ -218,6 +221,7 @@ export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
       'moduleLoader',
       'options',
       'source',
+      'sourceType',
       'syncBridge',
       'syncHostFunctionNamespaces',
       'type',
@@ -234,6 +238,7 @@ export const assertMainToWorkerMessage: AssertMainToWorkerMessage = value => {
       new Set(value.syncHostFunctionNamespaces).size !==
         value.syncHostFunctionNamespaces.length ||
       typeof value.moduleLoader !== 'boolean' ||
+      !hasValidSourceType(value.sourceType) ||
       !hasValidSyncBridgeConfiguration(value) ||
       !isDeterminism(value.determinism) ||
       !isRunOptions(value.options)

--- a/packages/run/src/runtime/protocol.test.ts
+++ b/packages/run/src/runtime/protocol.test.ts
@@ -26,6 +26,7 @@ const createRunMessage = (invocationId: string) => ({
   moduleLoader: false,
   options: WORKER_OPTIONS,
   source: 'return await tools.echo({ value: 1 });',
+  sourceType: 'function-body',
   syncBridge: undefined,
   syncHostFunctionNamespaces: [],
   type: 'run',

--- a/packages/run/src/runtime/protocol.ts
+++ b/packages/run/src/runtime/protocol.ts
@@ -11,6 +11,7 @@ export interface WorkerRunMessage {
   hostFunctionNamespaces: string[];
   syncHostFunctionNamespaces: string[];
   moduleLoader: boolean;
+  sourceType: 'function-body' | 'module';
   syncBridge: SharedArrayBuffer | undefined;
   determinism: RunDeterminismState;
   options: Pick<

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -26,6 +26,7 @@ const createRunMessage = (
     timeoutMs: 1000,
   },
   source,
+  sourceType: 'function-body',
   syncBridge: new SharedArrayBuffer(1024),
   syncHostFunctionNamespaces: [],
   type: 'run',

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -388,7 +388,7 @@ async function evaluateUserSource(
   serializeJsonPayload: JSValueHandle,
   getTrustedErrorCode: JSValueHandle,
 ): Promise<string> {
-  if (message.moduleLoader) {
+  if (message.sourceType === 'module') {
     let modulePromise: JSValueHandle;
     try {
       modulePromise = context.evalCode(

--- a/packages/run/src/sync-host-functions.test.ts
+++ b/packages/run/src/sync-host-functions.test.ts
@@ -538,6 +538,37 @@ describe('synchronous host functions', () => {
 });
 
 describe('native module loading', () => {
+  it('loads dynamic imports from function-body source', async () => {
+    const runner = createRunner();
+
+    await expect(
+      runner.run({
+        moduleLoader: {
+          load(specifier) {
+            if (specifier === '/value.js') {
+              return "export const value = 'loaded';";
+            }
+            throw new Error('not found');
+          },
+        },
+        source: `
+          const module = await import('/value.js');
+          return module.value;
+        `,
+        sourceType: 'function-body',
+      }),
+    ).resolves.toEqual({ status: 'completed', value: 'loaded' });
+  });
+
+  it('evaluates explicit module source without requiring a loader', async () => {
+    await expect(
+      createRunner().run({
+        source: 'export const value = 1;',
+        sourceType: 'module',
+      }),
+    ).resolves.toEqual({ status: 'completed', value: undefined });
+  });
+
   it('loads static, aliased, cyclic, and dynamic ESM', async () => {
     const seen: string[] = [];
     const modules = new Map<string, string>([
@@ -667,6 +698,42 @@ describe('native module loading', () => {
         source: 'await tools.pause();',
       }),
     ).rejects.toThrow('non-empty identity');
+  });
+
+  it('binds non-default source type to the continuation scope', async () => {
+    const runner = createRunner({ continuationSecret: 's'.repeat(32) });
+    const pause = () =>
+      getHostFunctionContext().resume?.resolution ??
+      getHostFunctionContext().interrupt('pause');
+    const input = {
+      hostFunctions: { tools: { pause } },
+      moduleLoader: {
+        identity: 'scope-loader',
+        load: () => 'export {};',
+      },
+      source: 'return await tools.pause();',
+    } as const;
+    const interrupted = await runner.run({
+      ...input,
+      sourceType: 'function-body',
+    });
+    if (interrupted.status !== 'interrupted') {
+      throw new Error('Expected the function-body run to be interrupted.');
+    }
+
+    await expect(
+      runner.run({
+        ...input,
+        continuation: interrupted.continuation,
+        resolutions: [
+          {
+            interruptionId: interrupted.interruptions[0]?.id ?? '',
+            value: true,
+          },
+        ],
+        sourceType: 'module',
+      }),
+    ).rejects.toThrow(/continuation|scope/iu);
   });
 
   it('redacts module loader errors from guest code', async () => {

--- a/packages/run/src/types.ts
+++ b/packages/run/src/types.ts
@@ -99,6 +99,9 @@ export interface RunnerOptions<TOKEN = string> {
   continuationAudience?: string;
 }
 
+/** How the entry source is evaluated. */
+export type RunSourceType = 'function-body' | 'module';
+
 /** Input accepted by `run` and `Runner.run`. */
 export interface RunInput<TOKEN = unknown> {
   /**
@@ -108,10 +111,17 @@ export interface RunInput<TOKEN = unknown> {
    * Top-level `await` and `return` are supported.
    */
   source: string;
+  /**
+   * Entry-source evaluation mode. A function body supports top-level `await`
+   * and `return`; a module supports static imports and has no return value.
+   * Defaults to `module` when `moduleLoader` is present and `function-body`
+   * otherwise.
+   */
+  sourceType?: RunSourceType;
   hostFunctions?: HostFunctions;
   /**
-   * Optional native ES module loader. Its presence evaluates source as ESM;
-   * entry-module evaluation completes with an undefined run value.
+   * Optional native ES module loader. It enables native dynamic imports in a
+   * function body and static and dynamic imports in a module.
    */
   moduleLoader?: RunModuleLoader;
   abortSignal?: AbortSignal;


### PR DESCRIPTION
## Summary

- add an explicit `sourceType: "function-body" | "module"` run option
- allow native dynamic imports from function-body source without losing top-level `await`, `return`, or the serialized run value
- preserve existing behavior when `sourceType` is omitted, keeping this patch-compatible
- bind non-default evaluation semantics into continuation scope validation
- document and test both evaluation modes

This removes the need for consumers such as `just-bash` to guess whether source is ESM with a regular expression merely to install a module loader.

## Compatibility

The default remains unchanged:

- no `moduleLoader` => `function-body`
- `moduleLoader` present => `module`

Callers opt into the decoupled behavior by passing `sourceType` explicitly.

## Validation

- `pnpm --filter run build`
- `pnpm --filter run test:node` (330 tests)
- `pnpm --filter run type-check`
- `pnpm --filter run check`

## Release

Includes a patch changeset.