### PR TITLE
fix(run): isolate suspension and identify guest source failures

### DIFF
--- a/.changeset/tidy-workers-suspend.md
+++ b/.changeset/tidy-workers-suspend.md
@@ -1,0 +1,7 @@
+---
+'run': patch
+---
+
+Fix interruptions timing out when guest `catch` or `finally` handlers run during worker cancellation. Suspension now discards the cancelled guest context without executing its handlers, while preserving worker reuse and continuation replay.
+
+Report uncaught guest errors as `RUN_USER_SOURCE_ERROR` so callers can distinguish source failures from infrastructure failures. Trusted host and runtime error codes are preserved; guest-authored codes are replaced.

--- a/content/docs/advanced/continuations.mdx
+++ b/content/docs/advanced/continuations.mdx
@@ -15,6 +15,13 @@ An interruption does not leave a worker suspended. The invocation ends and
 returns a continuation token. When the host supplies that token and a
 resolution, `run` starts a new invocation and replays the source.
 
+Suspension is a host operation, not a rejected promise inside the guest. It
+discards the guest context without executing guest `catch` or `finally`
+handlers. On resume, those handlers follow normal JavaScript semantics as the
+source replays and the interrupted host call receives its resolution. Put
+cleanup for work owned by the host in the host function; guest `finally` is not
+a suspension or cancellation hook.
+
 Continuations do not turn `run` into a complete durable execution system. The
 host application remains responsible for storing tokens, collecting decisions,
 scheduling resumed work, authorizing callers, and handling retries.

--- a/content/docs/reference/errors.mdx
+++ b/content/docs/reference/errors.mdx
@@ -19,6 +19,18 @@ try {
 }
 ```
 
+## Guest source failures
+
+Uncaught guest evaluation failures, including syntax errors and thrown values,
+use `RUN_USER_SOURCE_ERROR`. This identifies where the error came from; it does
+not guarantee that retrying will succeed or fail. Inspect the source, inputs,
+and resource limits before choosing a retry policy.
+
+Run replaces guest-authored `code` properties with `RUN_USER_SOURCE_ERROR`,
+including custom codes and attempts to imitate runtime errors. Trusted errors
+from host functions retain their codes, and actual timeouts remain `RUN_TIMEOUT`.
+Generic `RUN_ERROR` remains a fallback and does not identify a source failure.
+
 ## Import
 
 ```ts

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -490,6 +490,9 @@ Runtime failures extend `RunError` and expose a stable `code`:
   host effects are safe to retry.
 - `RUN_PROTOCOL_ERROR` indicates malformed, tampered, expired, or divergent
   continuation state. Do not retry unchanged input.
+- `RUN_USER_SOURCE_ERROR` identifies uncaught guest evaluation failures, including
+  syntax errors and thrown values. Guest-authored `code` properties are replaced;
+  trusted host and runtime codes are preserved.
 - `RUN_HOST_FUNCTION_ERROR` comes from capability lookup or host function
   execution.
 - `RUN_BRIDGE_LIMIT`, `RUN_SOURCE_TOO_LARGE`, and serialization failures require

--- a/packages/run/src/runtime/worker-message.test.ts
+++ b/packages/run/src/runtime/worker-message.test.ts
@@ -135,3 +135,78 @@ it('reports message failures and ignores late messages without crashing', async 
     await worker.terminate();
   }
 });
