### PR TITLE
docs: render API reference definitions as tables

### DIFF
--- a/content/docs/reference/create-runner.mdx
+++ b/content/docs/reference/create-runner.mdx
@@ -35,176 +35,223 @@ import { createRunner } from 'run';
 
 ### Type Parameters
 
-```json
-[
-  {
-    "name": "TOKEN",
-    "type": "unknown",
-    "isOptional": true,
-    "description": "The token type produced and consumed by the continuation codec. Default: string."
-  }
-]
-```
+<TypeTable
+  type={{
+    TOKEN: {
+      type: 'unknown',
+      typeDescription: 'unknown',
+      required: false,
+      description:
+        'The token type produced and consumed by the continuation codec. Default: string.',
+    },
+  }}
+/>
 
 ### Parameters
 
-```json
-[
-  {
-    "name": "limits",
-    "type": "RunLimits",
-    "isOptional": true,
-    "description": "Shared resource limits. Per-run limits override these values.",
-    "properties": [
-      {
-        "type": "RunLimits",
-        "parameters": [
-          {
-            "name": "timeoutMs",
-            "type": "number",
-            "isOptional": true,
-            "description": "Invocation timeout in milliseconds. Default: 30000."
-          },
-          {
-            "name": "memoryLimitBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "QuickJS memory limit in bytes. Default: 67108864."
-          },
-          {
-            "name": "maxStackSizeBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "QuickJS stack limit in bytes. Default: 2097152."
-          },
-          {
-            "name": "maxResultBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized result size in bytes. Default: 1048576."
-          },
-          {
-            "name": "maxConsoleOutputBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum console output in bytes. Default: 65536."
-          },
-          {
-            "name": "maxSourceBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum source size in bytes. Default: 262144."
-          },
-          {
-            "name": "maxHostFunctionArgumentsBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized arguments for one host function request in bytes. Default: 1048576."
-          },
-          {
-            "name": "maxHostFunctionOutputBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized host function output or interruption payload in bytes. Default: 4194304."
-          },
-          {
-            "name": "maxBridgeRequests",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum bridge requests in one invocation. Default: 256."
-          },
-          {
-            "name": "maxInFlightBridgeRequests",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum bridge requests in flight at once. Default: 32."
-          },
-          {
-            "name": "maxContinuationBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized continuation state in bytes. Default: 33554432."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "syncHostFunctions",
-    "type": "SyncHostFunctions",
-    "isOptional": true,
-    "description": "Host function groups exposed with synchronous guest call semantics. Calls must settle to serializable values, cannot interrupt, and share maxBridgeRequests with asynchronous host functions. Default: {}.",
-    "properties": [
-      {
-        "type": "SyncHostFunctions",
-        "parameters": [
-          {
-            "name": "[groupName]",
-            "type": "HostFunctionGroup",
-            "description": "A synchronous binding namespace. It cannot overlap an asynchronous host-function namespace."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "continuationSecret",
-    "type": "string | Uint8Array",
-    "isOptional": true,
-    "description": "The HMAC key used by the default signed continuation codec. Must contain at least 32 bytes. Defaults to RUN_CONTINUATION_SECRET. Cannot be combined with continuationCodec."
-  },
-  {
-    "name": "continuationCodec",
-    "type": "ContinuationCodec<TOKEN>",
-    "isOptional": true,
-    "description": "A custom continuation encoder and decoder. Cannot be combined with continuationSecret.",
-    "properties": [
-      {
-        "type": "ContinuationCodec<TOKEN>",
-        "parameters": [
-          {
-            "name": "encode",
-            "type": "(state: RunContinuationState, context?: ContinuationOperationContext) => TOKEN | Promise<TOKEN>",
-            "description": "Encodes replay state into a continuation token."
-          },
-          {
-            "name": "decode",
-            "type": "(token: TOKEN, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>",
-            "description": "Decodes a continuation token into replay state."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "continuationAudience",
-    "type": "string",
-    "isOptional": true,
-    "description": "The authenticated application or endpoint audience for every continuation. Must contain between 1 and 512 bytes. Default: 'run'."
-  }
-]
-```
+<TypeTable
+  type={{
+    limits: {
+      type: 'RunLimits',
+      typeDescription: 'RunLimits',
+      required: false,
+      description: (
+        <>
+          <p>
+            {'Shared resource limits. Per-run limits override these values.'}
+          </p>
+          <p>
+            <code>{'RunLimits'}</code>
+          </p>
+          <TypeTable
+            type={{
+              timeoutMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Invocation timeout in milliseconds. Default: 30000.',
+              },
+              memoryLimitBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'QuickJS memory limit in bytes. Default: 67108864.',
+              },
+              maxStackSizeBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'QuickJS stack limit in bytes. Default: 2097152.',
+              },
+              maxResultBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized result size in bytes. Default: 1048576.',
+              },
+              maxConsoleOutputBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Maximum console output in bytes. Default: 65536.',
+              },
+              maxSourceBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Maximum source size in bytes. Default: 262144.',
+              },
+              maxHostFunctionArgumentsBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized arguments for one host function request in bytes. Default: 1048576.',
+              },
+              maxHostFunctionOutputBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized host function output or interruption payload in bytes. Default: 4194304.',
+              },
+              maxBridgeRequests: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum bridge requests in one invocation. Default: 256.',
+              },
+              maxInFlightBridgeRequests: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum bridge requests in flight at once. Default: 32.',
+              },
+              maxContinuationBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized continuation state in bytes. Default: 33554432.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    syncHostFunctions: {
+      type: 'SyncHostFunctions',
+      typeDescription: 'SyncHostFunctions',
+      required: false,
+      description: (
+        <>
+          <p>
+            {
+              'Host function groups exposed with synchronous guest call semantics. Calls must settle to serializable values, cannot interrupt, and share maxBridgeRequests with asynchronous host functions. Default: {}.'
+            }
+          </p>
+          <p>
+            <code>{'SyncHostFunctions'}</code>
+          </p>
+          <TypeTable
+            type={{
+              '[groupName]': {
+                type: 'HostFunctionGroup',
+                typeDescription: 'HostFunctionGroup',
+                required: true,
+                description:
+                  'A synchronous binding namespace. It cannot overlap an asynchronous host-function namespace.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    continuationSecret: {
+      type: 'string | Uint8Array',
+      typeDescription: 'string | Uint8Array',
+      required: false,
+      description:
+        'The HMAC key used by the default signed continuation codec. Must contain at least 32 bytes. Defaults to RUN_CONTINUATION_SECRET. Cannot be combined with continuationCodec.',
+    },
+    continuationCodec: {
+      type: 'ContinuationCodec<TOKEN>',
+      typeDescription: 'ContinuationCodec<TOKEN>',
+      required: false,
+      description: (
+        <>
+          <p>
+            {
+              'A custom continuation encoder and decoder. Cannot be combined with continuationSecret.'
+            }
+          </p>
+          <p>
+            <code>{'ContinuationCodec<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              encode: {
+                type: '(state: RunContinuationState, context?: ContinuationOperationContext) => TOKEN | Promise<TOKEN>',
+                typeDescription:
+                  '(state: RunContinuationState, context?: ContinuationOperationContext) => TOKEN | Promise<TOKEN>',
+                required: true,
+                description: 'Encodes replay state into a continuation token.',
+              },
+              decode: {
+                type: '(token: TOKEN, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                typeDescription:
+                  '(token: TOKEN, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                required: true,
+                description: 'Decodes a continuation token into replay state.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    continuationAudience: {
+      type: 'string',
+      typeDescription: 'string',
+      required: false,
+      description:
+        "The authenticated application or endpoint audience for every continuation. Must contain between 1 and 512 bytes. Default: 'run'.",
+    },
+  }}
+/>
 
 ### Returns
 
-```json
-[
-  {
-    "name": "runner",
-    "type": "Runner<TOKEN>",
-    "description": "A reusable configured runner.",
-    "properties": [
-      {
-        "type": "Runner<TOKEN>",
-        "parameters": [
-          {
-            "name": "run",
-            "type": "<OUTPUT = unknown>(input: RunInput<TOKEN>) => Promise<RunResult<OUTPUT, TOKEN>>",
-            "description": "Executes source in a fresh sandbox using the runner defaults."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    runner: {
+      type: 'Runner<TOKEN>',
+      typeDescription: 'Runner<TOKEN>',
+      required: true,
+      description: (
+        <>
+          <p>{'A reusable configured runner.'}</p>
+          <p>
+            <code>{'Runner<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              run: {
+                type: '<OUTPUT = unknown>(input: RunInput<TOKEN>) => Promise<RunResult<OUTPUT, TOKEN>>',
+                typeDescription:
+                  '<OUTPUT = unknown>(input: RunInput<TOKEN>) => Promise<RunResult<OUTPUT, TOKEN>>',
+                required: true,
+                description:
+                  'Executes source in a fresh sandbox using the runner defaults.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/create-signed-continuation-codec.mdx
+++ b/content/docs/reference/create-signed-continuation-codec.mdx
@@ -34,125 +34,155 @@ import { createSignedContinuationCodec } from 'run';
 
 ### Parameters
 
-```json
-[
-  {
-    "name": "secret",
-    "type": "string | Uint8Array",
-    "description": "The primary HMAC key used to create and verify tokens. Must contain at least 32 bytes."
-  },
-  {
-    "name": "verificationSecrets",
-    "type": "(string | Uint8Array)[]",
-    "isOptional": true,
-    "description": "Previous HMAC keys accepted only when verifying tokens. Default: []."
-  },
-  {
-    "name": "maxAgeMs",
-    "type": "number",
-    "isOptional": true,
-    "description": "The maximum token lifetime in milliseconds. Must be a positive integer. Default: 3600000."
-  },
-  {
-    "name": "maxTokenBytes",
-    "type": "number",
-    "isOptional": true,
-    "description": "The maximum encoded token size in bytes. Must be a positive integer. Default: 33554432."
-  },
-  {
-    "name": "clockSkewMs",
-    "type": "number",
-    "isOptional": true,
-    "description": "The allowed positive clock skew during issued-at validation. Must be a non-negative integer. Default: 60000."
-  }
-]
-```
+<TypeTable
+  type={{
+    secret: {
+      type: 'string | Uint8Array',
+      typeDescription: 'string | Uint8Array',
+      required: true,
+      description:
+        'The primary HMAC key used to create and verify tokens. Must contain at least 32 bytes.',
+    },
+    verificationSecrets: {
+      type: '(string | Uint8Array)[]',
+      typeDescription: '(string | Uint8Array)[]',
+      required: false,
+      description:
+        'Previous HMAC keys accepted only when verifying tokens. Default: [].',
+    },
+    maxAgeMs: {
+      type: 'number',
+      typeDescription: 'number',
+      required: false,
+      description:
+        'The maximum token lifetime in milliseconds. Must be a positive integer. Default: 3600000.',
+    },
+    maxTokenBytes: {
+      type: 'number',
+      typeDescription: 'number',
+      required: false,
+      description:
+        'The maximum encoded token size in bytes. Must be a positive integer. Default: 33554432.',
+    },
+    clockSkewMs: {
+      type: 'number',
+      typeDescription: 'number',
+      required: false,
+      description:
+        'The allowed positive clock skew during issued-at validation. Must be a non-negative integer. Default: 60000.',
+    },
+  }}
+/>
 
 ### Returns
 
-```json
-[
-  {
-    "name": "codec",
-    "type": "ContinuationCodec<string>",
-    "description": "A signed string continuation codec.",
-    "properties": [
-      {
-        "type": "ContinuationCodec<string>",
-        "parameters": [
-          {
-            "name": "encode",
-            "type": "(state: RunContinuationState, context?: ContinuationOperationContext) => string | Promise<string>",
-            "description": "Encodes replay state into a signed string token."
-          },
-          {
-            "name": "decode",
-            "type": "(token: string, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>",
-            "description": "Verifies and decodes a signed string token."
-          }
-        ]
-      },
-      {
-        "type": "ContinuationOperationContext",
-        "parameters": [
-          {
-            "name": "abortSignal",
-            "type": "AbortSignal",
-            "description": "The signal for the continuation operation."
-          },
-          {
-            "name": "deadlineMs",
-            "type": "number",
-            "description": "The operation deadline as a Unix timestamp in milliseconds."
-          }
-        ]
-      },
-      {
-        "type": "RunContinuationState",
-        "parameters": [
-          {
-            "name": "version",
-            "type": "2",
-            "description": "The continuation state version."
-          },
-          {
-            "name": "runtime",
-            "type": "'run-replay-v2'",
-            "description": "The replay runtime identifier."
-          },
-          {
-            "name": "serde",
-            "type": "'run-js-v1'",
-            "description": "The serialization format identifier."
-          },
-          {
-            "name": "source",
-            "type": "string",
-            "description": "The source associated with the continuation."
-          },
-          {
-            "name": "logicalRunId",
-            "type": "string",
-            "description": "The logical run identifier."
-          },
-          {
-            "name": "scopeHash",
-            "type": "string",
-            "description": "The authenticated continuation scope hash."
-          },
-          {
-            "name": "determinism",
-            "type": "{ dateNowMs: number; randomSeed: string }",
-            "description": "The deterministic clock and random seed."
-          },
-          {
-            "name": "ledger",
-            "type": "RunLedgerEntry[]",
-            "description": "The recorded host function outcomes."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    codec: {
+      type: 'ContinuationCodec<string>',
+      typeDescription: 'ContinuationCodec<string>',
+      required: true,
+      description: (
+        <>
+          <p>{'A signed string continuation codec.'}</p>
+          <p>
+            <code>{'ContinuationCodec<string>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              encode: {
+                type: '(state: RunContinuationState, context?: ContinuationOperationContext) => string | Promise<string>',
+                typeDescription:
+                  '(state: RunContinuationState, context?: ContinuationOperationContext) => string | Promise<string>',
+                required: true,
+                description: 'Encodes replay state into a signed string token.',
+              },
+              decode: {
+                type: '(token: string, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                typeDescription:
+                  '(token: string, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                required: true,
+                description: 'Verifies and decodes a signed string token.',
+              },
+            }}
+          />
+          <p>
+            <code>{'ContinuationOperationContext'}</code>
+          </p>
+          <TypeTable
+            type={{
+              abortSignal: {
+                type: 'AbortSignal',
+                typeDescription: 'AbortSignal',
+                required: true,
+                description: 'The signal for the continuation operation.',
+              },
+              deadlineMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description:
+                  'The operation deadline as a Unix timestamp in milliseconds.',
+              },
+            }}
+          />
+          <p>
+            <code>{'RunContinuationState'}</code>
+          </p>
+          <TypeTable
+            type={{
+              version: {
+                type: '2',
+                typeDescription: '2',
+                required: true,
+                description: 'The continuation state version.',
+              },
+              runtime: {
+                type: "'run-replay-v2'",
+                typeDescription: "'run-replay-v2'",
+                required: true,
+                description: 'The replay runtime identifier.',
+              },
+              serde: {
+                type: "'run-js-v1'",
+                typeDescription: "'run-js-v1'",
+                required: true,
+                description: 'The serialization format identifier.',
+              },
+              source: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The source associated with the continuation.',
+              },
+              logicalRunId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The logical run identifier.',
+              },
+              scopeHash: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The authenticated continuation scope hash.',
+              },
+              determinism: {
+                type: '{ dateNowMs: number; randomSeed: string }',
+                typeDescription: '{ dateNowMs: number; randomSeed: string }',
+                required: true,
+                description: 'The deterministic clock and random seed.',
+              },
+              ledger: {
+                type: 'RunLedgerEntry[]',
+                typeDescription: 'RunLedgerEntry[]',
+                required: true,
+                description: 'The recorded host function outcomes.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/create-stored-continuation-codec.mdx
+++ b/content/docs/reference/create-stored-continuation-codec.mdx
@@ -51,149 +51,201 @@ import { createStoredContinuationCodec } from 'run';
 
 ### Parameters
 
-```json
-[
-  {
-    "name": "storage",
-    "type": "ContinuationStorage",
-    "description": "The storage adapter used to save, temporarily claim, and atomically consume continuation state.",
-    "properties": [
-      {
-        "type": "ContinuationStorage",
-        "parameters": [
-          {
-            "name": "set",
-            "type": "(key: string, value: StoredContinuation, context?: ContinuationOperationContext) => void | Promise<void>",
-            "description": "Stores a continuation under the generated key."
-          },
-          {
-            "name": "acquire",
-            "type": "(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>",
-            "description": "Atomically creates a temporary claim on a continuation without removing it."
-          },
-          {
-            "name": "consume",
-            "type": "(key: string, claimId: string) => void | Promise<void>",
-            "description": "Atomically removes a continuation when its claim identifier matches."
-          },
-          {
-            "name": "release",
-            "type": "(key: string, claimId: string) => void | Promise<void>",
-            "description": "Atomically releases a continuation when its claim identifier matches."
-          }
-        ]
-      },
-      {
-        "type": "StoredContinuation",
-        "parameters": [
-          {
-            "name": "state",
-            "type": "RunContinuationState",
-            "description": "The serializable replay state."
-          },
-          {
-            "name": "expiresAtMs",
-            "type": "number",
-            "description": "The expiration time as a Unix timestamp in milliseconds."
-          }
-        ]
-      },
-      {
-        "type": "ContinuationOperationContext",
-        "parameters": [
-          {
-            "name": "abortSignal",
-            "type": "AbortSignal",
-            "description": "The signal for the continuation operation."
-          },
-          {
-            "name": "deadlineMs",
-            "type": "number",
-            "description": "The operation deadline as a Unix timestamp in milliseconds."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "maxAgeMs",
-    "type": "number",
-    "isOptional": true,
-    "description": "The lifetime assigned to stored continuations in milliseconds. Must be a positive integer. Default: 3600000."
-  }
-]
-```
+<TypeTable
+  type={{
+    storage: {
+      type: 'ContinuationStorage',
+      typeDescription: 'ContinuationStorage',
+      required: true,
+      description: (
+        <>
+          <p>
+            {
+              'The storage adapter used to save, temporarily claim, and atomically consume continuation state.'
+            }
+          </p>
+          <p>
+            <code>{'ContinuationStorage'}</code>
+          </p>
+          <TypeTable
+            type={{
+              set: {
+                type: '(key: string, value: StoredContinuation, context?: ContinuationOperationContext) => void | Promise<void>',
+                typeDescription:
+                  '(key: string, value: StoredContinuation, context?: ContinuationOperationContext) => void | Promise<void>',
+                required: true,
+                description: 'Stores a continuation under the generated key.',
+              },
+              acquire: {
+                type: '(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>',
+                typeDescription:
+                  '(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>',
+                required: true,
+                description:
+                  'Atomically creates a temporary claim on a continuation without removing it.',
+              },
+              consume: {
+                type: '(key: string, claimId: string) => void | Promise<void>',
+                typeDescription:
+                  '(key: string, claimId: string) => void | Promise<void>',
+                required: true,
+                description:
+                  'Atomically removes a continuation when its claim identifier matches.',
+              },
+              release: {
+                type: '(key: string, claimId: string) => void | Promise<void>',
+                typeDescription:
+                  '(key: string, claimId: string) => void | Promise<void>',
+                required: true,
+                description:
+                  'Atomically releases a continuation when its claim identifier matches.',
+              },
+            }}
+          />
+          <p>
+            <code>{'StoredContinuation'}</code>
+          </p>
+          <TypeTable
+            type={{
+              state: {
+                type: 'RunContinuationState',
+                typeDescription: 'RunContinuationState',
+                required: true,
+                description: 'The serializable replay state.',
+              },
+              expiresAtMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description:
+                  'The expiration time as a Unix timestamp in milliseconds.',
+              },
+            }}
+          />
+          <p>
+            <code>{'ContinuationOperationContext'}</code>
+          </p>
+          <TypeTable
+            type={{
+              abortSignal: {
+                type: 'AbortSignal',
+                typeDescription: 'AbortSignal',
+                required: true,
+                description: 'The signal for the continuation operation.',
+              },
+              deadlineMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description:
+                  'The operation deadline as a Unix timestamp in milliseconds.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    maxAgeMs: {
+      type: 'number',
+      typeDescription: 'number',
+      required: false,
+      description:
+        'The lifetime assigned to stored continuations in milliseconds. Must be a positive integer. Default: 3600000.',
+    },
+  }}
+/>
 
 ### Returns
 
-```json
-[
-  {
-    "name": "codec",
-    "type": "ContinuationCodec<string>",
-    "description": "A storage-backed string continuation codec.",
-    "properties": [
-      {
-        "type": "ContinuationCodec<string>",
-        "parameters": [
-          {
-            "name": "encode",
-            "type": "(state: RunContinuationState, context?: ContinuationOperationContext) => string | Promise<string>",
-            "description": "Stores replay state and returns a random base64url key."
-          },
-          {
-            "name": "decode",
-            "type": "(key: string, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>",
-            "description": "Atomically consumes the stored continuation and returns its replay state."
-          }
-        ]
-      },
-      {
-        "type": "RunContinuationState",
-        "parameters": [
-          {
-            "name": "version",
-            "type": "2",
-            "description": "The continuation state version."
-          },
-          {
-            "name": "runtime",
-            "type": "'run-replay-v2'",
-            "description": "The replay runtime identifier."
-          },
-          {
-            "name": "serde",
-            "type": "'run-js-v1'",
-            "description": "The serialization format identifier."
-          },
-          {
-            "name": "source",
-            "type": "string",
-            "description": "The source associated with the continuation."
-          },
-          {
-            "name": "logicalRunId",
-            "type": "string",
-            "description": "The logical run identifier."
-          },
-          {
-            "name": "scopeHash",
-            "type": "string",
-            "description": "The authenticated continuation scope hash."
-          },
-          {
-            "name": "determinism",
-            "type": "{ dateNowMs: number; randomSeed: string }",
-            "description": "The deterministic clock and random seed."
-          },
-          {
-            "name": "ledger",
-            "type": "RunLedgerEntry[]",
-            "description": "The recorded host function outcomes."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    codec: {
+      type: 'ContinuationCodec<string>',
+      typeDescription: 'ContinuationCodec<string>',
+      required: true,
+      description: (
+        <>
+          <p>{'A storage-backed string continuation codec.'}</p>
+          <p>
+            <code>{'ContinuationCodec<string>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              encode: {
+                type: '(state: RunContinuationState, context?: ContinuationOperationContext) => string | Promise<string>',
+                typeDescription:
+                  '(state: RunContinuationState, context?: ContinuationOperationContext) => string | Promise<string>',
+                required: true,
+                description:
+                  'Stores replay state and returns a random base64url key.',
+              },
+              decode: {
+                type: '(key: string, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                typeDescription:
+                  '(key: string, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                required: true,
+                description:
+                  'Atomically consumes the stored continuation and returns its replay state.',
+              },
+            }}
+          />
+          <p>
+            <code>{'RunContinuationState'}</code>
+          </p>
+          <TypeTable
+            type={{
+              version: {
+                type: '2',
+                typeDescription: '2',
+                required: true,
+                description: 'The continuation state version.',
+              },
+              runtime: {
+                type: "'run-replay-v2'",
+                typeDescription: "'run-replay-v2'",
+                required: true,
+                description: 'The replay runtime identifier.',
+              },
+              serde: {
+                type: "'run-js-v1'",
+                typeDescription: "'run-js-v1'",
+                required: true,
+                description: 'The serialization format identifier.',
+              },
+              source: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The source associated with the continuation.',
+              },
+              logicalRunId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The logical run identifier.',
+              },
+              scopeHash: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The authenticated continuation scope hash.',
+              },
+              determinism: {
+                type: '{ dateNowMs: number; randomSeed: string }',
+                typeDescription: '{ dateNowMs: number; randomSeed: string }',
+                required: true,
+                description: 'The deterministic clock and random seed.',
+              },
+              ledger: {
+                type: 'RunLedgerEntry[]',
+                typeDescription: 'RunLedgerEntry[]',
+                required: true,
+                description: 'The recorded host function outcomes.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/errors.mdx
+++ b/content/docs/reference/errors.mdx
@@ -39,231 +39,320 @@ import {
 
 ### Classes
 
-```json
-[
-  {
-    "name": "RunError",
-    "type": "Error",
-    "description": "The base class for errors raised by the JavaScript runtime.",
-    "properties": [
-      {
-        "type": "RunError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(message: string, code?: string, details?: unknown) => RunError",
-            "description": "Creates a RunError. The default code is 'RUN_ERROR'."
-          },
-          {
-            "name": "code",
-            "type": "string",
-            "description": "The stable machine-readable error code."
-          },
-          {
-            "name": "details",
-            "type": "unknown",
-            "isOptional": true,
-            "description": "Optional structured diagnostic details."
-          },
-          {
-            "name": "isInstance",
-            "type": "(error: unknown) => error is RunError",
-            "description": "Identifies RunError instances across duplicate package copies."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunAbortedError",
-    "type": "RunError",
-    "description": "Raised when the caller's abort signal aborts a run invocation.",
-    "properties": [
-      {
-        "type": "RunAbortedError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "() => RunAbortedError",
-            "description": "Creates a RunAbortedError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_ABORTED'",
-            "description": "The stable error code."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunHostFunctionError",
-    "type": "RunError",
-    "description": "The base class for failures caused by nested host function execution.",
-    "properties": [
-      {
-        "type": "RunHostFunctionError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(message: string, details?: unknown) => RunHostFunctionError",
-            "description": "Creates a RunHostFunctionError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_HOST_FUNCTION_ERROR'",
-            "description": "The stable error code."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunBridgeLimitError",
-    "type": "RunError",
-    "description": "Raised when sandboxed code exceeds bridge request limits.",
-    "properties": [
-      {
-        "type": "RunBridgeLimitError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(message: string, details?: unknown) => RunBridgeLimitError",
-            "description": "Creates a RunBridgeLimitError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_BRIDGE_LIMIT'",
-            "description": "The stable error code."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunConcurrencyError",
-    "type": "RunError",
-    "description": "Raised when the process-global worker cap has been reached.",
-    "properties": [
-      {
-        "type": "RunConcurrencyError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(maxWorkers: number) => RunConcurrencyError",
-            "description": "Creates a RunConcurrencyError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_CONCURRENCY_LIMIT'",
-            "description": "The stable error code."
-          },
-          {
-            "name": "details",
-            "type": "{ maxWorkers: number }",
-            "description": "The configured worker cap."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunDetachedBridgeRequestError",
-    "type": "RunError",
-    "description": "Raised when sandboxed code returns with detached host bridge work.",
-    "properties": [
-      {
-        "type": "RunDetachedBridgeRequestError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(message: string, details?: unknown) => RunDetachedBridgeRequestError",
-            "description": "Creates a RunDetachedBridgeRequestError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_DETACHED_BRIDGE_REQUEST'",
-            "description": "The stable error code."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunProtocolError",
-    "type": "RunError",
-    "description": "Raised when the main thread and worker protocol observes an invalid or mismatched message.",
-    "properties": [
-      {
-        "type": "RunProtocolError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(message: string, details?: unknown) => RunProtocolError",
-            "description": "Creates a RunProtocolError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_PROTOCOL_ERROR'",
-            "description": "The stable error code."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunSourceTooLargeError",
-    "type": "RunError",
-    "description": "Raised when source exceeds limits.maxSourceBytes.",
-    "properties": [
-      {
-        "type": "RunSourceTooLargeError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(bytes: number, maxBytes: number) => RunSourceTooLargeError",
-            "description": "Creates a RunSourceTooLargeError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_SOURCE_TOO_LARGE'",
-            "description": "The stable error code."
-          },
-          {
-            "name": "details",
-            "type": "{ bytes: number; maxBytes: number }",
-            "description": "The source size and configured limit."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunTimeoutError",
-    "type": "RunError",
-    "description": "Raised when a sandbox invocation exceeds its timeout.",
-    "properties": [
-      {
-        "type": "RunTimeoutError",
-        "parameters": [
-          {
-            "name": "constructor",
-            "type": "(timeoutMs: number) => RunTimeoutError",
-            "description": "Creates a RunTimeoutError."
-          },
-          {
-            "name": "code",
-            "type": "'RUN_TIMEOUT'",
-            "description": "The stable error code."
-          },
-          {
-            "name": "details",
-            "type": "{ timeoutMs: number }",
-            "description": "The configured timeout in milliseconds."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    RunError: {
+      type: 'Error',
+      typeDescription: 'Error',
+      required: true,
+      description: (
+        <>
+          <p>{'The base class for errors raised by the JavaScript runtime.'}</p>
+          <p>
+            <code>{'RunError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(message: string, code?: string, details?: unknown) => RunError',
+                typeDescription:
+                  '(message: string, code?: string, details?: unknown) => RunError',
+                required: true,
+                description:
+                  "Creates a RunError. The default code is 'RUN_ERROR'.",
+              },
+              code: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The stable machine-readable error code.',
+              },
+              details: {
+                type: 'unknown',
+                typeDescription: 'unknown',
+                required: false,
+                description: 'Optional structured diagnostic details.',
+              },
+              isInstance: {
+                type: '(error: unknown) => error is RunError',
+                typeDescription: '(error: unknown) => error is RunError',
+                required: true,
+                description:
+                  'Identifies RunError instances across duplicate package copies.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunAbortedError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>
+            {"Raised when the caller's abort signal aborts a run invocation."}
+          </p>
+          <p>
+            <code>{'RunAbortedError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '() => RunAbortedError',
+                typeDescription: '() => RunAbortedError',
+                required: true,
+                description: 'Creates a RunAbortedError.',
+              },
+              code: {
+                type: "'RUN_ABORTED'",
+                typeDescription: "'RUN_ABORTED'",
+                required: true,
+                description: 'The stable error code.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunHostFunctionError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>
+            {
+              'The base class for failures caused by nested host function execution.'
+            }
+          </p>
+          <p>
+            <code>{'RunHostFunctionError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(message: string, details?: unknown) => RunHostFunctionError',
+                typeDescription:
+                  '(message: string, details?: unknown) => RunHostFunctionError',
+                required: true,
+                description: 'Creates a RunHostFunctionError.',
+              },
+              code: {
+                type: "'RUN_HOST_FUNCTION_ERROR'",
+                typeDescription: "'RUN_HOST_FUNCTION_ERROR'",
+                required: true,
+                description: 'The stable error code.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunBridgeLimitError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>{'Raised when sandboxed code exceeds bridge request limits.'}</p>
+          <p>
+            <code>{'RunBridgeLimitError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(message: string, details?: unknown) => RunBridgeLimitError',
+                typeDescription:
+                  '(message: string, details?: unknown) => RunBridgeLimitError',
+                required: true,
+                description: 'Creates a RunBridgeLimitError.',
+              },
+              code: {
+                type: "'RUN_BRIDGE_LIMIT'",
+                typeDescription: "'RUN_BRIDGE_LIMIT'",
+                required: true,
+                description: 'The stable error code.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunConcurrencyError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>{'Raised when the process-global worker cap has been reached.'}</p>
+          <p>
+            <code>{'RunConcurrencyError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(maxWorkers: number) => RunConcurrencyError',
+                typeDescription: '(maxWorkers: number) => RunConcurrencyError',
+                required: true,
+                description: 'Creates a RunConcurrencyError.',
+              },
+              code: {
+                type: "'RUN_CONCURRENCY_LIMIT'",
+                typeDescription: "'RUN_CONCURRENCY_LIMIT'",
+                required: true,
+                description: 'The stable error code.',
+              },
+              details: {
+                type: '{ maxWorkers: number }',
+                typeDescription: '{ maxWorkers: number }',
+                required: true,
+                description: 'The configured worker cap.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunDetachedBridgeRequestError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>
+            {
+              'Raised when sandboxed code returns with detached host bridge work.'
+            }
+          </p>
+          <p>
+            <code>{'RunDetachedBridgeRequestError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(message: string, details?: unknown) => RunDetachedBridgeRequestError',
+                typeDescription:
+                  '(message: string, details?: unknown) => RunDetachedBridgeRequestError',
+                required: true,
+                description: 'Creates a RunDetachedBridgeRequestError.',
+              },
+              code: {
+                type: "'RUN_DETACHED_BRIDGE_REQUEST'",
+                typeDescription: "'RUN_DETACHED_BRIDGE_REQUEST'",
+                required: true,
+                description: 'The stable error code.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunProtocolError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>
+            {
+              'Raised when the main thread and worker protocol observes an invalid or mismatched message.'
+            }
+          </p>
+          <p>
+            <code>{'RunProtocolError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(message: string, details?: unknown) => RunProtocolError',
+                typeDescription:
+                  '(message: string, details?: unknown) => RunProtocolError',
+                required: true,
+                description: 'Creates a RunProtocolError.',
+              },
+              code: {
+                type: "'RUN_PROTOCOL_ERROR'",
+                typeDescription: "'RUN_PROTOCOL_ERROR'",
+                required: true,
+                description: 'The stable error code.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunSourceTooLargeError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>{'Raised when source exceeds limits.maxSourceBytes.'}</p>
+          <p>
+            <code>{'RunSourceTooLargeError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(bytes: number, maxBytes: number) => RunSourceTooLargeError',
+                typeDescription:
+                  '(bytes: number, maxBytes: number) => RunSourceTooLargeError',
+                required: true,
+                description: 'Creates a RunSourceTooLargeError.',
+              },
+              code: {
+                type: "'RUN_SOURCE_TOO_LARGE'",
+                typeDescription: "'RUN_SOURCE_TOO_LARGE'",
+                required: true,
+                description: 'The stable error code.',
+              },
+              details: {
+                type: '{ bytes: number; maxBytes: number }',
+                typeDescription: '{ bytes: number; maxBytes: number }',
+                required: true,
+                description: 'The source size and configured limit.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunTimeoutError: {
+      type: 'RunError',
+      typeDescription: 'RunError',
+      required: true,
+      description: (
+        <>
+          <p>{'Raised when a sandbox invocation exceeds its timeout.'}</p>
+          <p>
+            <code>{'RunTimeoutError'}</code>
+          </p>
+          <TypeTable
+            type={{
+              constructor: {
+                type: '(timeoutMs: number) => RunTimeoutError',
+                typeDescription: '(timeoutMs: number) => RunTimeoutError',
+                required: true,
+                description: 'Creates a RunTimeoutError.',
+              },
+              code: {
+                type: "'RUN_TIMEOUT'",
+                typeDescription: "'RUN_TIMEOUT'",
+                required: true,
+                description: 'The stable error code.',
+              },
+              details: {
+                type: '{ timeoutMs: number }',
+                typeDescription: '{ timeoutMs: number }',
+                required: true,
+                description: 'The configured timeout in milliseconds.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/get-host-function-context.mdx
+++ b/content/docs/reference/get-host-function-context.mdx
@@ -34,88 +34,120 @@ import { getHostFunctionContext } from 'run';
 
 ### Parameters
 
-```json
-[]
-```
+This function takes no parameters.
 
 ### Returns
 
-```json
-[
-  {
-    "name": "context",
-    "type": "HostFunctionContext",
-    "description": "The context for the active host binding or module-loader call.",
-    "properties": [
-      {
-        "type": "HostFunctionContext",
-        "parameters": [
-          {
-            "name": "abortSignal",
-            "type": "AbortSignal",
-            "description": "A signal aborted when the run is aborted, times out, or fails."
-          },
-          {
-            "name": "invocationId",
-            "type": "string",
-            "description": "The stable identifier for the current run attempt."
-          },
-          {
-            "name": "logicalRunId",
-            "type": "string",
-            "description": "The stable identifier for the logical run across replay attempts."
-          },
-          {
-            "name": "requestId",
-            "type": "string",
-            "description": "The stable identifier for this host function request in the current attempt."
-          },
-          {
-            "name": "requestIndex",
-            "type": "number",
-            "description": "The one-based host function request order in the current attempt."
-          },
-          {
-            "name": "hostFunctionName",
-            "type": "string",
-            "description": "The fully qualified callback path, for example tools.search or moduleLoader.load."
-          },
-          {
-            "name": "interrupt",
-            "type": "(payload: unknown) => never",
-            "description": "Interrupts an asynchronous host function and suspends the run. Synchronous bindings and module loaders cannot interrupt."
-          },
-          {
-            "name": "resume",
-            "type": "HostFunctionResumeContext",
-            "isOptional": true,
-            "description": "Resume data available when an interrupted host function is invoked again.",
-            "properties": [
-              {
-                "type": "HostFunctionResumeContext",
-                "parameters": [
-                  {
-                    "name": "interruptionId",
-                    "type": "string",
-                    "description": "The ID of the interruption being resolved."
-                  },
-                  {
-                    "name": "payload",
-                    "type": "unknown",
-                    "description": "The original interruption payload."
-                  },
-                  {
-                    "name": "resolution",
-                    "type": "unknown",
-                    "description": "The application-defined resolution value."
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    context: {
+      type: 'HostFunctionContext',
+      typeDescription: 'HostFunctionContext',
+      required: true,
+      description: (
+        <>
+          <p>
+            {'The context for the active host binding or module-loader call.'}
+          </p>
+          <p>
+            <code>{'HostFunctionContext'}</code>
+          </p>
+          <TypeTable
+            type={{
+              abortSignal: {
+                type: 'AbortSignal',
+                typeDescription: 'AbortSignal',
+                required: true,
+                description:
+                  'A signal aborted when the run is aborted, times out, or fails.',
+              },
+              invocationId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The stable identifier for the current run attempt.',
+              },
+              logicalRunId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The stable identifier for the logical run across replay attempts.',
+              },
+              requestId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The stable identifier for this host function request in the current attempt.',
+              },
+              requestIndex: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description:
+                  'The one-based host function request order in the current attempt.',
+              },
+              hostFunctionName: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The fully qualified callback path, for example tools.search or moduleLoader.load.',
+              },
+              interrupt: {
+                type: '(payload: unknown) => never',
+                typeDescription: '(payload: unknown) => never',
+                required: true,
+                description:
+                  'Interrupts an asynchronous host function and suspends the run. Synchronous bindings and module loaders cannot interrupt.',
+              },
+              resume: {
+                type: 'HostFunctionResumeContext',
+                typeDescription: 'HostFunctionResumeContext',
+                required: false,
+                description: (
+                  <>
+                    <p>
+                      {
+                        'Resume data available when an interrupted host function is invoked again.'
+                      }
+                    </p>
+                    <p>
+                      <code>{'HostFunctionResumeContext'}</code>
+                    </p>
+                    <TypeTable
+                      type={{
+                        interruptionId: {
+                          type: 'string',
+                          typeDescription: 'string',
+                          required: true,
+                          description:
+                            'The ID of the interruption being resolved.',
+                        },
+                        payload: {
+                          type: 'unknown',
+                          typeDescription: 'unknown',
+                          required: true,
+                          description: 'The original interruption payload.',
+                        },
+                        resolution: {
+                          type: 'unknown',
+                          typeDescription: 'unknown',
+                          required: true,
+                          description:
+                            'The application-defined resolution value.',
+                        },
+                      }}
+                    />
+                  </>
+                ),
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/index.mdx
+++ b/content/docs/reference/index.mdx
@@ -5,61 +5,14 @@ description: API Reference for run.
 
 # API Reference
 
-```json
-[
-  {
-    "name": "run",
-    "type": "function",
-    "description": "Executes source in a fresh sandbox.",
-    "href": "./run"
-  },
-  {
-    "name": "createRunner",
-    "type": "function",
-    "description": "Creates a runner with shared defaults.",
-    "href": "./create-runner"
-  },
-  {
-    "name": "getHostFunctionContext",
-    "type": "function",
-    "description": "Returns the context of the active host function.",
-    "href": "./get-host-function-context"
-  },
-  {
-    "name": "createSignedContinuationCodec",
-    "type": "function",
-    "description": "Creates an HMAC-signed continuation codec.",
-    "href": "./create-signed-continuation-codec"
-  },
-  {
-    "name": "createStoredContinuationCodec",
-    "type": "function",
-    "description": "Creates a storage-backed continuation codec.",
-    "href": "./create-stored-continuation-codec"
-  },
-  {
-    "name": "isRunInterruptedResult",
-    "type": "function",
-    "description": "Checks whether a value is an interrupted run result.",
-    "href": "./is-run-interrupted-result"
-  },
-  {
-    "name": "setMaxWorkers",
-    "type": "function",
-    "description": "Sets the process-wide worker cap.",
-    "href": "./set-max-workers"
-  },
-  {
-    "name": "Errors",
-    "type": "classes",
-    "description": "Lists the errors exported by run.",
-    "href": "./errors"
-  },
-  {
-    "name": "Types",
-    "type": "types",
-    "description": "Lists the TypeScript types exported by run.",
-    "href": "./types"
-  }
-]
-```
+| API                                                                                 | Type     | Description                                          |
+| ----------------------------------------------------------------------------------- | -------- | ---------------------------------------------------- |
+| [`run`](/docs/reference/run)                                                        | function | Executes source in a fresh sandbox.                  |
+| [`createRunner`](/docs/reference/create-runner)                                     | function | Creates a runner with shared defaults.               |
+| [`getHostFunctionContext`](/docs/reference/get-host-function-context)               | function | Returns the context of the active host function.     |
+| [`createSignedContinuationCodec`](/docs/reference/create-signed-continuation-codec) | function | Creates an HMAC-signed continuation codec.           |
+| [`createStoredContinuationCodec`](/docs/reference/create-stored-continuation-codec) | function | Creates a storage-backed continuation codec.         |
+| [`isRunInterruptedResult`](/docs/reference/is-run-interrupted-result)               | function | Checks whether a value is an interrupted run result. |
+| [`setMaxWorkers`](/docs/reference/set-max-workers)                                  | function | Sets the process-wide worker cap.                    |
+| [`Errors`](/docs/reference/errors)                                                  | classes  | Lists the errors exported by run.                    |
+| [`Types`](/docs/reference/types)                                                    | types    | Lists the TypeScript types exported by run.          |

--- a/content/docs/reference/is-run-interrupted-result.mdx
+++ b/content/docs/reference/is-run-interrupted-result.mdx
@@ -27,73 +27,94 @@ import { isRunInterruptedResult } from 'run';
 
 ### Parameters
 
-```json
-[
-  {
-    "name": "value",
-    "type": "unknown",
-    "description": "The value to inspect."
-  }
-]
-```
+<TypeTable
+  type={{
+    value: {
+      type: 'unknown',
+      typeDescription: 'unknown',
+      required: true,
+      description: 'The value to inspect.',
+    },
+  }}
+/>
 
 ### Returns
 
-```json
-[
-  {
-    "name": "isInterrupted",
-    "type": "value is RunInterruptedResult<unknown>",
-    "description": "Whether the value has the shape of an interrupted run result.",
-    "properties": [
-      {
-        "type": "RunInterruptedResult<unknown>",
-        "parameters": [
-          {
-            "name": "status",
-            "type": "'interrupted'",
-            "description": "Indicates that execution was interrupted."
-          },
-          {
-            "name": "interruptions",
-            "type": "RunInterruption[]",
-            "description": "The pending interruptions.",
-            "properties": [
-              {
-                "type": "RunInterruption",
-                "parameters": [
-                  {
-                    "name": "id",
-                    "type": "string",
-                    "description": "The unique interruption ID."
-                  },
-                  {
-                    "name": "hostFunctionName",
-                    "type": "string",
-                    "description": "The fully qualified host function path."
-                  },
-                  {
-                    "name": "arguments",
-                    "type": "unknown[]",
-                    "description": "The complete guest argument list."
-                  },
-                  {
-                    "name": "payload",
-                    "type": "unknown",
-                    "description": "The application-defined interruption payload."
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "continuation",
-            "type": "unknown",
-            "description": "The opaque continuation token."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    isInterrupted: {
+      type: 'value is RunInterruptedResult<unknown>',
+      typeDescription: 'value is RunInterruptedResult<unknown>',
+      required: true,
+      description: (
+        <>
+          <p>
+            {'Whether the value has the shape of an interrupted run result.'}
+          </p>
+          <p>
+            <code>{'RunInterruptedResult<unknown>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              status: {
+                type: "'interrupted'",
+                typeDescription: "'interrupted'",
+                required: true,
+                description: 'Indicates that execution was interrupted.',
+              },
+              interruptions: {
+                type: 'RunInterruption[]',
+                typeDescription: 'RunInterruption[]',
+                required: true,
+                description: (
+                  <>
+                    <p>{'The pending interruptions.'}</p>
+                    <p>
+                      <code>{'RunInterruption'}</code>
+                    </p>
+                    <TypeTable
+                      type={{
+                        id: {
+                          type: 'string',
+                          typeDescription: 'string',
+                          required: true,
+                          description: 'The unique interruption ID.',
+                        },
+                        hostFunctionName: {
+                          type: 'string',
+                          typeDescription: 'string',
+                          required: true,
+                          description:
+                            'The fully qualified host function path.',
+                        },
+                        arguments: {
+                          type: 'unknown[]',
+                          typeDescription: 'unknown[]',
+                          required: true,
+                          description: 'The complete guest argument list.',
+                        },
+                        payload: {
+                          type: 'unknown',
+                          typeDescription: 'unknown',
+                          required: true,
+                          description:
+                            'The application-defined interruption payload.',
+                        },
+                      }}
+                    />
+                  </>
+                ),
+              },
+              continuation: {
+                type: 'unknown',
+                typeDescription: 'unknown',
+                required: true,
+                description: 'The opaque continuation token.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/run.mdx
+++ b/content/docs/reference/run.mdx
@@ -35,287 +35,368 @@ import { run } from 'run';
 
 ### Type Parameters
 
-```json
-[
-  {
-    "name": "OUTPUT",
-    "type": "unknown",
-    "isOptional": true,
-    "description": "The expected type of a successfully returned value. Default: unknown."
-  }
-]
-```
+<TypeTable
+  type={{
+    OUTPUT: {
+      type: 'unknown',
+      typeDescription: 'unknown',
+      required: false,
+      description:
+        'The expected type of a successfully returned value. Default: unknown.',
+    },
+  }}
+/>
 
 ### Parameters
 
-```json
-[
-  {
-    "name": "source",
-    "type": "string",
-    "description": "JavaScript or type-stripped TypeScript source. Its evaluation mode is selected by sourceType, with backward-compatible defaults based on whether moduleLoader is present."
-  },
-  {
-    "name": "sourceType",
-    "type": "'function-body' | 'module'",
-    "isOptional": true,
-    "description": "How to evaluate the entry source. Function-body source supports top-level await and return. Module source supports static imports and completes with value undefined. Defaults to module when moduleLoader is present and function-body otherwise."
-  },
-  {
-    "name": "hostFunctions",
-    "type": "HostFunctions",
-    "isOptional": true,
-    "description": "Host function groups installed as globals in the sandbox. Default: {}.",
-    "properties": [
-      {
-        "type": "HostFunctions",
-        "parameters": [
-          {
-            "name": "[groupName]",
-            "type": "HostFunctionGroup",
-            "description": "A named collection of host functions.",
-            "properties": [
-              {
-                "type": "HostFunctionGroup",
-                "parameters": [
-                  {
-                    "name": "[hostFunctionName]",
-                    "type": "(...args: unknown[]) => unknown | Promise<unknown>",
-                    "description": "A host function made available to sandboxed JavaScript."
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "moduleLoader",
-    "type": "RunModuleLoader",
-    "isOptional": true,
-    "description": "A host-controlled native ES module loader. It enables dynamic imports from function-body source and static and dynamic imports from module source. A non-empty stable identity is required to create or resume continuations.",
-    "properties": [
-      {
-        "type": "RunModuleLoader",
-        "parameters": [
-          {
-            "name": "identity",
-            "type": "string",
-            "isOptional": true,
-            "description": "A stable loader identity authenticated by continuations, limited to 512 bytes and required to create or resume one."
-          },
-          {
-            "name": "normalize",
-            "type": "(specifier: string, importer: string) => string | Promise<string>",
-            "isOptional": true,
-            "description": "Returns the canonical module name for a raw specifier and importer. The raw specifier is used when omitted."
-          },
-          {
-            "name": "load",
-            "type": "(specifier: string) => string | Promise<string>",
-            "description": "Returns source text for a normalized module name."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "abortSignal",
-    "type": "AbortSignal",
-    "isOptional": true,
-    "description": "An optional signal used to cancel the invocation."
-  },
-  {
-    "name": "limits",
-    "type": "RunLimits",
-    "isOptional": true,
-    "description": "Resource limits for this invocation.",
-    "properties": [
-      {
-        "type": "RunLimits",
-        "parameters": [
-          {
-            "name": "timeoutMs",
-            "type": "number",
-            "isOptional": true,
-            "description": "Invocation timeout in milliseconds. Default: 30000."
-          },
-          {
-            "name": "memoryLimitBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "QuickJS memory limit in bytes. Default: 67108864."
-          },
-          {
-            "name": "maxStackSizeBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "QuickJS stack limit in bytes. Default: 2097152."
-          },
-          {
-            "name": "maxResultBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized result size in bytes. Default: 1048576."
-          },
-          {
-            "name": "maxConsoleOutputBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum console output in bytes. Default: 65536."
-          },
-          {
-            "name": "maxSourceBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum source size in bytes. Default: 262144."
-          },
-          {
-            "name": "maxHostFunctionArgumentsBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized arguments for one host function request in bytes. Default: 1048576."
-          },
-          {
-            "name": "maxHostFunctionOutputBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized host function output or interruption payload in bytes. Default: 4194304."
-          },
-          {
-            "name": "maxBridgeRequests",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum bridge requests in one invocation. Default: 256."
-          },
-          {
-            "name": "maxInFlightBridgeRequests",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum bridge requests in flight at once. Default: 32."
-          },
-          {
-            "name": "maxContinuationBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Maximum serialized continuation state in bytes. Default: 33554432."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "continuation",
-    "type": "string",
-    "isOptional": true,
-    "description": "An opaque continuation token from an interrupted result."
-  },
-  {
-    "name": "resolutions",
-    "type": "RunResolution[]",
-    "isOptional": true,
-    "description": "Values that resolve every interruption in the supplied continuation.",
-    "properties": [
-      {
-        "type": "RunResolution",
-        "parameters": [
-          {
-            "name": "interruptionId",
-            "type": "string",
-            "description": "The ID of the interruption being resolved."
-          },
-          {
-            "name": "value",
-            "type": "unknown",
-            "description": "The application-defined resolution value."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "continuationContext",
-    "type": "unknown",
-    "isOptional": true,
-    "description": "Serializable tenant, principal, or policy context authenticated by a continuation and required unchanged when resumed."
-  }
-]
-```
+<TypeTable
+  type={{
+    source: {
+      type: 'string',
+      typeDescription: 'string',
+      required: true,
+      description:
+        'JavaScript or type-stripped TypeScript source. Its evaluation mode is selected by sourceType, with backward-compatible defaults based on whether moduleLoader is present.',
+    },
+    sourceType: {
+      type: "'function-body' | 'module'",
+      typeDescription: "'function-body' | 'module'",
+      required: false,
+      description:
+        'How to evaluate the entry source. Function-body source supports top-level await and return. Module source supports static imports and completes with value undefined. Defaults to module when moduleLoader is present and function-body otherwise.',
+    },
+    hostFunctions: {
+      type: 'HostFunctions',
+      typeDescription: 'HostFunctions',
+      required: false,
+      description: (
+        <>
+          <p>
+            {
+              'Host function groups installed as globals in the sandbox. Default: {}.'
+            }
+          </p>
+          <p>
+            <code>{'HostFunctions'}</code>
+          </p>
+          <TypeTable
+            type={{
+              '[groupName]': {
+                type: 'HostFunctionGroup',
+                typeDescription: 'HostFunctionGroup',
+                required: true,
+                description: (
+                  <>
+                    <p>{'A named collection of host functions.'}</p>
+                    <p>
+                      <code>{'HostFunctionGroup'}</code>
+                    </p>
+                    <TypeTable
+                      type={{
+                        '[hostFunctionName]': {
+                          type: '(...args: unknown[]) => unknown | Promise<unknown>',
+                          typeDescription:
+                            '(...args: unknown[]) => unknown | Promise<unknown>',
+                          required: true,
+                          description:
+                            'A host function made available to sandboxed JavaScript.',
+                        },
+                      }}
+                    />
+                  </>
+                ),
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    moduleLoader: {
+      type: 'RunModuleLoader',
+      typeDescription: 'RunModuleLoader',
+      required: false,
+      description: (
+        <>
+          <p>
+            {
+              'A host-controlled native ES module loader. It enables dynamic imports from function-body source and static and dynamic imports from module source. A non-empty stable identity is required to create or resume continuations.'
+            }
+          </p>
+          <p>
+            <code>{'RunModuleLoader'}</code>
+          </p>
+          <TypeTable
+            type={{
+              identity: {
+                type: 'string',
+                typeDescription: 'string',
+                required: false,
+                description:
+                  'A stable loader identity authenticated by continuations, limited to 512 bytes and required to create or resume one.',
+              },
+              normalize: {
+                type: '(specifier: string, importer: string) => string | Promise<string>',
+                typeDescription:
+                  '(specifier: string, importer: string) => string | Promise<string>',
+                required: false,
+                description:
+                  'Returns the canonical module name for a raw specifier and importer. The raw specifier is used when omitted.',
+              },
+              load: {
+                type: '(specifier: string) => string | Promise<string>',
+                typeDescription:
+                  '(specifier: string) => string | Promise<string>',
+                required: true,
+                description:
+                  'Returns source text for a normalized module name.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    abortSignal: {
+      type: 'AbortSignal',
+      typeDescription: 'AbortSignal',
+      required: false,
+      description: 'An optional signal used to cancel the invocation.',
+    },
+    limits: {
+      type: 'RunLimits',
+      typeDescription: 'RunLimits',
+      required: false,
+      description: (
+        <>
+          <p>{'Resource limits for this invocation.'}</p>
+          <p>
+            <code>{'RunLimits'}</code>
+          </p>
+          <TypeTable
+            type={{
+              timeoutMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Invocation timeout in milliseconds. Default: 30000.',
+              },
+              memoryLimitBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'QuickJS memory limit in bytes. Default: 67108864.',
+              },
+              maxStackSizeBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'QuickJS stack limit in bytes. Default: 2097152.',
+              },
+              maxResultBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized result size in bytes. Default: 1048576.',
+              },
+              maxConsoleOutputBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Maximum console output in bytes. Default: 65536.',
+              },
+              maxSourceBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Maximum source size in bytes. Default: 262144.',
+              },
+              maxHostFunctionArgumentsBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized arguments for one host function request in bytes. Default: 1048576.',
+              },
+              maxHostFunctionOutputBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized host function output or interruption payload in bytes. Default: 4194304.',
+              },
+              maxBridgeRequests: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum bridge requests in one invocation. Default: 256.',
+              },
+              maxInFlightBridgeRequests: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum bridge requests in flight at once. Default: 32.',
+              },
+              maxContinuationBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description:
+                  'Maximum serialized continuation state in bytes. Default: 33554432.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    continuation: {
+      type: 'string',
+      typeDescription: 'string',
+      required: false,
+      description: 'An opaque continuation token from an interrupted result.',
+    },
+    resolutions: {
+      type: 'RunResolution[]',
+      typeDescription: 'RunResolution[]',
+      required: false,
+      description: (
+        <>
+          <p>
+            {
+              'Values that resolve every interruption in the supplied continuation.'
+            }
+          </p>
+          <p>
+            <code>{'RunResolution'}</code>
+          </p>
+          <TypeTable
+            type={{
+              interruptionId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The ID of the interruption being resolved.',
+              },
+              value: {
+                type: 'unknown',
+                typeDescription: 'unknown',
+                required: true,
+                description: 'The application-defined resolution value.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    continuationContext: {
+      type: 'unknown',
+      typeDescription: 'unknown',
+      required: false,
+      description:
+        'Serializable tenant, principal, or policy context authenticated by a continuation and required unchanged when resumed.',
+    },
+  }}
+/>
 
 ### Returns
 
-```json
-[
-  {
-    "name": "result",
-    "type": "Promise<RunCompletedResult<OUTPUT> | RunInterruptedResult<string>>",
-    "description": "The completed or interrupted run result.",
-    "properties": [
-      {
-        "type": "RunCompletedResult<OUTPUT>",
-        "parameters": [
-          {
-            "name": "status",
-            "type": "'completed'",
-            "description": "Indicates that execution completed."
-          },
-          {
-            "name": "value",
-            "type": "OUTPUT",
-            "description": "The value returned by the sandboxed source."
-          }
-        ]
-      },
-      {
-        "type": "RunInterruptedResult<string>",
-        "parameters": [
-          {
-            "name": "status",
-            "type": "'interrupted'",
-            "description": "Indicates that execution was interrupted."
-          },
-          {
-            "name": "interruptions",
-            "type": "RunInterruption[]",
-            "description": "The pending interruptions.",
-            "properties": [
-              {
-                "type": "RunInterruption",
-                "parameters": [
-                  {
-                    "name": "id",
-                    "type": "string",
-                    "description": "The unique interruption ID."
-                  },
-                  {
-                    "name": "hostFunctionName",
-                    "type": "string",
-                    "description": "The fully qualified host function path."
-                  },
-                  {
-                    "name": "arguments",
-                    "type": "unknown[]",
-                    "description": "The complete guest argument list."
-                  },
-                  {
-                    "name": "payload",
-                    "type": "unknown",
-                    "description": "The application-defined interruption payload."
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "continuation",
-            "type": "string",
-            "description": "The opaque continuation token used to resume the run."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    result: {
+      type: 'Promise<RunCompletedResult<OUTPUT> | RunInterruptedResult<string>>',
+      typeDescription:
+        'Promise<RunCompletedResult<OUTPUT> | RunInterruptedResult<string>>',
+      required: true,
+      description: (
+        <>
+          <p>{'The completed or interrupted run result.'}</p>
+          <p>
+            <code>{'RunCompletedResult<OUTPUT>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              status: {
+                type: "'completed'",
+                typeDescription: "'completed'",
+                required: true,
+                description: 'Indicates that execution completed.',
+              },
+              value: {
+                type: 'OUTPUT',
+                typeDescription: 'OUTPUT',
+                required: true,
+                description: 'The value returned by the sandboxed source.',
+              },
+            }}
+          />
+          <p>
+            <code>{'RunInterruptedResult<string>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              status: {
+                type: "'interrupted'",
+                typeDescription: "'interrupted'",
+                required: true,
+                description: 'Indicates that execution was interrupted.',
+              },
+              interruptions: {
+                type: 'RunInterruption[]',
+                typeDescription: 'RunInterruption[]',
+                required: true,
+                description: (
+                  <>
+                    <p>{'The pending interruptions.'}</p>
+                    <p>
+                      <code>{'RunInterruption'}</code>
+                    </p>
+                    <TypeTable
+                      type={{
+                        id: {
+                          type: 'string',
+                          typeDescription: 'string',
+                          required: true,
+                          description: 'The unique interruption ID.',
+                        },
+                        hostFunctionName: {
+                          type: 'string',
+                          typeDescription: 'string',
+                          required: true,
+                          description:
+                            'The fully qualified host function path.',
+                        },
+                        arguments: {
+                          type: 'unknown[]',
+                          typeDescription: 'unknown[]',
+                          required: true,
+                          description: 'The complete guest argument list.',
+                        },
+                        payload: {
+                          type: 'unknown',
+                          typeDescription: 'unknown',
+                          required: true,
+                          description:
+                            'The application-defined interruption payload.',
+                        },
+                      }}
+                    />
+                  </>
+                ),
+              },
+              continuation: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The opaque continuation token used to resume the run.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>

--- a/content/docs/reference/set-max-workers.mdx
+++ b/content/docs/reference/set-max-workers.mdx
@@ -26,25 +26,27 @@ import { setMaxWorkers } from 'run';
 
 ### Parameters
 
-```json
-[
-  {
-    "name": "maxWorkers",
-    "type": "number",
-    "isOptional": true,
-    "description": "A positive integer worker cap. Omit the value or pass undefined to restore the dynamic memory-based default."
-  }
-]
-```
+<TypeTable
+  type={{
+    maxWorkers: {
+      type: 'number',
+      typeDescription: 'number',
+      required: false,
+      description:
+        'A positive integer worker cap. Omit the value or pass undefined to restore the dynamic memory-based default.',
+    },
+  }}
+/>
 
 ### Returns
 
-```json
-[
-  {
-    "name": "result",
-    "type": "void",
-    "description": "This function does not return a value."
-  }
-]
-```
+<TypeTable
+  type={{
+    result: {
+      type: 'void',
+      typeDescription: 'void',
+      required: true,
+      description: 'This function does not return a value.',
+    },
+  }}
+/>

--- a/content/docs/reference/types.mdx
+++ b/content/docs/reference/types.mdx
@@ -53,765 +53,956 @@ import type {
 
 ### Execution Types
 
-```json
-[
-  {
-    "name": "RunInput<TOKEN = unknown>",
-    "type": "interface",
-    "description": "Input accepted by run and Runner.run.",
-    "properties": [
-      {
-        "type": "RunInput<TOKEN>",
-        "parameters": [
-          {
-            "name": "source",
-            "type": "string",
-            "description": "JavaScript or type-stripped TypeScript source. Its evaluation mode is selected by sourceType, with backward-compatible defaults based on whether moduleLoader is present."
-          },
-          {
-            "name": "sourceType",
-            "type": "'function-body' | 'module'",
-            "isOptional": true,
-            "description": "How to evaluate the entry source. Defaults to module when moduleLoader is present and function-body otherwise."
-          },
-          {
-            "name": "hostFunctions",
-            "type": "HostFunctions",
-            "isOptional": true,
-            "description": "Host function groups installed as guest globals."
-          },
-          {
-            "name": "moduleLoader",
-            "type": "RunModuleLoader",
-            "isOptional": true,
-            "description": "A host-controlled native ES module loader for dynamic imports from function bodies and static or dynamic imports from modules."
-          },
-          {
-            "name": "abortSignal",
-            "type": "AbortSignal",
-            "isOptional": true,
-            "description": "The signal used to cancel the invocation."
-          },
-          {
-            "name": "limits",
-            "type": "RunLimits",
-            "isOptional": true,
-            "description": "Per-run resource limits."
-          },
-          {
-            "name": "continuation",
-            "type": "TOKEN",
-            "isOptional": true,
-            "description": "An opaque continuation token."
-          },
-          {
-            "name": "resolutions",
-            "type": "RunResolution[]",
-            "isOptional": true,
-            "description": "Values that resolve pending interruptions."
-          },
-          {
-            "name": "continuationContext",
-            "type": "unknown",
-            "isOptional": true,
-            "description": "Serializable context authenticated by a continuation and required unchanged when resumed."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunResult<OUTPUT = unknown, TOKEN = unknown>",
-    "type": "RunCompletedResult<OUTPUT> | RunInterruptedResult<TOKEN>",
-    "description": "The result of a sandbox invocation."
-  },
-  {
-    "name": "RunCompletedResult<OUTPUT = unknown>",
-    "type": "interface",
-    "description": "A completed sandbox invocation.",
-    "properties": [
-      {
-        "type": "RunCompletedResult<OUTPUT>",
-        "parameters": [
-          {
-            "name": "status",
-            "type": "'completed'",
-            "description": "The completed status discriminator."
-          },
-          {
-            "name": "value",
-            "type": "OUTPUT",
-            "description": "The value returned by the sandboxed source."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunInterruptedResult<TOKEN = unknown>",
-    "type": "interface",
-    "description": "An interrupted sandbox invocation.",
-    "properties": [
-      {
-        "type": "RunInterruptedResult<TOKEN>",
-        "parameters": [
-          {
-            "name": "status",
-            "type": "'interrupted'",
-            "description": "The interrupted status discriminator."
-          },
-          {
-            "name": "interruptions",
-            "type": "RunInterruption[]",
-            "description": "The pending interruptions."
-          },
-          {
-            "name": "continuation",
-            "type": "TOKEN",
-            "description": "The opaque continuation token."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunInterruption<PAYLOAD = unknown>",
-    "type": "interface",
-    "description": "A pending host function interruption.",
-    "properties": [
-      {
-        "type": "RunInterruption<PAYLOAD>",
-        "parameters": [
-          {
-            "name": "id",
-            "type": "string",
-            "description": "The unique interruption ID."
-          },
-          {
-            "name": "hostFunctionName",
-            "type": "string",
-            "description": "The fully qualified host function path."
-          },
-          {
-            "name": "arguments",
-            "type": "unknown[]",
-            "description": "The complete guest argument list."
-          },
-          {
-            "name": "payload",
-            "type": "PAYLOAD",
-            "description": "The application-defined interruption payload."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunResolution<VALUE = unknown>",
-    "type": "interface",
-    "description": "A resolution supplied for an interruption.",
-    "properties": [
-      {
-        "type": "RunResolution<VALUE>",
-        "parameters": [
-          {
-            "name": "interruptionId",
-            "type": "string",
-            "description": "The ID of the interruption being resolved."
-          },
-          {
-            "name": "value",
-            "type": "VALUE",
-            "description": "The application-defined resolution value."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunLimits",
-    "type": "interface",
-    "description": "Resource limits applied to one sandbox invocation.",
-    "properties": [
-      {
-        "type": "RunLimits",
-        "parameters": [
-          {
-            "name": "timeoutMs",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 30000."
-          },
-          {
-            "name": "memoryLimitBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 67108864."
-          },
-          {
-            "name": "maxStackSizeBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 2097152."
-          },
-          {
-            "name": "maxResultBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 1048576."
-          },
-          {
-            "name": "maxConsoleOutputBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 65536."
-          },
-          {
-            "name": "maxSourceBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 262144."
-          },
-          {
-            "name": "maxHostFunctionArgumentsBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 1048576."
-          },
-          {
-            "name": "maxHostFunctionOutputBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 4194304."
-          },
-          {
-            "name": "maxBridgeRequests",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 256."
-          },
-          {
-            "name": "maxInFlightBridgeRequests",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 32."
-          },
-          {
-            "name": "maxContinuationBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "Default: 33554432."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    'RunInput<TOKEN = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Input accepted by run and Runner.run.'}</p>
+          <p>
+            <code>{'RunInput<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              source: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'JavaScript or type-stripped TypeScript source. Its evaluation mode is selected by sourceType, with backward-compatible defaults based on whether moduleLoader is present.',
+              },
+              sourceType: {
+                type: "'function-body' | 'module'",
+                typeDescription: "'function-body' | 'module'",
+                required: false,
+                description:
+                  'How to evaluate the entry source. Defaults to module when moduleLoader is present and function-body otherwise.',
+              },
+              hostFunctions: {
+                type: 'HostFunctions',
+                typeDescription: 'HostFunctions',
+                required: false,
+                description: 'Host function groups installed as guest globals.',
+              },
+              moduleLoader: {
+                type: 'RunModuleLoader',
+                typeDescription: 'RunModuleLoader',
+                required: false,
+                description:
+                  'A host-controlled native ES module loader for dynamic imports from function bodies and static or dynamic imports from modules.',
+              },
+              abortSignal: {
+                type: 'AbortSignal',
+                typeDescription: 'AbortSignal',
+                required: false,
+                description: 'The signal used to cancel the invocation.',
+              },
+              limits: {
+                type: 'RunLimits',
+                typeDescription: 'RunLimits',
+                required: false,
+                description: 'Per-run resource limits.',
+              },
+              continuation: {
+                type: 'TOKEN',
+                typeDescription: 'TOKEN',
+                required: false,
+                description: 'An opaque continuation token.',
+              },
+              resolutions: {
+                type: 'RunResolution[]',
+                typeDescription: 'RunResolution[]',
+                required: false,
+                description: 'Values that resolve pending interruptions.',
+              },
+              continuationContext: {
+                type: 'unknown',
+                typeDescription: 'unknown',
+                required: false,
+                description:
+                  'Serializable context authenticated by a continuation and required unchanged when resumed.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    'RunResult<OUTPUT = unknown, TOKEN = unknown>': {
+      type: 'RunCompletedResult<OUTPUT> | RunInterruptedResult<TOKEN>',
+      typeDescription:
+        'RunCompletedResult<OUTPUT> | RunInterruptedResult<TOKEN>',
+      required: true,
+      description: 'The result of a sandbox invocation.',
+    },
+    'RunCompletedResult<OUTPUT = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'A completed sandbox invocation.'}</p>
+          <p>
+            <code>{'RunCompletedResult<OUTPUT>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              status: {
+                type: "'completed'",
+                typeDescription: "'completed'",
+                required: true,
+                description: 'The completed status discriminator.',
+              },
+              value: {
+                type: 'OUTPUT',
+                typeDescription: 'OUTPUT',
+                required: true,
+                description: 'The value returned by the sandboxed source.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    'RunInterruptedResult<TOKEN = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'An interrupted sandbox invocation.'}</p>
+          <p>
+            <code>{'RunInterruptedResult<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              status: {
+                type: "'interrupted'",
+                typeDescription: "'interrupted'",
+                required: true,
+                description: 'The interrupted status discriminator.',
+              },
+              interruptions: {
+                type: 'RunInterruption[]',
+                typeDescription: 'RunInterruption[]',
+                required: true,
+                description: 'The pending interruptions.',
+              },
+              continuation: {
+                type: 'TOKEN',
+                typeDescription: 'TOKEN',
+                required: true,
+                description: 'The opaque continuation token.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    'RunInterruption<PAYLOAD = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'A pending host function interruption.'}</p>
+          <p>
+            <code>{'RunInterruption<PAYLOAD>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              id: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The unique interruption ID.',
+              },
+              hostFunctionName: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The fully qualified host function path.',
+              },
+              arguments: {
+                type: 'unknown[]',
+                typeDescription: 'unknown[]',
+                required: true,
+                description: 'The complete guest argument list.',
+              },
+              payload: {
+                type: 'PAYLOAD',
+                typeDescription: 'PAYLOAD',
+                required: true,
+                description: 'The application-defined interruption payload.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    'RunResolution<VALUE = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'A resolution supplied for an interruption.'}</p>
+          <p>
+            <code>{'RunResolution<VALUE>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              interruptionId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The ID of the interruption being resolved.',
+              },
+              value: {
+                type: 'VALUE',
+                typeDescription: 'VALUE',
+                required: true,
+                description: 'The application-defined resolution value.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunLimits: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Resource limits applied to one sandbox invocation.'}</p>
+          <p>
+            <code>{'RunLimits'}</code>
+          </p>
+          <TypeTable
+            type={{
+              timeoutMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 30000.',
+              },
+              memoryLimitBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 67108864.',
+              },
+              maxStackSizeBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 2097152.',
+              },
+              maxResultBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 1048576.',
+              },
+              maxConsoleOutputBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 65536.',
+              },
+              maxSourceBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 262144.',
+              },
+              maxHostFunctionArgumentsBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 1048576.',
+              },
+              maxHostFunctionOutputBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 4194304.',
+              },
+              maxBridgeRequests: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 256.',
+              },
+              maxInFlightBridgeRequests: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 32.',
+              },
+              maxContinuationBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'Default: 33554432.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>
 
 ### Runner Types
 
-```json
-[
-  {
-    "name": "RunnerOptions<TOKEN = string>",
-    "type": "interface",
-    "description": "Shared defaults used by a runner.",
-    "properties": [
-      {
-        "type": "RunnerOptions<TOKEN>",
-        "parameters": [
-          {
-            "name": "limits",
-            "type": "RunLimits",
-            "isOptional": true,
-            "description": "Shared resource limits."
-          },
-          {
-            "name": "syncHostFunctions",
-            "type": "SyncHostFunctions",
-            "isOptional": true,
-            "description": "Host functions exposed with synchronous guest call semantics."
-          },
-          {
-            "name": "continuationSecret",
-            "type": "string | Uint8Array",
-            "isOptional": true,
-            "description": "The HMAC key used for signed continuations."
-          },
-          {
-            "name": "continuationCodec",
-            "type": "ContinuationCodec<TOKEN>",
-            "isOptional": true,
-            "description": "A custom continuation codec."
-          },
-          {
-            "name": "continuationAudience",
-            "type": "string",
-            "isOptional": true,
-            "description": "The authenticated continuation audience."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "Runner<TOKEN = unknown>",
-    "type": "interface",
-    "description": "A configured JavaScript runner.",
-    "properties": [
-      {
-        "type": "Runner<TOKEN>",
-        "parameters": [
-          {
-            "name": "run",
-            "type": "<OUTPUT = unknown>(input: RunInput<TOKEN>) => Promise<RunResult<OUTPUT, TOKEN>>",
-            "description": "Executes a sandbox invocation."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    'RunnerOptions<TOKEN = string>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Shared defaults used by a runner.'}</p>
+          <p>
+            <code>{'RunnerOptions<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              limits: {
+                type: 'RunLimits',
+                typeDescription: 'RunLimits',
+                required: false,
+                description: 'Shared resource limits.',
+              },
+              syncHostFunctions: {
+                type: 'SyncHostFunctions',
+                typeDescription: 'SyncHostFunctions',
+                required: false,
+                description:
+                  'Host functions exposed with synchronous guest call semantics.',
+              },
+              continuationSecret: {
+                type: 'string | Uint8Array',
+                typeDescription: 'string | Uint8Array',
+                required: false,
+                description: 'The HMAC key used for signed continuations.',
+              },
+              continuationCodec: {
+                type: 'ContinuationCodec<TOKEN>',
+                typeDescription: 'ContinuationCodec<TOKEN>',
+                required: false,
+                description: 'A custom continuation codec.',
+              },
+              continuationAudience: {
+                type: 'string',
+                typeDescription: 'string',
+                required: false,
+                description: 'The authenticated continuation audience.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    'Runner<TOKEN = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'A configured JavaScript runner.'}</p>
+          <p>
+            <code>{'Runner<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              run: {
+                type: '<OUTPUT = unknown>(input: RunInput<TOKEN>) => Promise<RunResult<OUTPUT, TOKEN>>',
+                typeDescription:
+                  '<OUTPUT = unknown>(input: RunInput<TOKEN>) => Promise<RunResult<OUTPUT, TOKEN>>',
+                required: true,
+                description: 'Executes a sandbox invocation.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>
 
 ### Host Function Types
 
-```json
-[
-  {
-    "name": "HostFunction<ARGUMENTS extends unknown[] = unknown[], OUTPUT = unknown>",
-    "type": "(...args: ARGUMENTS) => OUTPUT | Promise<OUTPUT>",
-    "description": "A host function made available to sandboxed JavaScript."
-  },
-  {
-    "name": "HostFunctionGroup",
-    "type": "Record<string, HostFunction<never[], unknown>>",
-    "description": "A named collection of host functions."
-  },
-  {
-    "name": "HostFunctions",
-    "type": "Record<string, HostFunctionGroup>",
-    "description": "Host function groups installed as guest globals."
-  },
-  {
-    "name": "SyncHostFunctions",
-    "type": "HostFunctions",
-    "description": "Host function groups exposed with synchronous guest call semantics."
-  },
-  {
-    "name": "RunModuleLoader",
-    "type": "interface",
-    "description": "A host-controlled native ES module resolver.",
-    "properties": [
-      {
-        "type": "RunModuleLoader",
-        "parameters": [
-          {
-            "name": "identity",
-            "type": "string",
-            "isOptional": true,
-            "description": "A stable loader identity authenticated by continuations, limited to 512 bytes and required to create or resume one."
-          },
-          {
-            "name": "normalize",
-            "type": "(specifier: string, importer: string) => string | Promise<string>",
-            "isOptional": true,
-            "description": "Returns a canonical module name."
-          },
-          {
-            "name": "load",
-            "type": "(specifier: string) => string | Promise<string>",
-            "description": "Returns source for a normalized module name."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "HostFunctionContext",
-    "type": "interface",
-    "description": "Context supplied to each host function invocation.",
-    "properties": [
-      {
-        "type": "HostFunctionContext",
-        "parameters": [
-          {
-            "name": "abortSignal",
-            "type": "AbortSignal",
-            "description": "The signal for the active run."
-          },
-          {
-            "name": "invocationId",
-            "type": "string",
-            "description": "The current run attempt identifier."
-          },
-          {
-            "name": "logicalRunId",
-            "type": "string",
-            "description": "The logical run identifier."
-          },
-          {
-            "name": "requestId",
-            "type": "string",
-            "description": "The host function request identifier."
-          },
-          {
-            "name": "requestIndex",
-            "type": "number",
-            "description": "The one-based host function request order."
-          },
-          {
-            "name": "hostFunctionName",
-            "type": "string",
-            "description": "The fully qualified host function path."
-          },
-          {
-            "name": "interrupt",
-            "type": "(payload: unknown) => never",
-            "description": "Interrupts the host function and suspends the run."
-          },
-          {
-            "name": "resume",
-            "type": "HostFunctionResumeContext",
-            "isOptional": true,
-            "description": "Resume data for a replayed interrupted host function."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "HostFunctionResumeContext",
-    "type": "interface",
-    "description": "Resume data for a replayed interrupted host function.",
-    "properties": [
-      {
-        "type": "HostFunctionResumeContext",
-        "parameters": [
-          {
-            "name": "interruptionId",
-            "type": "string",
-            "description": "The interruption ID."
-          },
-          {
-            "name": "payload",
-            "type": "unknown",
-            "description": "The original interruption payload."
-          },
-          {
-            "name": "resolution",
-            "type": "unknown",
-            "description": "The supplied resolution."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    'HostFunction<ARGUMENTS extends unknown[] = unknown[], OUTPUT = unknown>': {
+      type: '(...args: ARGUMENTS) => OUTPUT | Promise<OUTPUT>',
+      typeDescription: '(...args: ARGUMENTS) => OUTPUT | Promise<OUTPUT>',
+      required: true,
+      description: 'A host function made available to sandboxed JavaScript.',
+    },
+    HostFunctionGroup: {
+      type: 'Record<string, HostFunction<never[], unknown>>',
+      typeDescription: 'Record<string, HostFunction<never[], unknown>>',
+      required: true,
+      description: 'A named collection of host functions.',
+    },
+    HostFunctions: {
+      type: 'Record<string, HostFunctionGroup>',
+      typeDescription: 'Record<string, HostFunctionGroup>',
+      required: true,
+      description: 'Host function groups installed as guest globals.',
+    },
+    SyncHostFunctions: {
+      type: 'HostFunctions',
+      typeDescription: 'HostFunctions',
+      required: true,
+      description:
+        'Host function groups exposed with synchronous guest call semantics.',
+    },
+    RunModuleLoader: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'A host-controlled native ES module resolver.'}</p>
+          <p>
+            <code>{'RunModuleLoader'}</code>
+          </p>
+          <TypeTable
+            type={{
+              identity: {
+                type: 'string',
+                typeDescription: 'string',
+                required: false,
+                description:
+                  'A stable loader identity authenticated by continuations, limited to 512 bytes and required to create or resume one.',
+              },
+              normalize: {
+                type: '(specifier: string, importer: string) => string | Promise<string>',
+                typeDescription:
+                  '(specifier: string, importer: string) => string | Promise<string>',
+                required: false,
+                description: 'Returns a canonical module name.',
+              },
+              load: {
+                type: '(specifier: string) => string | Promise<string>',
+                typeDescription:
+                  '(specifier: string) => string | Promise<string>',
+                required: true,
+                description: 'Returns source for a normalized module name.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    HostFunctionContext: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Context supplied to each host function invocation.'}</p>
+          <p>
+            <code>{'HostFunctionContext'}</code>
+          </p>
+          <TypeTable
+            type={{
+              abortSignal: {
+                type: 'AbortSignal',
+                typeDescription: 'AbortSignal',
+                required: true,
+                description: 'The signal for the active run.',
+              },
+              invocationId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The current run attempt identifier.',
+              },
+              logicalRunId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The logical run identifier.',
+              },
+              requestId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The host function request identifier.',
+              },
+              requestIndex: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description: 'The one-based host function request order.',
+              },
+              hostFunctionName: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The fully qualified host function path.',
+              },
+              interrupt: {
+                type: '(payload: unknown) => never',
+                typeDescription: '(payload: unknown) => never',
+                required: true,
+                description:
+                  'Interrupts the host function and suspends the run.',
+              },
+              resume: {
+                type: 'HostFunctionResumeContext',
+                typeDescription: 'HostFunctionResumeContext',
+                required: false,
+                description:
+                  'Resume data for a replayed interrupted host function.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    HostFunctionResumeContext: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Resume data for a replayed interrupted host function.'}</p>
+          <p>
+            <code>{'HostFunctionResumeContext'}</code>
+          </p>
+          <TypeTable
+            type={{
+              interruptionId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The interruption ID.',
+              },
+              payload: {
+                type: 'unknown',
+                typeDescription: 'unknown',
+                required: true,
+                description: 'The original interruption payload.',
+              },
+              resolution: {
+                type: 'unknown',
+                typeDescription: 'unknown',
+                required: true,
+                description: 'The supplied resolution.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>
 
 ### Continuation Types
 
-```json
-[
-  {
-    "name": "ContinuationCodec<TOKEN = unknown>",
-    "type": "interface",
-    "description": "An encoder and decoder for continuation state.",
-    "properties": [
-      {
-        "type": "ContinuationCodec<TOKEN>",
-        "parameters": [
-          {
-            "name": "encode",
-            "type": "(state: RunContinuationState, context?: ContinuationOperationContext) => TOKEN | Promise<TOKEN>",
-            "description": "Encodes replay state."
-          },
-          {
-            "name": "decode",
-            "type": "(token: TOKEN, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>",
-            "description": "Decodes replay state."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "ContinuationOperationContext",
-    "type": "interface",
-    "description": "Context supplied to a continuation codec operation.",
-    "properties": [
-      {
-        "type": "ContinuationOperationContext",
-        "parameters": [
-          {
-            "name": "abortSignal",
-            "type": "AbortSignal",
-            "description": "The operation signal."
-          },
-          {
-            "name": "deadlineMs",
-            "type": "number",
-            "description": "The operation deadline as a Unix timestamp in milliseconds."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "SignedContinuationCodecOptions",
-    "type": "interface",
-    "description": "Options for createSignedContinuationCodec.",
-    "properties": [
-      {
-        "type": "SignedContinuationCodecOptions",
-        "parameters": [
-          {
-            "name": "secret",
-            "type": "string | Uint8Array",
-            "description": "The primary HMAC key."
-          },
-          {
-            "name": "verificationSecrets",
-            "type": "(string | Uint8Array)[]",
-            "isOptional": true,
-            "description": "Previous HMAC keys accepted for verification."
-          },
-          {
-            "name": "maxAgeMs",
-            "type": "number",
-            "isOptional": true,
-            "description": "The maximum token lifetime."
-          },
-          {
-            "name": "maxTokenBytes",
-            "type": "number",
-            "isOptional": true,
-            "description": "The maximum token size."
-          },
-          {
-            "name": "clockSkewMs",
-            "type": "number",
-            "isOptional": true,
-            "description": "The allowed positive clock skew."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "ContinuationStorage",
-    "type": "interface",
-    "description": "Storage used by createStoredContinuationCodec.",
-    "properties": [
-      {
-        "type": "ContinuationStorage",
-        "parameters": [
-          {
-            "name": "set",
-            "type": "(key: string, value: StoredContinuation, context?: ContinuationOperationContext) => void | Promise<void>",
-            "description": "Stores a continuation."
-          },
-          {
-            "name": "acquire",
-            "type": "(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>",
-            "description": "Atomically creates a temporary claim on a continuation without removing it."
-          },
-          {
-            "name": "consume",
-            "type": "(key: string, claimId: string) => void | Promise<void>",
-            "description": "Atomically removes a continuation when its claim identifier matches."
-          },
-          {
-            "name": "release",
-            "type": "(key: string, claimId: string) => void | Promise<void>",
-            "description": "Atomically releases a continuation when its claim identifier matches."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "StoredContinuation",
-    "type": "interface",
-    "description": "A stored continuation value.",
-    "properties": [
-      {
-        "type": "StoredContinuation",
-        "parameters": [
-          {
-            "name": "state",
-            "type": "RunContinuationState",
-            "description": "The replay state."
-          },
-          {
-            "name": "expiresAtMs",
-            "type": "number",
-            "description": "The expiration time as a Unix timestamp in milliseconds."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunContinuationState",
-    "type": "interface",
-    "description": "Serializable replay state passed to a continuation codec.",
-    "properties": [
-      {
-        "type": "RunContinuationState",
-        "parameters": [
-          {
-            "name": "version",
-            "type": "2",
-            "description": "The continuation state version."
-          },
-          {
-            "name": "runtime",
-            "type": "'run-replay-v2'",
-            "description": "The replay runtime identifier."
-          },
-          {
-            "name": "serde",
-            "type": "'run-js-v1'",
-            "description": "The serialization format identifier."
-          },
-          {
-            "name": "source",
-            "type": "string",
-            "description": "The source associated with the continuation."
-          },
-          {
-            "name": "logicalRunId",
-            "type": "string",
-            "description": "The logical run identifier."
-          },
-          {
-            "name": "scopeHash",
-            "type": "string",
-            "description": "The authenticated scope hash."
-          },
-          {
-            "name": "determinism",
-            "type": "{ dateNowMs: number; randomSeed: string }",
-            "description": "The deterministic clock and random seed."
-          },
-          {
-            "name": "ledger",
-            "type": "RunLedgerEntry[]",
-            "description": "The recorded host function outcomes."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "name": "RunLedgerEntry",
-    "type": "fulfilled | rejected | interrupted",
-    "description": "A recorded host function outcome. The wire property name bindingName is the persisted host function path key.",
-    "properties": [
-      {
-        "type": "FulfilledRunLedgerEntry",
-        "parameters": [
-          {
-            "name": "bindingName",
-            "type": "string",
-            "description": "The persisted host function path key (wire property name remains bindingName)."
-          },
-          {
-            "name": "inputJson",
-            "type": "string",
-            "description": "The serialized host function input."
-          },
-          {
-            "name": "status",
-            "type": "'fulfilled'",
-            "description": "The fulfilled status discriminator."
-          },
-          {
-            "name": "settledOrder",
-            "type": "number",
-            "description": "The settlement order."
-          },
-          {
-            "name": "dateNowMs",
-            "type": "number",
-            "description": "The deterministic clock value."
-          },
-          {
-            "name": "valueJson",
-            "type": "string",
-            "description": "The serialized fulfilled value."
-          }
-        ]
-      },
-      {
-        "type": "RejectedRunLedgerEntry",
-        "parameters": [
-          {
-            "name": "bindingName",
-            "type": "string",
-            "description": "The persisted host function path key (wire property name remains bindingName)."
-          },
-          {
-            "name": "inputJson",
-            "type": "string",
-            "description": "The serialized host function input."
-          },
-          {
-            "name": "status",
-            "type": "'rejected'",
-            "description": "The rejected status discriminator."
-          },
-          {
-            "name": "settledOrder",
-            "type": "number",
-            "description": "The settlement order."
-          },
-          {
-            "name": "dateNowMs",
-            "type": "number",
-            "description": "The deterministic clock value."
-          },
-          {
-            "name": "error",
-            "type": "{ name: string; message: string; stack?: string; code?: string; details?: unknown }",
-            "description": "The serialized rejection."
-          }
-        ]
-      },
-      {
-        "type": "InterruptedRunLedgerEntry",
-        "parameters": [
-          {
-            "name": "bindingName",
-            "type": "string",
-            "description": "The persisted host function path key (wire property name remains bindingName)."
-          },
-          {
-            "name": "inputJson",
-            "type": "string",
-            "description": "The serialized host function input."
-          },
-          {
-            "name": "status",
-            "type": "'interrupted'",
-            "description": "The interrupted status discriminator."
-          },
-          {
-            "name": "interruptionId",
-            "type": "string",
-            "description": "The interruption ID."
-          },
-          {
-            "name": "payloadJson",
-            "type": "string",
-            "description": "The serialized interruption payload."
-          }
-        ]
-      }
-    ]
-  }
-]
-```
+<TypeTable
+  type={{
+    'ContinuationCodec<TOKEN = unknown>': {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'An encoder and decoder for continuation state.'}</p>
+          <p>
+            <code>{'ContinuationCodec<TOKEN>'}</code>
+          </p>
+          <TypeTable
+            type={{
+              encode: {
+                type: '(state: RunContinuationState, context?: ContinuationOperationContext) => TOKEN | Promise<TOKEN>',
+                typeDescription:
+                  '(state: RunContinuationState, context?: ContinuationOperationContext) => TOKEN | Promise<TOKEN>',
+                required: true,
+                description: 'Encodes replay state.',
+              },
+              decode: {
+                type: '(token: TOKEN, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                typeDescription:
+                  '(token: TOKEN, context?: ContinuationOperationContext) => RunContinuationState | Promise<RunContinuationState>',
+                required: true,
+                description: 'Decodes replay state.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    ContinuationOperationContext: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Context supplied to a continuation codec operation.'}</p>
+          <p>
+            <code>{'ContinuationOperationContext'}</code>
+          </p>
+          <TypeTable
+            type={{
+              abortSignal: {
+                type: 'AbortSignal',
+                typeDescription: 'AbortSignal',
+                required: true,
+                description: 'The operation signal.',
+              },
+              deadlineMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description:
+                  'The operation deadline as a Unix timestamp in milliseconds.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    SignedContinuationCodecOptions: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Options for createSignedContinuationCodec.'}</p>
+          <p>
+            <code>{'SignedContinuationCodecOptions'}</code>
+          </p>
+          <TypeTable
+            type={{
+              secret: {
+                type: 'string | Uint8Array',
+                typeDescription: 'string | Uint8Array',
+                required: true,
+                description: 'The primary HMAC key.',
+              },
+              verificationSecrets: {
+                type: '(string | Uint8Array)[]',
+                typeDescription: '(string | Uint8Array)[]',
+                required: false,
+                description: 'Previous HMAC keys accepted for verification.',
+              },
+              maxAgeMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'The maximum token lifetime.',
+              },
+              maxTokenBytes: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'The maximum token size.',
+              },
+              clockSkewMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: false,
+                description: 'The allowed positive clock skew.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    ContinuationStorage: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Storage used by createStoredContinuationCodec.'}</p>
+          <p>
+            <code>{'ContinuationStorage'}</code>
+          </p>
+          <TypeTable
+            type={{
+              set: {
+                type: '(key: string, value: StoredContinuation, context?: ContinuationOperationContext) => void | Promise<void>',
+                typeDescription:
+                  '(key: string, value: StoredContinuation, context?: ContinuationOperationContext) => void | Promise<void>',
+                required: true,
+                description: 'Stores a continuation.',
+              },
+              acquire: {
+                type: '(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>',
+                typeDescription:
+                  '(key: string, claimId: string, context?: ContinuationOperationContext) => StoredContinuation | undefined | Promise<StoredContinuation | undefined>',
+                required: true,
+                description:
+                  'Atomically creates a temporary claim on a continuation without removing it.',
+              },
+              consume: {
+                type: '(key: string, claimId: string) => void | Promise<void>',
+                typeDescription:
+                  '(key: string, claimId: string) => void | Promise<void>',
+                required: true,
+                description:
+                  'Atomically removes a continuation when its claim identifier matches.',
+              },
+              release: {
+                type: '(key: string, claimId: string) => void | Promise<void>',
+                typeDescription:
+                  '(key: string, claimId: string) => void | Promise<void>',
+                required: true,
+                description:
+                  'Atomically releases a continuation when its claim identifier matches.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    StoredContinuation: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'A stored continuation value.'}</p>
+          <p>
+            <code>{'StoredContinuation'}</code>
+          </p>
+          <TypeTable
+            type={{
+              state: {
+                type: 'RunContinuationState',
+                typeDescription: 'RunContinuationState',
+                required: true,
+                description: 'The replay state.',
+              },
+              expiresAtMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description:
+                  'The expiration time as a Unix timestamp in milliseconds.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunContinuationState: {
+      type: 'interface',
+      typeDescription: 'interface',
+      required: true,
+      description: (
+        <>
+          <p>{'Serializable replay state passed to a continuation codec.'}</p>
+          <p>
+            <code>{'RunContinuationState'}</code>
+          </p>
+          <TypeTable
+            type={{
+              version: {
+                type: '2',
+                typeDescription: '2',
+                required: true,
+                description: 'The continuation state version.',
+              },
+              runtime: {
+                type: "'run-replay-v2'",
+                typeDescription: "'run-replay-v2'",
+                required: true,
+                description: 'The replay runtime identifier.',
+              },
+              serde: {
+                type: "'run-js-v1'",
+                typeDescription: "'run-js-v1'",
+                required: true,
+                description: 'The serialization format identifier.',
+              },
+              source: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The source associated with the continuation.',
+              },
+              logicalRunId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The logical run identifier.',
+              },
+              scopeHash: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The authenticated scope hash.',
+              },
+              determinism: {
+                type: '{ dateNowMs: number; randomSeed: string }',
+                typeDescription: '{ dateNowMs: number; randomSeed: string }',
+                required: true,
+                description: 'The deterministic clock and random seed.',
+              },
+              ledger: {
+                type: 'RunLedgerEntry[]',
+                typeDescription: 'RunLedgerEntry[]',
+                required: true,
+                description: 'The recorded host function outcomes.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+    RunLedgerEntry: {
+      type: 'fulfilled | rejected | interrupted',
+      typeDescription: 'fulfilled | rejected | interrupted',
+      required: true,
+      description: (
+        <>
+          <p>
+            {
+              'A recorded host function outcome. The wire property name bindingName is the persisted host function path key.'
+            }
+          </p>
+          <p>
+            <code>{'FulfilledRunLedgerEntry'}</code>
+          </p>
+          <TypeTable
+            type={{
+              bindingName: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The persisted host function path key (wire property name remains bindingName).',
+              },
+              inputJson: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The serialized host function input.',
+              },
+              status: {
+                type: "'fulfilled'",
+                typeDescription: "'fulfilled'",
+                required: true,
+                description: 'The fulfilled status discriminator.',
+              },
+              settledOrder: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description: 'The settlement order.',
+              },
+              dateNowMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description: 'The deterministic clock value.',
+              },
+              valueJson: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The serialized fulfilled value.',
+              },
+            }}
+          />
+          <p>
+            <code>{'RejectedRunLedgerEntry'}</code>
+          </p>
+          <TypeTable
+            type={{
+              bindingName: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The persisted host function path key (wire property name remains bindingName).',
+              },
+              inputJson: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The serialized host function input.',
+              },
+              status: {
+                type: "'rejected'",
+                typeDescription: "'rejected'",
+                required: true,
+                description: 'The rejected status discriminator.',
+              },
+              settledOrder: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description: 'The settlement order.',
+              },
+              dateNowMs: {
+                type: 'number',
+                typeDescription: 'number',
+                required: true,
+                description: 'The deterministic clock value.',
+              },
+              error: {
+                type: '{ name: string; message: string; stack?: string; code?: string; details?: unknown }',
+                typeDescription:
+                  '{ name: string; message: string; stack?: string; code?: string; details?: unknown }',
+                required: true,
+                description: 'The serialized rejection.',
+              },
+            }}
+          />
+          <p>
+            <code>{'InterruptedRunLedgerEntry'}</code>
+          </p>
+          <TypeTable
+            type={{
+              bindingName: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description:
+                  'The persisted host function path key (wire property name remains bindingName).',
+              },
+              inputJson: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The serialized host function input.',
+              },
+              status: {
+                type: "'interrupted'",
+                typeDescription: "'interrupted'",
+                required: true,
+                description: 'The interrupted status discriminator.',
+              },
+              interruptionId: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The interruption ID.',
+              },
+              payloadJson: {
+                type: 'string',
+                typeDescription: 'string',
+                required: true,
+                description: 'The serialized interruption payload.',
+              },
+            }}
+          />
+        </>
+      ),
+    },
+  }}
+/>


### PR DESCRIPTION
The API reference pages displayed their definitions as syntax-highlighted JSON because they were authored as JSON code fences. Replace all 22 blocks across 10 pages with a linked overview table, Geistdocs `TypeTable` components for API fields, and plain text for the function with no parameters.

Nested properties remain expandable, optional fields retain their markers, and full type signatures are available in expanded rows on narrow screens. The existing descriptions and TypeScript examples are preserved.

Validation:
- `pnpm check`
- `pnpm --filter @run/website type-check`
- `pnpm --filter @run/website build`
- Compiled the MDX and compared all 268 fields, types, required flags, and descriptions against the original JSON; checked all 9 overview links and unchanged examples.
- Checked all 10 prerendered reference pages for remaining JSON code blocks and verified overview navigation and nested field expansion in a browser.