+
+it('discards cancelled guest work and reuses the worker despite a late bridge response', async () => {
+  const worker =
+    (globalThis as { Bun?: unknown }).Bun === undefined
+      ? new Worker(
+          new URL(
+            `data:text/javascript;base64,${Buffer.from(INLINE_RUN_WORKER_SOURCE).toString('base64')}`,
+          ),
+          { execArgv: [] },
+        )
+      : new Worker(INLINE_RUN_WORKER_SOURCE, { eval: true, execArgv: [] });
+  const postToWorker = (message: MainToWorkerMessage): void => {
+    // eslint-disable-next-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
+    worker.postMessage(message);
+  };
+  const completed = createPromiseWithResolvers<null>();
+  const results: unknown[] = [];
+  let requests = 0;
+  worker.on('error', completed.reject);
+  worker.on('message', (value: unknown) => {
+    const message = value as {
+      invocationId: string;
+      requestId: string;
+      type: string;
+    };
+    if (message.type === 'host-function-request') {
+      requests += 1;
+      postToWorker({ invocationId: message.invocationId, type: 'cancel' });
+      postToWorker({
+        dateNowMs: 1_700_000_000_002,
+        invocationId: message.invocationId,
+        requestId: message.requestId,
+        success: true,
+        type: 'bridge-response',
+        valueJson: '[null]',
+      });
+    }
+    if (message.type === 'result') {
+      results.push(value);
+    }
+    if (message.type === 'ready') {
+      if (message.invocationId === 'run-cancelled') {
+        postToWorker(createRunMessage('run-reused', 'return 42;'));
+      } else {
+        completed.resolve(null);
+      }
+    }
+  });
+  try {
+    postToWorker(
+      createRunMessage(
+        'run-cancelled',
+        `
+      try { await tools.pause(); }
+      finally {
+        for (let i = 0; i < 100000; i++) {}
+        await tools.cleanup();
+      }
+    `,
+      ),
+    );
+    await completed.promise;
+    expect(requests).toBe(1);
+    expect(results).toMatchObject([
+      {
+        error: { message: 'Worker execution cancelled by host' },
+        invocationId: 'run-cancelled',
+        success: false,
+      },
+      { invocationId: 'run-reused', success: true, valueJson: '[42]' },
+    ]);
+  } finally {
+    await worker.terminate();
+  }
+});

--- a/packages/run/src/runtime/worker.ts
+++ b/packages/run/src/runtime/worker.ts
@@ -51,6 +51,7 @@ let activeCancellation:
   | {
       invocationId: string;
       cancel: () => void;
+      isCancelled: () => boolean;
       fail: (error: unknown) => void;
     }
   | undefined;
@@ -95,6 +96,10 @@ async function handleMainMessage(value: unknown): Promise<void> {
           requestId: message.requestId,
         },
       );
+    }
+
+    if (activeCancellation?.isCancelled()) {
+      return;
     }
 
     resolveBridgeResponse(
@@ -226,22 +231,13 @@ async function execute(message: WorkerRunMessage): Promise<string> {
   activeCancellation = {
     cancel: () => {
       cancelled = true;
-      rejectPendingBridgeRequests(
-        context,
-        message.invocationId,
-        'Worker execution cancelled by host',
-      );
     },
     fail: error => {
       executionFailure ??= { error };
       cancelled = true;
-      rejectPendingBridgeRequests(
-        context,
-        message.invocationId,
-        'Worker message processing failed',
-      );
     },
     invocationId: message.invocationId,
+    isCancelled: () => cancelled,
   };
   if (pendingInvocationFailure?.invocationId === message.invocationId) {
     activeCancellation.fail(pendingInvocationFailure.error);
@@ -279,6 +275,11 @@ async function execute(message: WorkerRunMessage): Promise<string> {
       message,
       serializeJsonPayloadHandle,
       getTrustedErrorCodeHandle,
+      () => {
+        if (cancelled) {
+          throw new Error('Worker execution cancelled by host');
+        }
+      },
     );
     const completedFailure = getExecutionFailure();
     if (completedFailure !== undefined) {
@@ -298,21 +299,12 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     if (activeCancellation?.invocationId === message.invocationId) {
       activeCancellation = undefined;
     }
-    if (!cancelled) {
-      rejectPendingBridgeRequests(
-        context,
-        message.invocationId,
-        'Worker execution finished before bridge response',
-      );
-    }
-    const pendingForInvocation = [...pendingBridgeRequests.entries()].filter(
-      ([, pending]) => pending.invocationId === message.invocationId,
-    );
-    await Promise.allSettled(
-      pendingForInvocation.map(([, pending]) => pending.deferred.settled),
-    );
-    for (const [requestId] of pendingForInvocation) {
-      pendingBridgeRequests.delete(requestId);
+    // Guest promises are discarded with the context; settling them would run
+    // catch/finally handlers during suspension and could prevent teardown.
+    for (const [requestId, pending] of pendingBridgeRequests) {
+      if (pending.invocationId === message.invocationId) {
+        pendingBridgeRequests.delete(requestId);
+      }
     }
     disposeHandle(bridgeFunctions?.invokeHostFunction);
     disposeHandle(bridgeFunctions?.invokeSyncHostFunction);
@@ -387,6 +379,7 @@ async function evaluateUserSource(
   message: WorkerRunMessage,
   serializeJsonPayload: JSValueHandle,
   getTrustedErrorCode: JSValueHandle,
+  assertActive: () => void,
 ): Promise<string> {
   if (message.sourceType === 'module') {
     let modulePromise: JSValueHandle;
@@ -399,7 +392,11 @@ async function evaluateUserSource(
     } catch (error) {
       throw toUserSourceError(dumpQuickJSError(context, error), message.source);
     }
-    const resolvedModule = await resolveQuickJSPromise(context, modulePromise);
+    const resolvedModule = await resolveQuickJSPromise(
+      context,
+      modulePromise,
+      assertActive,
+    );
     if (!modulePromise.disposed) {
       modulePromise.dispose();
     }
@@ -432,7 +429,11 @@ async function evaluateUserSource(
   }
 
   const promiseHandle = context.global.getProp('__runResult');
-  const resolvedResult = await resolveQuickJSPromise(context, promiseHandle);
+  const resolvedResult = await resolveQuickJSPromise(
+    context,
+    promiseHandle,
+    assertActive,
+  );
   if (!promiseHandle.disposed) {
     promiseHandle.dispose();
   }
@@ -463,26 +464,6 @@ async function evaluateUserSource(
     'JavaScript runtime result',
   );
   return valueJson;
-}
-
-function rejectPendingBridgeRequests(
-  context: QuickJS,
-  invocationId: string,
-  message: string,
-): void {
-  let rejected = false;
-  for (const pending of pendingBridgeRequests.values()) {
-    if (pending.invocationId !== invocationId) {
-      continue;
-    }
-    const error = context.newError(message);
-    pending.deferred.reject(error);
-    error.dispose();
-    rejected = true;
-  }
-  if (rejected) {
-    context.executePendingJobs();
-  }
 }
 
 async function createQuickJSContext(options: {
@@ -906,7 +887,6 @@ function requestHost(
     ...(registerTrustedError === undefined ? {} : { registerTrustedError }),
     ...(resetDateNow === undefined ? {} : { resetDateNow }),
   });
-  completeDeferredWhenSettled(context, deferred);
   parentPort?.postMessage({
     invocationId,
     requestId,
@@ -916,14 +896,6 @@ function requestHost(
   });
   scheduleBridgeIdle(invocationId);
   return deferred.handle;
-}
-
-async function completeDeferredWhenSettled(
-  context: QuickJS,
-  deferred: Deferred,
-): Promise<void> {
-  await deferred.settled;
-  context.executePendingJobs();
 }
 
 function resolveBridgeResponse(
@@ -1032,22 +1004,23 @@ function drainPendingJobs(context: QuickJS): void {
 async function resolveQuickJSPromise(
   context: QuickJS,
   promiseHandle: JSValueHandle,
+  assertActive: () => void,
 ) {
   const resolved = context.resolvePromise(promiseHandle);
   const notSettled = Symbol('not-settled');
   for (;;) {
+    assertActive();
     drainPendingJobs(context);
     const nextTurn = createPromiseWithResolvers<typeof notSettled>();
     setTimeout(() => nextTurn.resolve(notSettled), 0);
     const result = await Promise.race([resolved, nextTurn.promise]);
     if (result !== notSettled) {
+      assertActive();
       drainPendingJobs(context);
       return result;
     }
   }
 }
-
-const GUEST_ALLOWED_RUN_ERROR_CODES = new Set(['RUN_ERROR']);
 
 function toError(
   value: unknown,
@@ -1068,7 +1041,9 @@ function toError(
       details?: unknown;
     };
     const error = new Error(errorValue.message);
-    const errorCode = trustedCode ?? errorValue.code;
+    const errorCode =
+      trustedCode ??
+      (filterGuestCode ? 'RUN_USER_SOURCE_ERROR' : errorValue.code);
     const { name } = errorValue;
     if (typeof name === 'string') {
       error.name = name;
@@ -1079,14 +1054,7 @@ function toError(
     ) {
       error.stack = (value as { stack: string }).stack;
     }
-    if (
-      errorCode !== undefined &&
-      (!filterGuestCode ||
-        trustedCode !== undefined ||
-        typeof errorCode !== 'string' ||
-        !errorCode.startsWith('RUN_') ||
-        GUEST_ALLOWED_RUN_ERROR_CODES.has(errorCode))
-    ) {
+    if (errorCode !== undefined) {
       Object.defineProperty(error, 'code', {
         enumerable: true,
         value: errorCode,
@@ -1100,7 +1068,14 @@ function toError(
     }
     return error;
   }
-  return new Error(String(value));
+  const error = new Error(String(value));
+  if (filterGuestCode) {
+    Object.defineProperty(error, 'code', {
+      enumerable: true,
+      value: trustedCode ?? 'RUN_USER_SOURCE_ERROR',
+    });
+  }
+  return error;
 }
 
 function toUserSourceError(

--- a/packages/run/src/security-hardening.test.ts
+++ b/packages/run/src/security-hardening.test.ts
@@ -377,7 +377,7 @@ describe('guest sandbox hardening', () => {
         `,
       }),
     ).rejects.toMatchObject({
-      code: 'RUN_ERROR',
+      code: 'RUN_USER_SOURCE_ERROR',
       details: { tenant: 'victim-tenant-42' },
       message: 'guest failure',
     });

--- a/packages/run/src/suspension.test.ts
+++ b/packages/run/src/suspension.test.ts
@@ -6,54 +6,104 @@ describe.each(['function-body', 'module'] as const)(
   'suspending guest exception handlers (%s)',
   sourceType => {
     it.each([
-      'try { await tools.pause(); } catch { for (let i = 0; i < 100000; i++) {} }',
-      'try { await tools.pause(); } finally { for (let i = 0; i < 100000; i++) {} }',
-      `for (let i = 0; i < 4; i++) {
-      try { await tools.pause(); }
-      catch { try { await tools.pause(); } catch { continue; } }
-    }`,
-    ])('returns a continuation and resumes %s', async source => {
-      const effect = vi.fn(() => 'created');
-      const pause = vi.fn(() => {
-        const context = getHostFunctionContext();
-        if (context.resume === undefined) {
-          context.interrupt({ kind: 'pause' });
+      {
+        name: 'catch with pending guest work',
+        rounds: 1,
+        source:
+          'try { await tools.pause(); } catch { for (let i = 0; i < 100000; i++) {} }',
+      },
+      {
+        name: 'finally with pending guest work',
+        rounds: 1,
+        source:
+          'try { await tools.pause(); } finally { for (let i = 0; i < 100000; i++) {} }',
+      },
+      {
+        name: 'nested catch across four interruptions',
+        rounds: 4,
+        source: `for (let i = 0; i < 4; i++) {
+          try { await tools.pause(); }
+          catch { try { await tools.pause(); } catch { continue; } }
+        }`,
+      },
+      {
+        name: 'Promise.catch callback',
+        rounds: 1,
+        source:
+          'await tools.pause().catch(() => { for (let i = 0; i < 100000; i++) {} });',
+      },
+      {
+        name: 'Promise.finally callback',
+        rounds: 1,
+        source:
+          'await tools.pause().finally(() => { for (let i = 0; i < 100000; i++) {} });',
+      },
+      {
+        name: 'finally inside an awaited async helper',
+        rounds: 1,
+        source: `async function helper() {
+          try { await tools.pause(); }
+          finally { for (let i = 0; i < 100000; i++) {} }
         }
-        return context.resume?.resolution;
-      });
-      const input = {
-        hostFunctions: { tools: { effect, pause } },
-        limits: { timeoutMs: 1000 },
-        source: `await tools.effect(); ${source}; ${sourceType === 'function-body' ? 'return 42;' : ''}`,
-        sourceType,
-      };
-      let result = await run(input);
-      let rounds = 0;
-      while (result.status === 'interrupted') {
-        expect(getRuntimeDiagnostics()).toMatchObject({
-          activeInvocations: 0,
-          idleWorkers: 1,
-          terminatingWorkers: 0,
+        await helper();`,
+      },
+    ])(
+      'returns a continuation before the timeout: $name',
+      async ({ rounds: expectedRounds, source }) => {
+        const effect = vi.fn(() => 'created');
+        const pause = vi.fn(() => {
+          const context = getHostFunctionContext();
+          if (context.resume === undefined) {
+            context.interrupt({ kind: 'pause' });
+          }
+          return context.resume?.resolution;
         });
-        rounds += 1;
-        expect(rounds).toBeLessThanOrEqual(4);
-        result = await run({
-          ...input,
-          continuation: result.continuation,
-          resolutions: result.interruptions.map(interruption => ({
-            interruptionId: interruption.id,
-            value: true,
-          })),
+        const input = {
+          hostFunctions: { tools: { effect, pause } },
+          limits: { timeoutMs: 1000 },
+          source: `await tools.effect(); ${source}; ${sourceType === 'function-body' ? 'return 42;' : ''}`,
+          sourceType,
+        };
+        // The same source must complete normally; only host suspension changes.
+        await expect(
+          run({
+            ...input,
+            hostFunctions: {
+              tools: { effect: () => 'created', pause: () => true },
+            },
+          }),
+        ).resolves.toEqual({
+          status: 'completed',
+          value: sourceType === 'function-body' ? 42 : undefined,
         });
-      }
-      expect(rounds).toBeGreaterThan(0);
-      expect(result).toEqual({
-        status: 'completed',
-        value: sourceType === 'function-body' ? 42 : undefined,
-      });
-      expect(effect).toHaveBeenCalledTimes(1);
-      expect(pause).toHaveBeenCalledTimes(rounds * 2);
-    });
+        let result = await run(input);
+        let rounds = 0;
+        while (result.status === 'interrupted') {
+          expect(getRuntimeDiagnostics()).toMatchObject({
+            activeInvocations: 0,
+            idleWorkers: 1,
+            terminatingWorkers: 0,
+          });
+          rounds += 1;
+          expect(rounds).toBeLessThanOrEqual(expectedRounds);
+          result = await run({
+            ...input,
+            continuation: result.continuation,
+            resolutions: result.interruptions.map(interruption => ({
+              interruptionId: interruption.id,
+              value: true,
+            })),
+          });
+        }
+        expect(rounds).toBe(expectedRounds);
+        expect(result).toEqual({
+          status: 'completed',
+          value: sourceType === 'function-body' ? 42 : undefined,
+        });
+        expect(effect).toHaveBeenCalledTimes(1);
+        expect(pause).toHaveBeenCalledTimes(rounds * 2);
+      },
+    );
 
     it('runs finally host effects only after resuming the interrupted call', async () => {
       const cleanup = vi.fn(() => 'cleaned');
@@ -94,6 +144,246 @@ describe.each(['function-body', 'module'] as const)(
       });
       expect(cleanup).toHaveBeenCalledTimes(1);
     });
+
+    it.each(['resolve', 'reject'])(
+      'keeps catch and cleanup untouched until the host resumes with %s',
+      async resolution => {
+        const record = vi.fn();
+        const pause = vi.fn(() => {
+          const context = getHostFunctionContext();
+          if (context.resume === undefined) {
+            context.interrupt({ kind: 'pause' });
+          }
+          if (context.resume?.resolution === 'reject') {
+            throw new Error('resumed host failure');
+          }
+          return 'resumed value';
+        });
+        const input = {
+          hostFunctions: { tools: { pause, record } },
+          limits: { timeoutMs: 1000 },
+          source: `
+            try { await tools.record(await tools.pause()); }
+            catch (error) { await tools.record(error.message); }
+            finally { await tools.record('cleanup'); }
+          `,
+          sourceType,
+        };
+        const interrupted = await run(input);
+        expect(interrupted.status).toBe('interrupted');
+        expect(record.mock.calls).toEqual([]);
+        expect(pause).toHaveBeenCalledTimes(1);
+        if (interrupted.status !== 'interrupted') {
+          throw new Error(
+            'Expected suspension before catch or finally executes.',
+          );
+        }
+        expect(interrupted.interruptions).toHaveLength(1);
+        const result = await run({
+          ...input,
+          continuation: interrupted.continuation,
+          resolutions: interrupted.interruptions.map(item => ({
+            interruptionId: item.id,
+            value: resolution,
+          })),
+        });
+        expect(result).toEqual({ status: 'completed', value: undefined });
+        expect(record.mock.calls).toEqual([
+          [resolution === 'reject' ? 'Host function failed.' : 'resumed value'],
+          ['cleanup'],
+        ]);
+        expect(pause).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    it('can suspend again inside finally without repeating earlier cleanup', async () => {
+      const record = vi.fn();
+      const pause = vi.fn((phase: string) => {
+        const context = getHostFunctionContext();
+        if (context.resume === undefined) {
+          context.interrupt({ phase });
+        }
+        return context.resume?.resolution;
+      });
+      const input = {
+        hostFunctions: { tools: { pause, record } },
+        limits: { timeoutMs: 1000 },
+        source: `
+          try { await tools.pause('work'); }
+          finally {
+            await tools.record('before-cleanup');
+            await tools.pause('cleanup');
+            await tools.record('after-cleanup');
+          }
+          await tools.record('done');
+        `,
+        sourceType,
+      };
+      let result = await run(input);
+      for (const phase of ['work', 'cleanup']) {
+        expect(result).toMatchObject({
+          interruptions: [{ arguments: [phase], payload: { phase } }],
+          status: 'interrupted',
+        });
+        expect(record.mock.calls).toEqual(
+          phase === 'work' ? [] : [['before-cleanup']],
+        );
+        if (result.status !== 'interrupted') {
+          throw new Error(`Expected suspension during ${phase}.`);
+        }
+        expect(result.interruptions).toHaveLength(1);
+        result = await run({
+          ...input,
+          continuation: result.continuation,
+          resolutions: result.interruptions.map(item => ({
+            interruptionId: item.id,
+            value: true,
+          })),
+        });
+      }
+      expect(result).toEqual({ status: 'completed', value: undefined });
+      expect(record.mock.calls).toEqual([
+        ['before-cleanup'],
+        ['after-cleanup'],
+        ['done'],
+      ]);
+      expect(pause.mock.calls).toEqual([
+        ['work'],
+        ['work'],
+        ['cleanup'],
+        ['cleanup'],
+      ]);
+    });
+
+    it('resumes parallel interruptions by id and preserves settled outcomes in allSettled', async () => {
+      const record = vi.fn();
+      const ready = vi.fn(() => 'already completed');
+      const fail = vi.fn(() => {
+        throw new Error('already failed');
+      });
+      const pause = vi.fn((name: string) => {
+        const context = getHostFunctionContext();
+        if (context.resume === undefined) {
+          context.interrupt({ name });
+        }
+        return context.resume?.resolution;
+      });
+      const input = {
+        hostFunctions: { tools: { fail, pause, ready, record } },
+        limits: { timeoutMs: 1000 },
+        source: `
+          try {
+            const results = await Promise.allSettled([
+              tools.ready(), tools.pause('alpha'), tools.fail(), tools.pause('beta'),
+            ]);
+            await tools.record(results.map(result => result.status === 'fulfilled'
+              ? result.value : result.reason.message));
+          } finally { await tools.record('cleanup'); }
+        `,
+        sourceType,
+      };
+      const interrupted = await run(input);
+      expect(interrupted).toMatchObject({
+        interruptions: [{ arguments: ['alpha'] }, { arguments: ['beta'] }],
+        status: 'interrupted',
+      });
+      expect(record.mock.calls).toEqual([]);
+      expect(ready).toHaveBeenCalledTimes(1);
+      expect(fail).toHaveBeenCalledTimes(1);
+      if (interrupted.status !== 'interrupted') {
+        throw new Error(
+          'Expected both pending calls to interrupt the same invocation.',
+        );
+      }
+      expect(interrupted.interruptions).toHaveLength(2);
+      const result = await run({
+        ...input,
+        continuation: interrupted.continuation,
+        resolutions: interrupted.interruptions.toReversed().map(item => ({
+          interruptionId: item.id,
+          value: `${item.arguments[0]} resolved`,
+        })),
+      });
+      expect(result).toEqual({ status: 'completed', value: undefined });
+      expect(record.mock.calls).toEqual([
+        [
+          [
+            'already completed',
+            'alpha resolved',
+            'Host function failed.',
+            'beta resolved',
+          ],
+        ],
+        ['cleanup'],
+      ]);
+      expect(ready).toHaveBeenCalledTimes(1);
+      expect(fail).toHaveBeenCalledTimes(1);
+      expect(pause.mock.calls).toEqual([
+        ['alpha'],
+        ['beta'],
+        ['alpha'],
+        ['beta'],
+      ]);
+    });
+
+    it.each(['return', 'throw'])(
+      'defers a finally %s override until after resume',
+      async override => {
+        const record = vi.fn();
+        const input = {
+          hostFunctions: {
+            tools: {
+              pause: () => {
+                const context = getHostFunctionContext();
+                if (context.resume === undefined) {
+                  context.interrupt({ kind: 'pause' });
+                }
+                return context.resume?.resolution;
+              },
+              record,
+            },
+          },
+          limits: { timeoutMs: 1000 },
+          source: `
+            async function task() {
+              try { return await tools.pause(); }
+              finally {
+                await tools.record('cleanup');
+                ${override === 'throw' ? "throw new Error('cleanup failure');" : "return 'cleanup value';"}
+              }
+            }
+            await tools.record(await task());
+          `,
+          sourceType,
+        };
+        const interrupted = await run(input);
+        expect(interrupted.status).toBe('interrupted');
+        expect(record.mock.calls).toEqual([]);
+        if (interrupted.status !== 'interrupted') {
+          throw new Error('Expected suspension before the finally override.');
+        }
+        const resumed = run({
+          ...input,
+          continuation: interrupted.continuation,
+          resolutions: interrupted.interruptions.map(item => ({
+            interruptionId: item.id,
+            value: 'original value',
+          })),
+        });
+        if (override === 'throw') {
+          await expect(resumed).rejects.toMatchObject({
+            message: 'cleanup failure',
+          });
+          expect(record.mock.calls).toEqual([['cleanup']]);
+        } else {
+          await expect(resumed).resolves.toEqual({
+            status: 'completed',
+            value: undefined,
+          });
+          expect(record.mock.calls).toEqual([['cleanup'], ['cleanup value']]);
+        }
+      },
+    );
   },
 );
 

--- a/packages/run/src/suspension.test.ts
+++ b/packages/run/src/suspension.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRunner, getHostFunctionContext, run } from './index.js';
+import { getRuntimeDiagnostics } from './runtime/manager.js';
+
+describe.each(['function-body', 'module'] as const)(
+  'suspending guest exception handlers (%s)',
+  sourceType => {
+    it.each([
+      'try { await tools.pause(); } catch { for (let i = 0; i < 100000; i++) {} }',
+      'try { await tools.pause(); } finally { for (let i = 0; i < 100000; i++) {} }',
+      `for (let i = 0; i < 4; i++) {
+      try { await tools.pause(); }
+      catch { try { await tools.pause(); } catch { continue; } }
+    }`,
+    ])('returns a continuation and resumes %s', async source => {
+      const effect = vi.fn(() => 'created');
+      const pause = vi.fn(() => {
+        const context = getHostFunctionContext();
+        if (context.resume === undefined) {
+          context.interrupt({ kind: 'pause' });
+        }
+        return context.resume?.resolution;
+      });
+      const input = {
+        hostFunctions: { tools: { effect, pause } },
+        limits: { timeoutMs: 1000 },
+        source: `await tools.effect(); ${source}; ${sourceType === 'function-body' ? 'return 42;' : ''}`,
+        sourceType,
+      };
+      let result = await run(input);
+      let rounds = 0;
+      while (result.status === 'interrupted') {
+        expect(getRuntimeDiagnostics()).toMatchObject({
+          activeInvocations: 0,
+          idleWorkers: 1,
+          terminatingWorkers: 0,
+        });
+        rounds += 1;
+        expect(rounds).toBeLessThanOrEqual(4);
+        result = await run({
+          ...input,
+          continuation: result.continuation,
+          resolutions: result.interruptions.map(interruption => ({
+            interruptionId: interruption.id,
+            value: true,
+          })),
+        });
+      }
+      expect(rounds).toBeGreaterThan(0);
+      expect(result).toEqual({
+        status: 'completed',
+        value: sourceType === 'function-body' ? 42 : undefined,
+      });
+      expect(effect).toHaveBeenCalledTimes(1);
+      expect(pause).toHaveBeenCalledTimes(rounds * 2);
+    });
+
+    it('runs finally host effects only after resuming the interrupted call', async () => {
+      const cleanup = vi.fn(() => 'cleaned');
+      const input = {
+        hostFunctions: {
+          tools: {
+            cleanup,
+            pause: () => {
+              const context = getHostFunctionContext();
+              if (context.resume === undefined) {
+                context.interrupt({ kind: 'pause' });
+              }
+              return context.resume?.resolution;
+            },
+          },
+        },
+        source: `try { ${sourceType === 'function-body' ? 'return ' : ''}await tools.pause(); } finally { await tools.cleanup(); }`,
+        sourceType,
+      };
+      const interrupted = await run(input);
+      expect(interrupted.status).toBe('interrupted');
+      expect(cleanup).not.toHaveBeenCalled();
+      if (interrupted.status !== 'interrupted') {
+        throw new Error('Expected an interruption.');
+      }
+      await expect(
+        run({
+          ...input,
+          continuation: interrupted.continuation,
+          resolutions: interrupted.interruptions.map(interruption => ({
+            interruptionId: interruption.id,
+            value: 42,
+          })),
+        }),
+      ).resolves.toEqual({
+        status: 'completed',
+        value: sourceType === 'function-body' ? 42 : undefined,
+      });
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+  },
+);
+
+describe('resuming repeated host calls', () => {
+  it.each([
+    'for (let i = 0; i < 40; i++) { await tools.alpha({ i }); } return 40;',
+    'const a = []; for (let i = 0; i < 40; i++) { a.push(await tools.alpha({ i })); } return a.length;',
+  ])('completes 40 resumptions: %s', async source => {
+    const alpha = vi.fn(() => {
+      const context = getHostFunctionContext();
+      if (context.resume === undefined) {
+        context.interrupt({});
+      }
+      return context.resume?.resolution;
+    });
+    const input = {
+      hostFunctions: { tools: { alpha } },
+      limits: { timeoutMs: 1000 },
+      source,
+    };
+    let resumeInput = {};
+    for (let round = 1; round <= 41; round += 1) {
+      const runner = createRunner({ continuationSecret: 'x'.repeat(48) });
+      const result = await runner.run({ ...input, ...resumeInput });
+      if (result.status === 'completed') {
+        expect(round).toBe(41);
+        expect(result.value).toBe(40);
+        expect(alpha).toHaveBeenCalledTimes(80);
+        return;
+      }
+      resumeInput = {
+        continuation: result.continuation,
+        resolutions: result.interruptions.map(interruption => ({
+          interruptionId: interruption.id,
+          value: 1,
+        })),
+      };
+    }
+    throw new Error('Expected completion after 40 resumptions.');
+  });
+});
+
+describe('guest source error provenance', () => {
+  it.each([
+    'return (;',
+    "throw new Error('guest failure');",
+    "throw 'guest primitive';",
+    "throw Object.assign(new Error('guest failure'), { code: 'RUN_PROTOCOL_ERROR' });",
+  ])('marks a guest failure without trusting its code: %s', async source => {
+    await expect(run({ source })).rejects.toMatchObject({
+      code: 'RUN_USER_SOURCE_ERROR',
+    });
+  });
+
+  it('preserves an actual host failure and a real CPU timeout', async () => {
+    await expect(
+      run({
+        hostFunctions: {
+          tools: {
+            fail: () => {
+              throw new Error('host failure');
+            },
+          },
+        },
+        source: 'return await tools.fail();',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_HOST_FUNCTION_ERROR' });
+    await expect(
+      run({
+        limits: { timeoutMs: 100 },
+        source: 'while (true) {}',
+      }),
+    ).rejects.toMatchObject({ code: 'RUN_TIMEOUT' });
+    await expect(run({ source: 'return 42;' })).resolves.toMatchObject({
+      status: 'completed',
+      value: 42,
+    });
+  });
+});


### PR DESCRIPTION
The suspension repro times out after **30s** on `run@2.1.3`; this patch completes interrupt/resume in **14ms**. Fixes #64 and #63.

- **Suspension:** cancellation currently rejects guest promises and waits for their handlers during teardown. Instead, stop guest execution and dispose the context, allowing the worker to report `ready` and return the continuation. Replay and settled host effects stay unchanged.
- **Error classification:** uncaught guest failures now return `RUN_USER_SOURCE_ERROR`. Guest-authored codes are replaced; trusted host/runtime codes remain intact. This identifies error origin, not whether to retry.

**Tests:** 33 suspension/error cases pass, including Promise callbacks, cleanup across resumptions, parallel results, and return/throw overrides. On the unpatched base, 11 time out and four fail the new error-code assertions. Full suite: **364 passing**; typechecks, lint and formatting pass.

Includes docs and a changeset; no dependency or generated-bundle changes. [Reproducer, raw results, and flow diagram](https://github.com/vercel-labs/run/issues/64).
